### PR TITLE
Restrict DB access in serialization

### DIFF
--- a/backend/core/auth/registration/serializers.py
+++ b/backend/core/auth/registration/serializers.py
@@ -23,8 +23,9 @@ from requests.exceptions import HTTPError
 if "allauth.socialaccount" in settings.INSTALLED_APPS:
     from allauth.socialaccount.helpers import complete_social_login
 
+from core.serialization import BaseSerializer, BaseModelSerializer
 
-class SocialLoginSerializer(serializers.Serializer):
+class SocialLoginSerializer(BaseSerializer):
     access_token = serializers.CharField(required=False, allow_blank=True)
     code = serializers.CharField(required=False, allow_blank=True)
 
@@ -137,7 +138,7 @@ class SocialLoginSerializer(serializers.Serializer):
         return attrs
 
 
-class RegisterSerializer(serializers.Serializer):
+class RegisterSerializer(BaseSerializer):
     username = serializers.CharField(
         max_length=get_username_max_length(),
         min_length=allauth_settings.USERNAME_MIN_LENGTH,
@@ -200,11 +201,11 @@ class RegisterSerializer(serializers.Serializer):
         return user
 
 
-class VerifyEmailSerializer(serializers.Serializer):
+class VerifyEmailSerializer(BaseSerializer):
     key = serializers.CharField()
 
 
-class SocialAccountSerializer(serializers.ModelSerializer):
+class SocialAccountSerializer(BaseModelSerializer):
     """
     serializer allauth SocialAccounts for use with a REST API
     """

--- a/backend/core/auth/registration/serializers.py
+++ b/backend/core/auth/registration/serializers.py
@@ -2,6 +2,7 @@ from django.http import HttpRequest
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import get_user_model
+from core.serialization import BaseSerializer, BaseModelSerializer
 
 try:
     from allauth.account import app_settings as allauth_settings
@@ -22,8 +23,6 @@ from requests.exceptions import HTTPError
 # case the allauth.socialaccount will be declared
 if "allauth.socialaccount" in settings.INSTALLED_APPS:
     from allauth.socialaccount.helpers import complete_social_login
-
-from core.serialization import BaseSerializer, BaseModelSerializer
 
 
 class SocialLoginSerializer(BaseSerializer):

--- a/backend/core/auth/registration/serializers.py
+++ b/backend/core/auth/registration/serializers.py
@@ -25,6 +25,7 @@ if "allauth.socialaccount" in settings.INSTALLED_APPS:
 
 from core.serialization import BaseSerializer, BaseModelSerializer
 
+
 class SocialLoginSerializer(BaseSerializer):
     access_token = serializers.CharField(required=False, allow_blank=True)
     code = serializers.CharField(required=False, allow_blank=True)

--- a/backend/core/auth/serializers.py
+++ b/backend/core/auth/serializers.py
@@ -11,10 +11,12 @@ from django.utils.encoding import force_text
 from rest_framework import serializers, exceptions
 from rest_framework.exceptions import ValidationError
 
+from core.serialization import BaseSerializer
+
 UserModel = get_user_model()
 
 
-class LoginSerializer(serializers.Serializer):
+class LoginSerializer(BaseSerializer):
     username = serializers.CharField(required=False, allow_blank=True)
     email = serializers.EmailField(required=False, allow_blank=True)
     password = serializers.CharField(style={"input_type": "password"})
@@ -116,7 +118,7 @@ class LoginSerializer(serializers.Serializer):
         return attrs
 
 
-class PasswordResetSerializer(serializers.Serializer):
+class PasswordResetSerializer(BaseSerializer):
     """
     Serializer for requesting a password reset e-mail.
     """
@@ -150,7 +152,7 @@ class PasswordResetSerializer(serializers.Serializer):
         self.reset_form.save(**opts)
 
 
-class PasswordResetConfirmSerializer(serializers.Serializer):
+class PasswordResetConfirmSerializer(BaseSerializer):
     """
     Serializer for requesting a password reset e-mail.
     """
@@ -191,7 +193,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         return self.set_password_form.save()
 
 
-class PasswordChangeSerializer(serializers.Serializer):
+class PasswordChangeSerializer(BaseSerializer):
     old_password = serializers.CharField(max_length=128)
     new_password1 = serializers.CharField(max_length=128)
     new_password2 = serializers.CharField(max_length=128)

--- a/backend/core/auth/social_serializers.py
+++ b/backend/core/auth/social_serializers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.http import HttpRequest
 from rest_framework import serializers
+from core.serialization import BaseSerializer
 
 # Import is needed only if we are using social login, in which
 # case the allauth.socialaccount will be declared
@@ -8,8 +9,6 @@ if "allauth.socialaccount" in settings.INSTALLED_APPS:
     from allauth.socialaccount.helpers import complete_social_login
     from allauth.socialaccount.models import SocialToken
     from allauth.socialaccount.providers.oauth.client import OAuthError
-
-from core.serialization import BaseSerializer
 
 
 class TwitterLoginSerializer(BaseSerializer):

--- a/backend/core/auth/social_serializers.py
+++ b/backend/core/auth/social_serializers.py
@@ -9,8 +9,10 @@ if "allauth.socialaccount" in settings.INSTALLED_APPS:
     from allauth.socialaccount.models import SocialToken
     from allauth.socialaccount.providers.oauth.client import OAuthError
 
+from core.serialization import BaseSerializer
 
-class TwitterLoginSerializer(serializers.Serializer):
+
+class TwitterLoginSerializer(BaseSerializer):
     access_token = serializers.CharField()
     token_secret = serializers.CharField()
 

--- a/backend/core/export/serializers.py
+++ b/backend/core/export/serializers.py
@@ -7,13 +7,13 @@ from core.serialization import BaseModelSerializer
 
 class RecipeExportSerializer(BaseModelSerializer):
 
-    steps = serializers.ListField(child=serializers.CharField(), source='step_set.all')
+    steps = serializers.ListField(child=serializers.CharField(), source="step_set.all")
 
     ingredients = IngredientSerializer(
         many=True,
         read_only=True,
         fields=("quantity", "name", "description", "optional"),
-        source='ingredient_set'
+        source="ingredient_set",
     )
     owner = OwnerRelatedField(read_only=True, export=True)
 

--- a/backend/core/export/serializers.py
+++ b/backend/core/export/serializers.py
@@ -1,23 +1,25 @@
 from rest_framework import serializers
 
 from core.recipes.serializers import IngredientSerializer, OwnerRelatedField
-
 from core.models import Recipe
+from core.serialization import BaseModelSerializer
 
 
-class RecipeExportSerializer(serializers.ModelSerializer):
+class RecipeExportSerializer(BaseModelSerializer):
 
-    steps = serializers.ListField(child=serializers.CharField())
+    steps = serializers.ListField(child=serializers.CharField(), source='step_set.all')
 
     ingredients = IngredientSerializer(
         many=True,
         read_only=True,
         fields=("quantity", "name", "description", "optional"),
+        source='ingredient_set'
     )
     owner = OwnerRelatedField(read_only=True, export=True)
 
     class Meta:
         model = Recipe
+        read_only = True
         fields = (
             "name",
             "author",

--- a/backend/core/export/views.py
+++ b/backend/core/export/views.py
@@ -15,8 +15,8 @@ from .serializers import RecipeExportSerializer
 def export_recipes(request, filetype, id=None):
 
     queryset = user_and_team_recipes(request.user).prefetch_related(
-            "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
-        )
+        "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
+    )
     many = id is None
 
     if not many:

--- a/backend/core/export/views.py
+++ b/backend/core/export/views.py
@@ -14,8 +14,9 @@ from .serializers import RecipeExportSerializer
 @login_required(login_url="/login/")
 def export_recipes(request, filetype, id=None):
 
-    queryset = user_and_team_recipes(request.user)
-
+    queryset = user_and_team_recipes(request.user).prefetch_related(
+            "owner", "step_set", "ingredient_set", "scheduledrecipe_set"
+        )
     many = id is None
 
     if not many:

--- a/backend/core/recipes/serializers.py
+++ b/backend/core/recipes/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from core.models import MyUser, Recipe, Ingredient, Step, Team
-from core.serialization import DBBlockerSerializerMixin
+from core.serialization import BaseModelSerializer
 
 
 class OwnerRelatedField(serializers.RelatedField):
@@ -26,7 +26,7 @@ class OwnerRelatedField(serializers.RelatedField):
         self.export = export
 
 
-class IngredientSerializer(serializers.ModelSerializer):
+class IngredientSerializer(BaseModelSerializer):
     """
     serializer the ingredient of a recipe
     """
@@ -49,7 +49,7 @@ class IngredientSerializer(serializers.ModelSerializer):
                 self.fields.pop(field_name)
 
 
-class StepSerializer(serializers.ModelSerializer):
+class StepSerializer(BaseModelSerializer):
     """
     serializer the step of a recipe
     """
@@ -72,7 +72,7 @@ class StepSerializer(serializers.ModelSerializer):
                 self.fields.pop(field_name)
 
 
-class RecipeSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
+class RecipeSerializer(BaseModelSerializer):
     steps = StepSerializer(many=True, source="step_set")
     last_scheduled = serializers.DateField(source="get_last_scheduled", read_only=True)
     ingredients = IngredientSerializer(many=True, source="ingredient_set")

--- a/backend/core/recipes/serializers.py
+++ b/backend/core/recipes/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from core.models import MyUser, Recipe, Ingredient, Step, Team
-from core.serialization import BaseModelSerializer
+from core.serialization import BaseModelSerializer, BaseSerializer
 
 
 class OwnerRelatedField(serializers.RelatedField):
@@ -152,7 +152,7 @@ class RecipeSerializer(BaseModelSerializer):
         return recipe
 
 
-class RecipeMoveCopySerializer(serializers.Serializer):
+class RecipeMoveCopySerializer(BaseSerializer):
     id = serializers.IntegerField(max_value=None, min_value=0, write_only=True)
     type = serializers.ChoiceField(choices=["user", "team"], write_only=True)
 

--- a/backend/core/recipes/serializers.py
+++ b/backend/core/recipes/serializers.py
@@ -1,10 +1,10 @@
 from rest_framework import serializers
 
 from core.models import MyUser, Recipe, Ingredient, Step, Team
-from core.serialization import BaseModelSerializer, BaseSerializer
+from core.serialization import BaseModelSerializer, BaseSerializer, BaseRelatedField
 
 
-class OwnerRelatedField(serializers.RelatedField):
+class OwnerRelatedField(BaseRelatedField):
     """
     A custom field to use for the `owner` generic relationship.
     """

--- a/backend/core/schedule/serializers.py
+++ b/backend/core/schedule/serializers.py
@@ -3,9 +3,10 @@ from rest_framework import serializers
 from core.models import ScheduledRecipe
 
 from core.recipes.serializers import RecipeSerializer
+from core.serialization import BaseModelSerializer
 
 
-class ScheduledRecipeSerializer(serializers.ModelSerializer):
+class ScheduledRecipeSerializer(BaseModelSerializer):
     recipe = RecipeSerializer(fields=("id", "name"))
 
     class Meta:
@@ -13,7 +14,7 @@ class ScheduledRecipeSerializer(serializers.ModelSerializer):
         fields = ("id", "recipe", "on", "count", "team", "user")
 
 
-class ScheduledRecipeSerializerCreate(serializers.ModelSerializer):
+class ScheduledRecipeSerializerCreate(BaseModelSerializer):
     class Meta:
         model = ScheduledRecipe
         fields = ("id", "recipe", "on", "count")

--- a/backend/core/schedule/serializers.py
+++ b/backend/core/schedule/serializers.py
@@ -1,7 +1,4 @@
-from rest_framework import serializers
-
 from core.models import ScheduledRecipe
-
 from core.recipes.serializers import RecipeSerializer
 from core.serialization import BaseModelSerializer
 

--- a/backend/core/schedule/test_team_calendar.py
+++ b/backend/core/schedule/test_team_calendar.py
@@ -16,6 +16,8 @@ def test_adding_to_team_calendar(client, user, team, recipe):
     client.force_authenticate(user)
     res = client.post(url, data)
     assert res.status_code == status.HTTP_201_CREATED
+    res = client.post(url, data)
+    assert res.status_code == status.HTTP_201_CREATED
     scheduled = ScheduledRecipe.objects.get(id=res.json().get("id"))
     assert scheduled.team.pk == team.pk
 

--- a/backend/core/schedule/test_team_calendar.py
+++ b/backend/core/schedule/test_team_calendar.py
@@ -14,6 +14,8 @@ def test_adding_to_team_calendar(client, user, team, recipe):
     data = {"recipe": recipe.id, "on": date(1976, 7, 6), "count": 1}
     assert team.is_member(user)
     client.force_authenticate(user)
+    # Making two requests triggers a different case of merging two scheduled
+    # recipes, which caused a DB query at one point.
     res = client.post(url, data)
     assert res.status_code == status.HTTP_201_CREATED
     res = client.post(url, data)

--- a/backend/core/schedule/views.py
+++ b/backend/core/schedule/views.py
@@ -133,7 +133,10 @@ class TeamCalendarViewSet(viewsets.ModelViewSet):
 
         team = get_object_or_404(Team, pk=team_pk)
         n = serializer.save(team=team)
-        return Response(self.get_serializer(n).data, status=status.HTTP_201_CREATED)
+        return Response(
+            self.get_serializer(n, dangerously_allow_db=True).data,
+            status=status.HTTP_201_CREATED,
+        )
 
     def list(self, request, team_pk=None):
         start = request.query_params.get("start")

--- a/backend/core/schedule/views.py
+++ b/backend/core/schedule/views.py
@@ -116,13 +116,14 @@ class CalendarViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+# TODO(chdsbd): Merge this into the CalendarViewSet
 class TeamCalendarViewSet(viewsets.ModelViewSet):
     serializer_class = ScheduledRecipeSerializer
     permission_classes = (IsAuthenticated, IsTeamMember)
 
     def get_queryset(self):
         team = get_object_or_404(Team, pk=self.kwargs["team_pk"])
-        return ScheduledRecipe.objects.filter(team=team)
+        return ScheduledRecipe.objects.filter(team=team).select_related("recipe")
 
     def create(self, request, team_pk=None):
         # use different create serializer since we create via primary key, and

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -40,16 +40,21 @@ class BaseSerializer(DBBlockerSerializerMixin, serializers.Serializer):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
+
     pass
+
 
 class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
+
     pass
+
 
 class BaseRelatedField(DBBlockerSerializerMixin, serializers.RelatedField):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
+
     pass

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -47,3 +47,9 @@ class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer)
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
     pass
