### PR TITLE
Fix webpack build for Typescript by disabled type checking

### DIFF
--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -120,8 +120,10 @@ module.exports = {
       {
         test: /\.(ts|tsx)$/,
         include: paths.appSrc,
-        loaders: ["babel-loader",  {
-            loader: 'ts-loader',
+        loaders: [
+          "babel-loader",
+          {
+            loader: "ts-loader",
             options: {
               transpileOnly: true
             }

--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -120,7 +120,13 @@ module.exports = {
       {
         test: /\.(ts|tsx)$/,
         include: paths.appSrc,
-        loaders: ["babel-loader", "ts-loader"]
+        loaders: ["babel-loader",  {
+            loader: 'ts-loader',
+            options: {
+              transpileOnly: true
+            }
+          }
+        ]
       },
       // The notation here is somewhat confusing.
       // "postcss" loader applies autoprefixer to our CSS.


### PR DESCRIPTION
We already type check our TS code in another build job, so we can save
time by only transpiling the code via Webpack ts-loader.

We were having the same module resolution issue I solved by updating the
tsconfig.json, but it seems like Webpack ts-loader doesn't use that for
module resolution, so it was broken. It's possible to use the tsconfig
path settings for module resolution, but I think it's easier if we
ignore type checking all together for this container build.

Documentation on using baseUrl and paths settings from tsconfig.json:
https://github.com/TypeStrong/ts-loader/tree/58505c477669695655277dbd9aa538dc01374cc1#baseurl--paths-module-resolution