### PR TITLE
Fix bug where changing between views would break

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -28,7 +28,11 @@ import Loader from "@/components/Loader"
 import CalendarDay from "@/components/CalendarDay"
 import { RootState } from "@/store/store"
 import { ITeam } from "@/store/reducers/teams"
-import { ICalRecipe } from "@/store/reducers/calendar"
+import {
+  ICalRecipe,
+  getTeamRecipes,
+  getPersonalRecipes
+} from "@/store/reducers/calendar"
 import { ScheduleRouteParams } from "@/components/Schedule"
 
 function monthYearFromDate(date: Date) {
@@ -42,21 +46,21 @@ interface IDays {
 const mapStateToProps = (state: RootState, props: ICalendarProps) => {
   const isTeam = props.teamID !== "personal"
 
-  const days = state.calendar.allIds
-    .map((id: number | string) => state.calendar.byId[id as number])
-    .reduce(
-      (a, b) => ({
-        ...a,
-        [b.on]: {
-          ...a[b.on],
-          [b.id]: b
-        }
-      }),
-      {} as IDays
-    )
+  const days = isTeam ? getTeamRecipes(state) : getPersonalRecipes(state)
+
+  const transformedDays = days.reduce(
+    (a, b) => ({
+      ...a,
+      [b.on]: {
+        ...a[b.on],
+        [b.id]: b
+      }
+    }),
+    {} as IDays
+  )
 
   return {
-    days,
+    days: transformedDays,
     loading: state.calendar.loading,
     error: state.calendar.error,
     loadingTeams: !!state.teams.loading,

--- a/frontend/src/store/reducers/calendar.ts
+++ b/frontend/src/store/reducers/calendar.ts
@@ -2,6 +2,7 @@ import { uniq, omit } from "lodash"
 import isSameDay from "date-fns/is_same_day"
 
 import { action as act } from "typesafe-actions"
+import { RootState } from "@/store/store"
 
 const SET_CALENDAR_RECIPES = "SET_CALENDAR_RECIPES"
 const SET_CALENDAR_RECIPE = "SET_CALENDAR_RECIPE"
@@ -87,7 +88,10 @@ export const calendar = (
     case SET_CALENDAR_RECIPES:
       return {
         ...state,
-        byId: action.payload.reduce((a, b) => ({ ...a, [b.id]: b }), {}),
+        byId: {
+          ...state.byId,
+          ...action.payload.reduce((a, b) => ({ ...a, [b.id]: b }), {})
+        },
         allIds: uniq(state.allIds.concat(action.payload.map(x => x.id)))
       }
     case SET_CALENDAR_RECIPE: {
@@ -199,3 +203,13 @@ export const calendar = (
 }
 
 export default calendar
+
+export const getTeamRecipes = (state: RootState): ICalRecipe[] =>
+  state.calendar.allIds
+    .map(id => state.calendar.byId[id])
+    .filter(recipe => recipe.team != null)
+
+export const getPersonalRecipes = (state: RootState): ICalRecipe[] =>
+  state.calendar.allIds
+    .map(id => state.calendar.byId[id])
+    .filter(recipe => recipe.team == null)


### PR DESCRIPTION
We were combining allIds by clearing byId, so indexing into byId from allIds
would return undefined. Now we concatenate byId and filter based on the current
team.