+
+class BaseRelatedField(DBBlockerSerializerMixin, serializers.RelatedField):
+    """
+    Serializer with `DBBlockerSerializerMixin` to disable DB access.
+    """
+    pass

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -37,4 +37,7 @@ class DBBlockerSerializerMixin:
 
 
 class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
+    """
+    Serializer with `DBBlockerSerializerMixin` to disable DB access.
+    """
     pass

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -32,7 +32,7 @@ class DBBlockerSerializerMixin:
             # We must cast to Any to support the mixin use of this class
             return cast(Any, super()).data
         elif not settings.DEBUG:
-            log.error('Database access in serializer')
+            log.error("Database access in serializer")
             return cast(Any, super()).data
         else:
             # only raise error when we are in DEBUG mode. We don't want to cause

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -31,14 +31,14 @@ class DBBlockerSerializerMixin:
             # Mypy is correct that we don't have a data property on our parent.
             # We must cast to Any to support the mixin use of this class
             return cast(Any, super()).data
-        elif not settings.DEBUG:
-            log.error("Database access in serializer")
-            return cast(Any, super()).data
-        else:
+        elif settings.DEBUG:
             # only raise error when we are in DEBUG mode. We don't want to cause
             # errors in production when we don't need to do so.
             with connection.execute_wrapper(blocker):
                 return cast(Any, super()).data
