### PR TITLE
Use global team id in add recipe form

### DIFF
--- a/frontend/src/containers/AddRecipe.ts
+++ b/frontend/src/containers/AddRecipe.ts
@@ -12,7 +12,6 @@ import {
   setAddRecipeFormSource,
   setAddRecipeFormTime,
   setAddRecipeFormServings,
-  setAddRecipeFormTeam,
   addAddRecipeFormIngredient,
   removeAddRecipeFormIngredient,
   updateAddRecipeFormIngredient,
@@ -27,6 +26,7 @@ import {
   IStepBasic,
   resetAddRecipeErrors
 } from "@/store/reducers/recipes"
+import { updateTeamID } from "@/store/reducers/user"
 
 const mapStateToProps = (state: RootState) => ({
   name: state.addrecipe.name,
@@ -41,7 +41,7 @@ const mapStateToProps = (state: RootState) => ({
   // we remove the loading
   teams: teamsFrom(state),
   loadingTeams: !!state.teams.loading,
-  teamID: state.addrecipe.team
+  teamID: state.user.teamID
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -55,7 +55,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(setAddRecipeFormTime(e.target.value)),
   setServings: (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch(setAddRecipeFormServings(e.target.value)),
-  setTeamID: (id: ITeam["id"] | null) => dispatch(setAddRecipeFormTeam(id)),
+  setTeamID: (id: ITeam["id"] | null) => dispatch(updateTeamID(id)),
 
   addIngredient: (x: IIngredientBasic) =>
     dispatch(addAddRecipeFormIngredient(x)),

--- a/frontend/src/store/reducers/addrecipe.ts
+++ b/frontend/src/store/reducers/addrecipe.ts
@@ -7,7 +7,6 @@ const SET_ADD_RECIPE_FORM_AUTHOR = "SET_ADD_RECIPE_FORM_AUTHOR"
 const SET_ADD_RECIPE_FORM_SOURCE = "SET_ADD_RECIPE_FORM_SOURCE"
 const SET_ADD_RECIPE_FORM_TIME = "SET_ADD_RECIPE_FORM_TIME"
 const SET_ADD_RECIPE_FORM_SERVINGS = "SET_ADD_RECIPE_FORM_SERVINGS"
-const SET_ADD_RECIPE_FORM_TEAM = "SET_ADD_RECIPE_FORM_TEAM"
 const ADD_ADD_RECIPE_FORM_INGREDIENT = "ADD_ADD_RECIPE_FORM_INGREDIENT"
 const REMOVE_ADD_RECIPE_FORM_INGREDIENT = "REMOVE_ADD_RECIPE_FORM_INGREDIENT"
 const ADD_ADD_RECIPE_FORM_STEP = "ADD_ADD_RECIPE_FORM_STEP"
@@ -30,9 +29,6 @@ export const setAddRecipeFormTime = (val: string) =>
 
 export const setAddRecipeFormServings = (val: string) =>
   act(SET_ADD_RECIPE_FORM_SERVINGS, val)
-
-export const setAddRecipeFormTeam = (val: ITeam["id"] | null) =>
-  act(SET_ADD_RECIPE_FORM_TEAM, val)
 
 export const addAddRecipeFormIngredient = (ingredient: IIngredientBasic) =>
   act(ADD_ADD_RECIPE_FORM_INGREDIENT, ingredient)
@@ -69,7 +65,6 @@ export type AddRecipeActions =
   | ReturnType<typeof setAddRecipeFormSource>
   | ReturnType<typeof setAddRecipeFormTime>
   | ReturnType<typeof setAddRecipeFormServings>
-  | ReturnType<typeof setAddRecipeFormTeam>
   | ReturnType<typeof addAddRecipeFormIngredient>
   | ReturnType<typeof removeAddRecipeFormIngredient>
   | ReturnType<typeof addAddRecipeFormStep>
@@ -139,12 +134,6 @@ const addrecipe = (
       return {
         ...state,
         steps: [...state.steps, action.payload]
-      }
-
-    case SET_ADD_RECIPE_FORM_TEAM:
-      return {
-        ...state,
-        team: action.payload
       }
     case REMOVE_ADD_RECIPE_FORM_STEP:
       return {

--- a/frontend/src/store/reducers/addrecipe.ts
+++ b/frontend/src/store/reducers/addrecipe.ts
@@ -1,5 +1,4 @@
 import { action as act } from "typesafe-actions"
-import { ITeam } from "@/store/reducers/teams"
 import { IStepBasic, IIngredientBasic } from "@/store/reducers/recipes"
 
 const SET_ADD_RECIPE_FORM_NAME = "SET_ADD_RECIPE_FORM_NAME"
@@ -81,7 +80,6 @@ export interface IAddRecipeState {
   readonly servings: string
   readonly ingredients: IIngredientBasic[]
   readonly steps: IStepBasic[]
-  readonly team: ITeam["id"] | null
 }
 
 export const initialState: IAddRecipeState = {
@@ -91,8 +89,7 @@ export const initialState: IAddRecipeState = {
   time: "",
   servings: "",
   ingredients: [],
-  steps: [],
-  team: null
+  steps: []
 }
 
 const addrecipe = (


### PR DESCRIPTION
The AddRecipe form now uses the global team id state to update the team selection dropdown.