### PR TITLE
Chrome would have the calendar overflow under the nav

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -136,7 +136,7 @@ function Nav({
   current
 }: INavProps) {
   return (
-    <div className="d-flex justify-space-between align-items-end">
+    <div className="d-flex justify-space-between align-items-end min-height-content">
       <section className="d-flex align-items-center">
         <CalTitle day={day} />
         <TeamSelect

--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -471,6 +471,10 @@
   width: unset;
 }
 
+.min-height-content {
+  min-height: min-content;
+}
+
 .min-width-max-content {
   min-width: max-content;
 }


### PR DESCRIPTION
Doesn't occur in safari and firefox