### PR TITLE
Allow text selection without editing activation in steps/ingredients

### DIFF
--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -122,6 +122,11 @@ export default class Ingredient extends React.Component<
   }
 
   enableEditing = () => {
+    // Don't enable editing when user is selecting text
+    if (window.getSelection().toString().length > 0) {
+      return
+    }
+    // FIXME(chdsbd): This is identical to the method in ListItem
     this.setState({
       editing: true,
       unsavedChanges: false

--- a/frontend/src/components/ListItem.tsx
+++ b/frontend/src/components/ListItem.tsx
@@ -88,6 +88,11 @@ export default class ListItem extends React.Component<
   }
 
   enableEditing = () => {
+    // Don't enable editing when user is selecting text
+    if (window.getSelection().toString().length > 0) {
+      return
+    }
+
     this.setState({
       editing: true,
       unsavedChanges: false


### PR DESCRIPTION
When a user clicks on an ingredient or step, we only enable editing when
they have no selection.