### PR TITLE
Limit the pre-rendered homepage to users without a session id

### DIFF
--- a/frontend/scripts/crawl.sh
+++ b/frontend/scripts/crawl.sh
@@ -24,5 +24,5 @@ TMP_FILE=$(mktemp)
 # kill the background webserver
 kill %%
 
-mv -f "$TMP_FILE" build/index.html
-chmod +r build/index.html
+mv -f "$TMP_FILE" build/landing.html
+chmod +r build/landing.html

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -113,6 +113,11 @@ server {
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
+    location /__static_landing {
+        alias /var/app/dist;
+        try_files $uri /landing.html;
+    }
+
     location / {
         if (-f /var/www/maintenance_on) {
             return 503;
@@ -120,7 +125,7 @@ server {
         root /var/app/dist;
         # return the pre-rendered file for people without a session id
         if ($cookie_sessionid = "") {
-            try_files $uri /landing.html;
+            rewrite ^(.*) /__static_landing$1 last;
         }
         # First attempt to serve request as file, then serve our index.html
         try_files $uri /index.html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -118,6 +118,10 @@ server {
             return 503;
         }
         root /var/app/dist;
+        # return the pre-rendered file for people without a session id
+        if (!$cookie_sessionid) {
+            try_files $uri /landing.html;
+        }
         # First attempt to serve request as file, then serve our index.html
         try_files $uri /index.html;
     }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -119,7 +119,7 @@ server {
         }
         root /var/app/dist;
         # return the pre-rendered file for people without a session id
-        if (!$cookie_sessionid) {
+        if ($cookie_sessionid = "") {
             try_files $uri /landing.html;
         }
         # First attempt to serve request as file, then serve our index.html


### PR DESCRIPTION
Update NGINX config to selectively route to pre-rendered homepage when
the user doesn't have a sessionid set in cookies. This prevents an
awkward flash of the landing page for users that already have an active
session.