### PR TITLE
Fix exception from incorrect string conversion of uuid

### DIFF
--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -7,7 +7,7 @@ export type Dispatch = ReduxDispatch<Action>
 
 export type GetState = () => RootState
 
-import { uuid4 } from "@/uuid"
+import { uuid4, random32Id } from "@/uuid"
 import Cookie from "js-cookie"
 
 import startOfMonth from "date-fns/start_of_month"
@@ -1431,7 +1431,7 @@ export const addingScheduledRecipe = (dispatch: Dispatch) => (
 ) => {
   const recipe = store.getState().recipes[recipeID]
   dispatch(setSchedulingRecipe(recipeID, true))
-  const id = uuid4()
+  const id = random32Id()
   const data = {
     recipe: recipeID,
     on: pyFormat(on),

--- a/frontend/src/uuid.ts
+++ b/frontend/src/uuid.ts
@@ -7,3 +7,23 @@ export const uuid4 = () =>
     const v = c === "x" ? r : (r & 0x3) | 0x8
     return v.toString(16)
   })
+
+/**
+ * Generate a random 32bit number
+ *
+ * **Note:** We are limited to 32bit ints because of JS. An int UUID must be
+ * 128 bits, so this is not considered unique, however, for our frontend
+ * purposes, it is acceptable
+ *
+ * @example
+ *
+ * const id = random32Id()
+ *
+ * const pendingRecipe = {
+ *  ...existingRecipe,
+ *  id,
+ *  pending: true
+ * }
+ *
+ */
+export const random32Id = () => crypto.getRandomValues(new Uint32Array(1))[0]


### PR DESCRIPTION
We introduced some bugs in d8dc53d474271288bec0b99ceb605832b6273f45. This
fixes an exception that is being raised when scheduling new recipes.