### PR TITLE
refactor recipe ids

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -7,11 +7,7 @@ import { matchesQuery } from "@/search"
 import Results from "@/components/Results"
 import { byNameAlphabetical } from "@/sorters"
 import { Dispatch, fetchingRecipeList } from "@/store/actions"
-import {
-  IRecipe,
-  getTeamRecipes,
-  getAllRecipes
-} from "@/store/reducers/recipes"
+import { IRecipe, getTeamRecipes } from "@/store/reducers/recipes"
 import { ITeam } from "@/store/reducers/teams"
 import { RootState } from "@/store/store"
 import { WebData, isSuccessOrRefetching } from "@/webdata"
@@ -91,13 +87,7 @@ class RecipesListSearch extends React.Component<IRecipesProps, IRecipesState> {
 }
 
 function mapStateToProps(state: RootState, ownProps: IOwnProps) {
-  if (ownProps.teamID == null) {
-    return {
-      recipes: getAllRecipes(state)
-    }
-  }
   return {
-    // TODO(sbdchd): fix this hack
     recipes: getTeamRecipes(state, ownProps.teamID || "personal")
   }
 }

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -391,14 +391,14 @@ export const fetchingRecentRecipes = (dispatch: Dispatch) => () => {
 export const fetchingRecipeList = (dispatch: Dispatch) => (
   teamID: ITeam["id"] | "personal"
 ) => {
-  dispatch(fetchRecipeList.request())
+  dispatch(fetchRecipeList.request({ teamID }))
   return api
     .getRecipeList(teamID)
     .then(res => {
-      dispatch(fetchRecipeList.success(res.data))
+      dispatch(fetchRecipeList.success({ recipes: res.data, teamID }))
     })
     .catch(() => {
-      dispatch(fetchRecipeList.failure())
+      dispatch(fetchRecipeList.failure({ teamID }))
     })
 }
 
@@ -777,7 +777,7 @@ export const fetchTeamRecipes = (dispatch: Dispatch) => (id: number) => {
   return api
     .getTeamRecipes(id)
     .then(res => {
-      dispatch(fetchRecipeList.success(res.data))
+      dispatch(fetchRecipeList.success({ recipes: res.data, teamID: id }))
       dispatch(setTeamRecipes(id, res.data))
       dispatch(setLoadingTeamRecipes(id, false))
     })

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -264,11 +264,6 @@ const mapSuccessLikeById = <T extends IRecipe["id"][]>(
       .map(unWrap)
   )
 
-export function getAllRecipes(state: RootState): WebData<IRecipe[]> {
-  // personalIDs will include both personal recipes as well as the team recipes a user has access to
-  return mapSuccessLikeById(state.recipes.personalIDs, state)
-}
-
 export function getTeamRecipes(
   state: RootState,
   teamID: TeamID

--- a/frontend/src/store/reducers/shoppinglist.ts
+++ b/frontend/src/store/reducers/shoppinglist.ts
@@ -7,15 +7,7 @@ import {
   ActionType,
   getType
 } from "typesafe-actions"
-import {
-  WebData,
-  Success,
-  Loading,
-  Failure,
-  HttpErrorKind,
-  isSuccess,
-  Refetching
-} from "@/webdata"
+import { WebData, Success, Failure, HttpErrorKind, toLoading } from "@/webdata"
 
 const SET_SELECTING_START = "SET_SELECTING_START"
 const SET_SELECTING_END = "SET_SELECTING_END"
@@ -59,12 +51,8 @@ const shoppinglist = (
   switch (action.type) {
     case getType(fetchShoppingList.success):
       return { ...state, shoppinglist: Success(action.payload) }
-    case getType(fetchShoppingList.request): {
-      const nextState = isSuccess(state.shoppinglist)
-        ? Refetching(state.shoppinglist.data)
-        : Loading()
-      return { ...state, shoppinglist: nextState }
-    }
+    case getType(fetchShoppingList.request):
+      return { ...state, shoppinglist: toLoading(state.shoppinglist) }
     case getType(fetchShoppingList.failure):
       return { ...state, shoppinglist: Failure(HttpErrorKind.other) }
     case SET_SELECTING_START:

--- a/frontend/src/store/reducers/user.ts
+++ b/frontend/src/store/reducers/user.ts
@@ -9,15 +9,7 @@ import {
   getType
 } from "typesafe-actions"
 import { IRecipe } from "@/store/reducers/recipes"
-import {
-  WebData,
-  Success,
-  Failure,
-  HttpErrorKind,
-  Loading,
-  isSuccess,
-  Refetching
-} from "@/webdata"
+import { WebData, Success, Failure, HttpErrorKind, toLoading } from "@/webdata"
 
 const LOG_IN = "LOG_IN"
 
@@ -162,12 +154,9 @@ export const user = (
     case getType(fetchUserStats.success):
       return { ...state, stats: Success(action.payload) }
     case getType(fetchUserStats.request): {
-      const stats = isSuccess(state.stats)
-        ? Refetching(state.stats.data)
-        : Loading()
       return {
         ...state,
-        stats
+        stats: toLoading(state.stats)
       }
     }
     case getType(fetchUserStats.failure):
@@ -178,13 +167,10 @@ export const user = (
     case SET_SOCIAL_ACCOUNT_CONNECTIONS:
       return {
         ...state,
-        socialAccountConnections: {
-          ...state.socialAccountConnections,
-          ...action.payload.reduce(
-            (acc, { provider, id }) => ({ ...acc, [provider]: id }),
-            {}
-          )
-        }
+        socialAccountConnections: action.payload.reduce(
+          (acc, { provider, id }) => ({ ...acc, [provider]: id }),
+          state.socialAccountConnections
+        )
       }
     case SET_SOCIAL_ACCOUNT_CONNECTION:
       return {

--- a/frontend/src/webdata.ts
+++ b/frontend/src/webdata.ts
@@ -5,7 +5,7 @@ const enum RDK {
   Refetching
 }
 
-interface ILoading {
+export interface ILoading {
   readonly kind: RDK.Loading
 }
 export function Loading(): ILoading {
@@ -81,3 +81,24 @@ export const isRefetching = <T>(x: WebData<T>): x is IRefetching<T> =>
 export const isSuccessOrRefetching = <T>(
   x: WebData<T>
 ): x is ISuccess<T> | IRefetching<T> => isSuccess(x) || isRefetching(x)
+
+export const unWrap = <T>(d: ISuccess<T> | IRefetching<T>): T => d.data
+
+/** map over WebData with @param func if data is a type structurally similar to Success */
+export function mapSuccessLike<T, R>(
+  d: WebData<T>,
+  func: (data: T) => R
+): WebData<R> {
+  if (isSuccessOrRefetching(d)) {
+    return { ...d, data: func(unWrap(d)) }
+  }
+  return d
+}
+
+/** handle transitioning from Success & InitialState to Loading */
+export function toLoading<T>(state: WebData<T>): IRefetching<T> | ILoading {
+  if (isSuccess(state)) {
+    return Refetching(unWrap(state))
+  }
+  return Loading()
+}

--- a/frontend/tslint.json
+++ b/frontend/tslint.json
@@ -39,7 +39,7 @@
     "no-invalid-regexp": true,
     "no-octal-literal": true,
     "no-regex-spaces": true,
-    "no-single-line-block-comment": true,
+    "no-single-line-block-comment": false,
     "no-typeof-undefined": true,
     "no-unnecessary-bind": true,
     "no-unnecessary-field-initialization": true,


### PR DESCRIPTION
Refactor recipe Ids array in reducer so that we have separate arrays for each team. Personal recipes get their own array. We also setup the arrays to use `WebData<T>` and update the selectors accordingly.