### PR TITLE
Update: css for recipe printing, larger font-size

### DIFF
--- a/frontend/src/components/scss/main.scss
+++ b/frontend/src/components/scss/main.scss
@@ -128,7 +128,18 @@ a {
 
   html {
     border-top: none;
-    font-size: 12px;
+    font-size: $printing-font-size;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  label,
+  p {
+    color: black !important;
   }
 
   @page {
@@ -147,7 +158,7 @@ a {
   }
 
   .ingredients-preparation-grid {
-    grid-gap: 0;
+    grid-gap: 0.5rem;
     grid-template-columns: minmax(350px, 3fr) 5fr;
   }
 }

--- a/frontend/src/components/scss/variables.scss
+++ b/frontend/src/components/scss/variables.scss
@@ -1,6 +1,7 @@
 $border-color: #dbdbdb;
 
 $base-font-size: 18px;
+$printing-font-size: 14px;
 
 $success: rgb(99, 203, 137);
 $danger: #ff3860;


### PR DESCRIPTION
Make text color black so it prints nicely. Gray doesn't behave with a
toner printer.

Add a grid-gap

Bump font-size