### PR TITLE
Add shift to duplicate scheduled recipe

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -32,7 +32,7 @@ import Recipes from "@/components/RecipeList"
 import ErrorBoundary from "@/components/ErrorBoundary"
 
 import "@/components/scss/main.scss"
-import GlobalEvent from "@/components/GlobalEvent"
+import { CurrentKeys } from "@/components/CurrentKeys"
 
 interface IAuthRouteProps extends RouteProps {
   readonly authenticated: boolean
@@ -111,18 +111,6 @@ const PublicOnlyRoute = connect(mapAuthenticated)(
     />
   )
 )
-
-export const heldKeys = new Set<string>()
-
-function CurrentKeys() {
-  const handleKeyDown = (e: KeyboardEvent) => {
-    heldKeys.add(e.key)
-  }
-  const handleKeyUp = (e: KeyboardEvent) => {
-    heldKeys.delete(e.key)
-  }
-  return <GlobalEvent keyDown={handleKeyDown} keyUp={handleKeyUp} />
-}
 
 function Base() {
   return (

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -117,11 +117,9 @@ export const heldKeys = new Set<string>()
 function CurrentKeys() {
   const handleKeyDown = (e: KeyboardEvent) => {
     heldKeys.add(e.key)
-    console.log("down", heldKeys)
   }
   const handleKeyUp = (e: KeyboardEvent) => {
     heldKeys.delete(e.key)
-    console.log("up", heldKeys)
   }
   return <GlobalEvent keyDown={handleKeyDown} keyUp={handleKeyUp} />
 }

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -32,6 +32,7 @@ import Recipes from "@/components/RecipeList"
 import ErrorBoundary from "@/components/ErrorBoundary"
 
 import "@/components/scss/main.scss"
+import GlobalEvent from "@/components/GlobalEvent"
 
 interface IAuthRouteProps extends RouteProps {
   readonly authenticated: boolean
@@ -111,10 +112,25 @@ const PublicOnlyRoute = connect(mapAuthenticated)(
   )
 )
 
+export const heldKeys = new Set<string>()
+
+function CurrentKeys() {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    heldKeys.add(e.key)
+    console.log("down", heldKeys)
+  }
+  const handleKeyUp = (e: KeyboardEvent) => {
+    heldKeys.delete(e.key)
+    console.log("up", heldKeys)
+  }
+  return <GlobalEvent keyDown={handleKeyDown} keyUp={handleKeyUp} />
+}
+
 function Base() {
   return (
     <ErrorBoundary>
       <Helmet defaultTitle="Recipe Yak" titleTemplate="%s | Recipe Yak" />
+      <CurrentKeys />
       <ConnectedRouter history={history}>
         <Switch>
           <PublicOnlyRoute exact path="/login" component={Login} />

--- a/frontend/src/components/CurrentKeys.tsx
+++ b/frontend/src/components/CurrentKeys.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import GlobalEvent from "@/components/GlobalEvent"
+export const heldKeys = new Set<string>()
+
+export function CurrentKeys() {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    heldKeys.add(e.key)
+  }
+  const handleKeyUp = (e: KeyboardEvent) => {
+    heldKeys.delete(e.key)
+  }
+  return <GlobalEvent keyDown={handleKeyDown} keyUp={handleKeyUp} />
+}

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -94,7 +94,7 @@ import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
 import { isPast, endOfDay } from "date-fns"
 import { isOk, isErr, Ok, Err } from "@/result"
-import { heldKeys } from "@/components/CurrentKeys";
+import { heldKeys } from "@/components/CurrentKeys"
 
 // TODO(sbdchd): move to @/store/store
 export type Dispatch = ReduxDispatch<Action>

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -94,6 +94,7 @@ import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
 import { isPast, endOfDay } from "date-fns"
 import { isOk, isErr, Ok, Err } from "@/result"
+import { heldKeys } from "@/components/App"
 
 // TODO(sbdchd): move to @/store/store
 export type Dispatch = ReduxDispatch<Action>
@@ -997,7 +998,8 @@ function toCalRecipe(
     },
     on: toDateString(on),
     count,
-    user: recipe.owner.id
+    user: recipe.owner.type === "user" ? recipe.owner.id : null,
+    team: recipe.owner.type === "team" ? recipe.owner.id : null
   }
 }
 
@@ -1078,8 +1080,12 @@ export const moveScheduledRecipe = (dispatch: Dispatch) => async (
   const state = store.getState()
   const from = getCalRecipeById(state, id)
 
-  // We want to copy recipes from the past, not move them
-  if (isPast(endOfDay(from.on))) {
+  // copy recipe if
+  // - recipe from the past
+  // - user is holding shift
+  const holdingShift = heldKeys.size === 1 && heldKeys.has("Shift")
+  const copyRecipe = isPast(endOfDay(from.on)) || holdingShift
+  if (copyRecipe) {
     return addingScheduledRecipe(dispatch)(
       from.recipe.id,
       teamID,

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -94,7 +94,7 @@ import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
 import { isPast, endOfDay } from "date-fns"
 import { isOk, isErr, Ok, Err } from "@/result"
-import { heldKeys } from "@/components/App"
+import { heldKeys } from "@/components/CurrentKeys";
 
 // TODO(sbdchd): move to @/store/store
 export type Dispatch = ReduxDispatch<Action>


### PR DESCRIPTION
Dragging a recipe while holding shift will duplicate it instead of
moving it.

Fix some weirdness around our optimistic scheduling of recipes.