+        else:
+            log.error("Database access in serializer")
+            return cast(Any, super()).data
 
     def __init__(self, *args, **kwargs):
         self.dangerously_allow_db = kwargs.pop("dangerously_allow_db", None)
@@ -50,20 +50,14 @@ class BaseSerializer(DBBlockerSerializerMixin, serializers.Serializer):
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
 
-    pass
-
 
 class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
 
-    pass
-
 
 class BaseRelatedField(DBBlockerSerializerMixin, serializers.RelatedField):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.
     """
-
-    pass

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -1,6 +1,7 @@
 from typing import Optional, cast, Any
 
 from django.db import connection
+from rest_framework import serializers
 
 
 def blocker(*args):
@@ -33,3 +34,7 @@ class DBBlockerSerializerMixin:
     def __init__(self, *args, **kwargs):
         self.dangerously_allow_db = kwargs.pop("dangerously_allow_db", None)
         return cast(Any, super()).__init__(*args, **kwargs)
+
+
+class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
+    pass

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -36,6 +36,12 @@ class DBBlockerSerializerMixin:
         return cast(Any, super()).__init__(*args, **kwargs)
 
 
+class BaseSerializer(DBBlockerSerializerMixin, serializers.Serializer):
+    """
+    Serializer with `DBBlockerSerializerMixin` to disable DB access.
+    """
+    pass
+
 class BaseModelSerializer(DBBlockerSerializerMixin, serializers.ModelSerializer):
     """
     Serializer with `DBBlockerSerializerMixin` to disable DB access.

