### PR TITLE
Add copying of past scheduled recipes

### DIFF
--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -30,7 +30,6 @@ import { RootState } from "@/store/store"
 import { ICalRecipe } from "@/store/reducers/calendar"
 import { AxiosResponse } from "axios"
 import { IRecipeItemDrag } from "@/components/RecipeItem"
-import { isPast } from "date-fns"
 
 const Title = ({ date }: { date: Date }) => {
   if (isFirstDayOfMonth(date)) {

--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -12,7 +12,7 @@ import { beforeCurrentDay } from "@/date"
 
 import { classNames } from "@/classnames"
 
-import CalendarItem from "@/components/CalendarDayItem"
+import CalendarItem, { ICalendarDragItem } from "@/components/CalendarDayItem"
 
 import {
   addingScheduledRecipe,
@@ -29,6 +29,8 @@ import { IRecipe } from "@/store/reducers/recipes"
 import { RootState } from "@/store/store"
 import { ICalRecipe } from "@/store/reducers/calendar"
 import { AxiosResponse } from "axios"
+import { IRecipeItemDrag } from "@/components/RecipeItem"
+import { isPast } from "date-fns"
 
 const Title = ({ date }: { date: Date }) => {
   if (isFirstDayOfMonth(date)) {
@@ -133,20 +135,23 @@ export default connect(
   mapDispatchToProps
 )(
   DropTarget(
-    DragDrop.RECIPE,
+    [DragDrop.RECIPE, DragDrop.CAL_RECIPE],
     {
       canDrop({ date }: ICalendarDayProps) {
+        // event when copying from past, we don't want to copy to past dates
         return !beforeCurrentDay(date)
       },
       drop(props: ICalendarDayProps, monitor: DropTargetMonitor) {
-        const { recipeID, count = 1, id } = monitor.getItem()
+        const recipe: ICalendarDragItem | IRecipeItemDrag = monitor.getItem()
         // NOTE(chdsbd): We use Promise.resolve to elminate slow drop event
         // warnings.
-        if (id != null) {
-          Promise.resolve().then(() => props.move(id, props.teamID, props.date))
-        } else {
+        if (recipe.kind === DragDrop.CAL_RECIPE) {
           Promise.resolve().then(() =>
-            props.create(recipeID, props.teamID, props.date, count)
+            props.move(recipe.id, props.teamID, props.date)
+          )
+        } else if (recipe.kind === DragDrop.RECIPE) {
+          Promise.resolve().then(() =>
+            props.create(recipe.recipeID, props.teamID, props.date, 1)
           )
         }
       }

--- a/frontend/src/components/RecipeItem.tsx
+++ b/frontend/src/components/RecipeItem.tsx
@@ -142,11 +142,17 @@ export class RecipeItem extends React.Component<
   }
 }
 
+export interface IRecipeItemDrag {
+  readonly recipeID: IRecipeItemProps["id"]
+  readonly kind: typeof DragDrop.RECIPE
+}
+
 export default DragSource(
   DragDrop.RECIPE,
   {
-    beginDrag(props: IRecipeItemProps) {
+    beginDrag(props: IRecipeItemProps): IRecipeItemDrag {
       return {
+        kind: DragDrop.RECIPE,
         recipeID: props.id
       }
     },

--- a/frontend/src/dragDrop.ts
+++ b/frontend/src/dragDrop.ts
@@ -1,2 +1,3 @@
 export const RECIPE = "RECIPE"
+export const CAL_RECIPE = "CAL_RECIPE"
 export const CARD = "CARD"

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -104,6 +104,7 @@ import {
 } from "@/store/reducers/auth"
 import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
+import { isPast } from "date-fns"
 
 // We check if detail matches our string because Django will not return 401 when
 // the session expires
@@ -1232,6 +1233,16 @@ export const moveScheduledRecipe = (dispatch: Dispatch) => (
   // HACK(sbdchd): With an endpoint we can eliminate this
   const state = store.getState()
   const from = getCalRecipeById(state, id)
+
+  // We want to copy recipes from the past, not move them
+  if (isPast(from.on)) {
+    return addingScheduledRecipe(dispatch)(
+      from.recipe.id,
+      teamID,
+      to,
+      from.count
+    )
+  }
   const existing = getAllCalRecipes(state)
     .filter(x => isSameDay(x.on, to) && isSameTeam(x, teamID))
     .find(x => x.recipe.id === from.recipe.id)


### PR DESCRIPTION
Before:
We could only move scheduled recipes that aren't in the past

After:
We can now copy recipes from the past.