### PR TITLE
Fix typo in calendar format string

### DIFF
--- a/frontend/src/components/Calendar.jsx
+++ b/frontend/src/components/Calendar.jsx
@@ -24,7 +24,7 @@ import Loader from './Loader'
 import CalendarDay from './CalendarDay'
 
 function monthYearFromDate (date) {
-  return format(date, 'MMM | D')
+  return format(date, 'MMM | YYYY')
 }
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
Now we have month and year instead of month and day