--- a/backend/core/teams/serializers.py
+++ b/backend/core/teams/serializers.py
@@ -2,6 +2,7 @@ from typing import List
 from rest_framework import serializers
 
 from core.models import MyUser, Team, Membership, Invite
+from core.serialization import BaseModelSerializer
 
 
 class PublicUserSerializer(serializers.ModelSerializer):
@@ -11,7 +12,7 @@ class PublicUserSerializer(serializers.ModelSerializer):
         fields = ("id", "email", "avatar_url")
 
 
-class TeamSerializer(serializers.ModelSerializer):
+class TeamSerializer(BaseModelSerializer):
 
     emails = serializers.ListField(
         child=serializers.EmailField(write_only=True), write_only=True

--- a/backend/core/teams/serializers.py
+++ b/backend/core/teams/serializers.py
@@ -72,7 +72,7 @@ class MembershipSerializer(serializers.ModelSerializer):
         return level
 
 
-class InviteSerializer(serializers.ModelSerializer):
+class InviteSerializer(BaseModelSerializer):
     user = PublicUserSerializer()
     team = TeamSerializer(fields=["id", "name"], read_only=True)
     creator = PublicUserSerializer()

--- a/backend/core/teams/serializers.py
+++ b/backend/core/teams/serializers.py
@@ -2,7 +2,7 @@ from typing import List
 from rest_framework import serializers
 
 from core.models import MyUser, Team, Membership, Invite
-from core.serialization import BaseModelSerializer
+from core.serialization import BaseModelSerializer, BaseSerializer
 
 
 class PublicUserSerializer(serializers.ModelSerializer):
@@ -83,7 +83,7 @@ class InviteSerializer(BaseModelSerializer):
         fields = ("id", "user", "team", "active", "creator", "status")
 
 
-class CreateInviteSerializer(serializers.Serializer):
+class CreateInviteSerializer(BaseSerializer):
     level = serializers.ChoiceField(
         choices=Membership.MEMBERSHIP_CHOICES, write_only=True
     )

--- a/backend/core/teams/serializers.py
+++ b/backend/core/teams/serializers.py
@@ -51,7 +51,7 @@ class TeamSerializer(BaseModelSerializer):
         return team
 
 
-class MembershipSerializer(serializers.ModelSerializer):
+class MembershipSerializer(BaseModelSerializer):
     user = PublicUserSerializer()
 
     class Meta:

--- a/backend/core/teams/serializers.py
+++ b/backend/core/teams/serializers.py
@@ -5,7 +5,7 @@ from core.models import MyUser, Team, Membership, Invite
 from core.serialization import BaseModelSerializer, BaseSerializer
 
 
-class PublicUserSerializer(serializers.ModelSerializer):
+class PublicUserSerializer(BaseModelSerializer):
     class Meta:
         model = MyUser
         editable = False

--- a/backend/core/teams/views.py
+++ b/backend/core/teams/views.py
@@ -80,7 +80,7 @@ class UserInvitesViewSet(
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
-        return Invite.objects.filter(membership__user=self.request.user)
+        return Invite.objects.filter(membership__user=self.request.user).select_related('membership', 'creator').prefetch_related('membership__user', 'membership__team')
 
     @detail_route(methods=["post"], url_name="accept")
     def accept(self, request, pk=None):

--- a/backend/core/teams/views.py
+++ b/backend/core/teams/views.py
@@ -109,7 +109,7 @@ class TeamViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         return Team.objects.filter(
-            membership__user__id=self.request.user.id
+            membership__user_id=self.request.user.id
         ) | Team.objects.filter(is_public=True)
 
     def get_permissions(self):

--- a/backend/core/teams/views.py
+++ b/backend/core/teams/views.py
@@ -75,7 +75,11 @@ class UserInvitesViewSet(
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
-        return Invite.objects.filter(membership__user=self.request.user).select_related('membership', 'creator').prefetch_related('membership__user', 'membership__team')
+        return (
+            Invite.objects.filter(membership__user=self.request.user)
+            .select_related("membership", "creator")
+            .prefetch_related("membership__user", "membership__team")
+        )
 
     @detail_route(methods=["post"], url_name="accept")
     def accept(self, request, pk=None):
@@ -145,7 +149,7 @@ class MembershipViewSet(
 
     def get_queryset(self):
         team = get_object_or_404(Team.objects.all(), pk=self.kwargs["team_pk"])
-        return team.membership_set.select_related('user').all()
+        return team.membership_set.select_related("user").all()
 
     def get_permissions(self):
         if self.request.method in SAFE_METHODS:

--- a/backend/core/teams/views.py
+++ b/backend/core/teams/views.py
@@ -41,11 +41,6 @@ class TeamInviteViewSet(
         team_pk = self.kwargs["team_pk"]
         return Invite.objects.filter(membership__team__id=team_pk)
 
-    def get_serializer_class(self):
-        if self.action == "create":
-            return CreateInviteSerializer
-        return InviteSerializer
-
     def create(self, request, team_pk=None):
         """
         for creating, we want: level, user_id
@@ -54,7 +49,7 @@ class TeamInviteViewSet(
         need to use to_representation or form_represenation
         """
         team = Team.objects.get(pk=team_pk)
-        serializer = self.get_serializer(data={**request.data, "team": team})
+        serializer = CreateInviteSerializer(data={**request.data, "team": team})
         serializer.is_valid(raise_exception=True)
         invite = serializer.save(team=team, creator=self.request.user)
         return Response(

--- a/backend/core/teams/views.py
+++ b/backend/core/teams/views.py
@@ -145,7 +145,7 @@ class MembershipViewSet(
 
     def get_queryset(self):
         team = get_object_or_404(Team.objects.all(), pk=self.kwargs["team_pk"])
-        return team.membership_set.all()
+        return team.membership_set.select_related('user').all()
 
     def get_permissions(self):
         if self.request.method in SAFE_METHODS:

--- a/backend/core/users/serializers.py
+++ b/backend/core/users/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from core.models import MyUser
 from core.serialization import BaseModelSerializer
 
+
 class UserSerializer(BaseModelSerializer):
     """serializer custom user model"""
 

--- a/backend/core/users/serializers.py
+++ b/backend/core/users/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 
 from core.models import MyUser
+from core.serialization import BaseModelSerializer
 
-
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(BaseModelSerializer):
     """serializer custom user model"""
 
     class Meta:

--- a/backend/core/users/serializers.py
+++ b/backend/core/users/serializers.py
@@ -1,5 +1,3 @@
-from rest_framework import serializers
-
 from core.models import MyUser
 from core.serialization import BaseModelSerializer
 

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -1179,6 +1179,14 @@ export const addingScheduledRecipe = (dispatch: Dispatch) => (
     .then(res => {
       dispatch(replaceCalendarRecipe(id, res.data))
       dispatch(setSchedulingRecipe(recipeID, false))
+      const scheduledDate = new Date(res.data.on).toLocaleDateString()
+      const recipeName = res.data.recipe.name
+      const message = `${recipeName} scheduled on ${scheduledDate}`
+      showNotificationWithTimeout(dispatch)({
+        message,
+        level: "success",
+        delay: 3 * second
+      })
     })
     .catch(() => {
       dispatch(deleteCalendarRecipe(id))


### PR DESCRIPTION
N+1 queries are more of an issue with list views, so I think it's acceptable to
allow queries inside create views where we only serialize one object.