### PR TITLE
Update circle config to build containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,4 +140,4 @@ workflows:
       - lint_frontend
       - build_frontend
       - build_api_container:
-          context: docker
+          context: DockerHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f Dockerfile --tag recipeyak/nginx:$CIRCLE_SHA1 .
-            docker push recipeyak/react:$CIRCLE_SHA1
+            docker push recipeyak/nginx:$CIRCLE_SHA1
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,33 @@ jobs:
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f Dockerfile-prod --tag recipeyak/django:$CIRCLE_SHA1 --build-arg GIT_SHA=$CIRCLE_SHA1 .
             docker push recipeyak/django:$CIRCLE_SHA1
+  # https://circleci.com/docs/2.0/building-docker-images/
+  build_ui_container:
+    requires:
+      - build_frontend
+      - test_frontend
+      - lint_frontend
+    docker:
+      - image: docker:18.05.0-ce
+    steps:
+      - checkout
+      - setup_remote_docker
+      # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
+      - run:
+          name: build container
+          working_directory: frontend
+          command: |
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            docker build -f Dockerfile-prod \
+              --tag recipeyak/react:$CIRCLE_SHA1 \
+              --build-arg OAUTH_BITBUCKET_CLIENT_ID=${OAUTH_BITBUCKET_CLIENT_ID-""} \
+              --build-arg OAUTH_FACEBOOK_CLIENT_ID=${OAUTH_FACEBOOK_CLIENT_ID-""} \
+              --build-arg OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID-""} \
+              --build-arg OAUTH_GITLAB_CLIENT_ID=${OAUTH_GITLAB_CLIENT_ID-""} \
+              --build-arg OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID-""} \
+              --build-arg GIT_SHA=$CIRCLE_SHA1 \
+              --build-arg FRONTEND_SENTRY_DSN=$FRONTEND_SENTRY_DSN .
+            docker push recipeyak/react:$CIRCLE_SHA1
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           name: build container
           working_directory: backend
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f Dockerfile-prod --tag recipeyak/django:$CIRCLE_SHA1 --build-arg GIT_SHA=$CIRCLE_SHA1 .
             docker push recipeyak/django:$CIRCLE_SHA1
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,16 @@ workflows:
       - build_frontend
       - build_api_container:
           context: DockerHub
+          filters:
+            branches:
+              only: master
       - build_ui_container:
           context: DockerHub
+          filters:
+            branches:
+              only: master
       - build_proxy_container:
           context: DockerHub
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,9 @@ jobs:
           working_directory: backend
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f Dockerfile-prod --tag recipeyak/django:$CIRCLE_SHA1 --build-arg GIT_SHA=$CIRCLE_SHA1 .
+            docker build -f Dockerfile-prod \
+              --tag recipeyak/django:$CIRCLE_SHA1 \
+              --build-arg GIT_SHA=$CIRCLE_SHA1 .
             docker push recipeyak/django:$CIRCLE_SHA1
   # https://circleci.com/docs/2.0/building-docker-images/
   build_ui_container:
@@ -170,7 +172,8 @@ jobs:
           working_directory: nginx
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f Dockerfile --tag recipeyak/nginx:$CIRCLE_SHA1 .
+            docker build -f Dockerfile \
+              --tag recipeyak/nginx:$CIRCLE_SHA1 .
             docker push recipeyak/nginx:$CIRCLE_SHA1
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,23 @@ jobs:
           name: run build
           working_directory: frontend
           command: npm run build
+  # https://circleci.com/docs/2.0/building-docker-images/
+  build_api_container:
+    requires:
+      - test_python
+    docker:
+      - image: docker:18.05.0-ce
+    steps:
+      - checkout
+      - setup_remote_docker
+      # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
+      - run:
+          name: build container
+          working_directory: backend
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker build -f Dockerfile-prod --tag recipeyak/django:$CIRCLE_SHA1 --build-arg GIT_SHA=$CIRCLE_SHA1 .
+            docker push recipeyak/django:$CIRCLE_SHA1
 workflows:
   version: 2
   test:
@@ -122,3 +139,5 @@ workflows:
       - test_frontend
       - lint_frontend
       - build_frontend
+      - build_api_container:
+          context: docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,20 @@ jobs:
               --build-arg GIT_SHA=$CIRCLE_SHA1 \
               --build-arg FRONTEND_SENTRY_DSN=$FRONTEND_SENTRY_DSN .
             docker push recipeyak/react:$CIRCLE_SHA1
+  build_proxy_container:
+    docker:
+      - image: docker:18.05.0-ce
+    steps:
+      - checkout
+      - setup_remote_docker
+      # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
+      - run:
+          name: build container
+          working_directory: nginx
+          command: |
+            docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+            docker build -f Dockerfile nginx --tag recipeyak/nginx:$CIRCLE_SHA1 .
+            docker push recipeyak/react:$CIRCLE_SHA1
 workflows:
   version: 2
   test:
@@ -167,4 +181,8 @@ workflows:
       - lint_frontend
       - build_frontend
       - build_api_container:
+          context: DockerHub
+      - build_ui_container:
+          context: DockerHub
+      - build_proxy_container:
           context: DockerHub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
           working_directory: nginx
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f Dockerfile nginx --tag recipeyak/nginx:$CIRCLE_SHA1 .
+            docker build -f Dockerfile --tag recipeyak/nginx:$CIRCLE_SHA1 .
             docker push recipeyak/react:$CIRCLE_SHA1
 workflows:
   version: 2

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -447,7 +447,7 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },


### PR DESCRIPTION
- ~~CircleCI fails to build the Node container (I the process is possibly running out of memory)~~
- A service that caches layers between builds would be extremely useful
- Google Container Builder is an option, but it doesn't cache layers, just as CircleCI doesn't