### PR TITLE
Add docker builder pattern for react image

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+Dockerfile-*

--- a/frontend/Dockerfile-prod
+++ b/frontend/Dockerfile-prod
@@ -11,3 +11,9 @@ RUN npm install
 WORKDIR /var/app
 COPY . /var/app
 RUN npm run build
+
+FROM alpine
+RUN mkdir -p /var/app/build
+COPY --from=0 /var/app/build /var/app/build
+COPY --from=0 /var/app/bootstrap.sh /var/app/
+WORKDIR /var/app

--- a/frontend/Dockerfile-prod
+++ b/frontend/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8-alpine as builder
 
 RUN mkdir -p /var/app
 
@@ -14,6 +14,6 @@ RUN npm run build
 
 FROM alpine
 RUN mkdir -p /var/app/build
-COPY --from=0 /var/app/build /var/app/build
-COPY --from=0 /var/app/bootstrap.sh /var/app/
+COPY --from=builder /var/app/build /var/app/build
+COPY --from=builder /var/app/bootstrap.sh /var/app/
 WORKDIR /var/app

--- a/frontend/bootstrap.sh
+++ b/frontend/bootstrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # Copy files from build/ (our current WORKDIR) to the volume mounted at dist
-cp -af build/* dist
+cp -af build/* dist && \
 tail -f /dev/null


### PR DESCRIPTION
Since we just use Javascript for building a bundle that we serve with
nginx, we don't actually need all the Javascript in the final release.
Our image size goes from 289MB => 8.76MB