### PR TITLE
Fix circleci config format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,6 @@ jobs:
 
   # https://circleci.com/docs/2.0/building-docker-images/
   build_api_container:
-    requires:
-      - backend_test
-      - backend_lint
     docker:
       - image: docker:18.05.0-ce
     steps:
@@ -158,9 +155,6 @@ jobs:
 
   # https://circleci.com/docs/2.0/building-docker-images/
   build_ui_container:
-    requires:
-      - frontend_test
-      - frontend_lint
     docker:
       - image: docker:18.05.0-ce
     steps:
@@ -209,11 +203,17 @@ workflows:
       - frontend_lint
       - build_api_container:
           context: DockerHub
+          requires:
+            - backend_test
+            - backend_lint
           filters:
             branches:
               only: master
       - build_ui_container:
           context: DockerHub
+          requires:
+            - frontend_test
+            - frontend_lint
           filters:
             branches:
               only: master


### PR DESCRIPTION
The `requires` key must be in the `jobs` subkey of `workflows`.

https://circleci.com/docs/2.0/workflows/#fan-outfan-in-workflow-example