### PR TITLE
Fix scheduled recipes page rendering recipes list

### DIFF
--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -168,7 +168,7 @@ class TeamRecipesViewSet(
 
     def list(self, request, team_pk=None):
         serializer = self.get_serializer(
-            self.get_queryset(), many=True, fields=("id", "name", "author", "tags")
+            self.get_queryset(), many=True, fields=("id", "name", "author", "tags", "owner")
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -168,7 +168,9 @@ class TeamRecipesViewSet(
 
     def list(self, request, team_pk=None):
         serializer = self.get_serializer(
-            self.get_queryset(), many=True, fields=("id", "name", "author", "tags", "owner")
+            self.get_queryset(),
+            many=True,
+            fields=("id", "name", "author", "tags", "owner"),
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
We weren't returning the owner field from the team endpoint. I'm not sure
why we had it this way, but now it behaves.