### PR TITLE
Replace alpine with slim for Python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test_python:
     docker:
-      - image: circleci/python:3.6.4-slim
+      - image: circleci/python:3.6.4
         environment:
           DEBUG: 1
           DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test_python:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.4-slim
         environment:
           DEBUG: 1
           DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ For Python, we use `pipenv`, so if you want to update/install a dependency, like
 
 For Javascript, we use `npm`, so if you want to update/install a dependency, like React, run `docker-compose -f docker-compose-dev.yml react npm install --save react@16.2.0`.
 
-__Note:__ If you update the version of `psycopg2`, you must update the `backend/Dockerfile-dev` to match. We install this package using `apk` to reduce the container size.
-
 ### Testing with OAuth
 1. Create an `.env-dev` file based on `.env-example` with proper client IDs.
 2. Configure the identity provider to enable redirecting to `http://localhost:3000/accounts/$providerName`.

--- a/backend/Dockerfile-dev
+++ b/backend/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6.4-slim
+FROM python:3.6.4
 ENV PYTHONUNBUFFERD 1
 
 RUN apt-get update

--- a/backend/Dockerfile-dev
+++ b/backend/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.6.4
+FROM python:3.6.4-slim
 ENV PYTHONUNBUFFERD 1
 
 RUN apt-get update

--- a/backend/Dockerfile-prod
+++ b/backend/Dockerfile-prod
@@ -1,8 +1,6 @@
 FROM python:3.6.4
 ENV PYTHONUNBUFFERD 1
 
-# we need libpq at runtime
-# the following can probably be simplified
 # -- Install Pipenv:
 RUN set -ex && pip install "pipenv~=11.8"
 

--- a/backend/Dockerfile-prod
+++ b/backend/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM python:3.6.4-slim
+FROM python:3.6.4
 ENV PYTHONUNBUFFERD 1
 
 # we need libpq at runtime

--- a/backend/Dockerfile-prod
+++ b/backend/Dockerfile-prod
@@ -1,16 +1,10 @@
-FROM python:3.6.4-alpine
+FROM python:3.6.4-slim
 ENV PYTHONUNBUFFERD 1
 
 # we need libpq at runtime
 # the following can probably be simplified
-RUN apk add --no-cache --virtual .build-deps build-base postgresql-dev && \
-    apk add --no-cache gcc git make libpq libffi-dev openssl-dev  \
-      libffi openssl ca-certificates linux-headers musl-dev && \
-    pip install psycopg2==2.7.3.2 cffi cryptography && \
-    apk del .build-deps
-
 # -- Install Pipenv:
-RUN set -ex && pip install git+git://github.com/pypa/pipenv.git@8378a1b104f2d817790a05da370bef0a1b00f452
+RUN set -ex && pip install "pipenv~=11.8"
 
 # -- Install Application into container:
 RUN set -ex && mkdir -p /var/app


### PR DESCRIPTION
- Musl is slower than glibc and using slim provides a smaller image in practice
- Use same images across CI/Dev/Prod