### PR TITLE
Disable dev middlewares for testing.

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -151,7 +151,7 @@ MIDDLEWARE = [
 
 SESSION_ENGINE = "user_sessions.backends.db"
 
-if DEBUG:
+if DEBUG and not TESTING:
     MIDDLEWARE += (
         "backend.middleware.ServerTimingMiddleware",
         "backend.middleware.APIDelayMiddleware",


### PR DESCRIPTION
We were literally calling time.sleep in our tests