### PR TITLE
Fix DB blocker to correctly warn about database access in serializers

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -200,6 +200,8 @@ DATABASES = {}
 
 DATABASES["default"] = dj_database_url.config(conn_max_age=600)
 
+ERROR_ON_SERIALIZER_DB_ACCESS = DEBUG or TESTING
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators


### PR DESCRIPTION
We were warning on all data accesses instead of database accesses. Now we only log a warning when a user attempts to access to the database.