### PR TITLE
Add prefetching to other recipe list view. Block DB access in serializers.

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -161,7 +161,7 @@ class Recipe(CommonInfo):
             self.save()
             return self
 
-    def copy_to(self, account):
+    def copy_to(self, account) -> "Recipe":
         """
         Copy recipe to another team or user
         """

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -161,7 +161,7 @@ class Recipe(CommonInfo):
             self.save()
             return self
 
-    def copy_to(self, account: Union[MyUser, Team]) -> "Recipe":
+    def copy_to(self, account: Union[MyUser, "Team"]) -> "Recipe":
         """
         Copy recipe to another team or user
         """

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -161,7 +161,7 @@ class Recipe(CommonInfo):
             self.save()
             return self
 
-    def copy_to(self, account) -> "Recipe":
+    def copy_to(self, account: Union[MyUser, Team]) -> "Recipe":
         """
         Copy recipe to another team or user
         """

--- a/backend/core/recipes/serializers.py
+++ b/backend/core/recipes/serializers.py
@@ -122,7 +122,7 @@ class RecipeSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         # Don't pass the 'fields' arg up to the superclass
         fields = kwargs.pop("fields", None)
-        self.allow_db = kwargs.pop("allow_db", None)
+        self.dangerously_allow_db = kwargs.pop("dangerously_allow_db", None)
 
         super().__init__(*args, **kwargs)
 

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets, status, mixins
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
+from rest_framework.request import Request
 from rest_framework.permissions import IsAuthenticated
 
 
@@ -113,13 +114,13 @@ class RecipeViewSet(viewsets.ModelViewSet):
         serializer_class=RecipeMoveCopySerializer,
         permission_classes=[HasRecipeAccess],
     )
-    def copy(self, request, pk=None):
+    def copy(self, request: Request, pk: str) -> Response:
         """
         Copy recipe from user to team.
         Any team member should be able to copy a recipe from the team.
         User should have write access to team to copy recipe
         """
-        recipe = self.get_object()
+        recipe: Recipe = self.get_object()
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -134,11 +135,11 @@ class RecipeViewSet(viewsets.ModelViewSet):
                 raise PermissionDenied(detail="user must be the same as requester")
             new_recipe = recipe.copy_to(user)
 
-        # TODO(chdsbd): Fix to use select_related.
-        return Response(
-            RecipeSerializer(new_recipe, dangerously_allow_db=True).data,
-            status=status.HTTP_200_OK,
-        )
+        # refetch all relations before serialization
+        new_recipe: Recipe = Recipe.objects.prefetch_related(
+            "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
+        ).get(id=new_recipe.id)
+        return Response(RecipeSerializer(new_recipe).data, status=status.HTTP_200_OK)
 
 
 class TeamRecipesViewSet(

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -136,10 +136,10 @@ class RecipeViewSet(viewsets.ModelViewSet):
             new_recipe = recipe.copy_to(user)
 
         # refetch all relations before serialization
-        new_recipe: Recipe = Recipe.objects.prefetch_related(
+        prefetched_recipe: Recipe = Recipe.objects.prefetch_related(
             "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
         ).get(id=new_recipe.id)
-        return Response(RecipeSerializer(new_recipe).data, status=status.HTTP_200_OK)
+        return Response(RecipeSerializer(prefetched_recipe).data, status=status.HTTP_200_OK)
 
 
 class TeamRecipesViewSet(

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -139,7 +139,9 @@ class RecipeViewSet(viewsets.ModelViewSet):
         prefetched_recipe: Recipe = Recipe.objects.prefetch_related(
             "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
         ).get(id=new_recipe.id)
-        return Response(RecipeSerializer(prefetched_recipe).data, status=status.HTTP_200_OK)
+        return Response(
+            RecipeSerializer(prefetched_recipe).data, status=status.HTTP_200_OK
+        )
 
 
 class TeamRecipesViewSet(

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast, Any
 
 from django.db import connection
 
@@ -23,11 +23,13 @@ class DBBlockerSerializerMixin:
     @property
     def data(self):
         if hasattr(self, "initial_data") or self.dangerously_allow_db:
-            return super().data
+            # Mypy is correct that we don't have a data property on our parent.
+            # We must cast to Any to support the mixin use of this class
+            return cast(Any, super()).data
         else:
             with connection.execute_wrapper(blocker):
-                return super().data
+                return cast(Any, super()).data
 
     def __init__(self, *args, **kwargs):
         self.dangerously_allow_db = kwargs.pop("dangerously_allow_db", None)
-        return super().__init__(*args, **kwargs)
+        return cast(Any, super()).__init__(*args, **kwargs)

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from django.db import connection
+
+
+def blocker(*args):
+    raise Exception("No database access allowed here.")
+
+
+class DBBlockerSerializerMixin:
+    """
+    Block database access within serializer
+
+    An escape hatch is available through the `dangerously_allow_db` kwarg.
+
+    NOTE: This mixin should come _before_ the parent serializer. This is
+    required for the constructor to remove `dangerously_allow_db` from `kwargs`
+    before calling the parent.
+    """
+
+    dangerously_allow_db: Optional[bool] = None
+
+    @property
+    def data(self):
+        if hasattr(self, "initial_data") or self.dangerously_allow_db:
+            return super().data
+        else:
+            with connection.execute_wrapper(blocker):
+                return super().data
+
+    def __init__(self, *args, **kwargs):
+        self.dangerously_allow_db = kwargs.pop("dangerously_allow_db", None)
+        return super().__init__(*args, **kwargs)


### PR DESCRIPTION
Disable DB access in serializers to prevent N+1 queries.

Teams recipes list view performance

name | trial 1 | trial 2 | trial 3 | avg | % change
---|---|---|---|--- |---
before | 0.286s | 0.180s | 0.279s | 0.248s| —
after | 0.169s | 0.156s | 0.167s | 0.164s | -51.2%