### PR TITLE
improve caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v3-{{ .Branch }}-
-            - backend-v3-
+            - backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v4-{{ .Branch }}-
+            - backend-v4-
       - run:
           name: install dependencies
           command: |
@@ -35,8 +35,8 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
-            - $HOME/.cache/
-          key: backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - /root/.cache/
+          key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
           command: poetry run yak test --api
@@ -62,9 +62,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v3-{{ .Branch }}-
-            - backend-v3-
+            - backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v4-{{ .Branch }}-
+            - backend-v4-
       - run:
           name: install dependencies
           command: |
@@ -76,8 +76,8 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
-            - $HOME/.cache/
-          key: backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - /root/.cache/
+          key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
           command: poetry run yak lint --api
@@ -93,9 +93,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v3-dependencies-{{ .Branch }}-
-            - frontend-v3-dependencies-
+            - frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v4-dependencies-{{ .Branch }}-
+            - frontend-v4-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -108,8 +108,8 @@ jobs:
           paths:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
-            - $HOME/.cache/
-          key: frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - /root/.cache/
+          key: frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -124,9 +124,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v3-dependencies-{{ .Branch }}-
-            - frontend-v3-dependencies-
+            - frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v4-dependencies-{{ .Branch }}-
+            - frontend-v4-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -139,8 +139,8 @@ jobs:
           paths:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
-            - $HOME/.cache/
-          key: frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - /root/.cache/
+          key: frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,11 +102,8 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            (
-              poetry install &
-              yarn install &
-              FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
-            )
+            poetry install
+            yarn install
       - save_cache:
           paths:
             - ./frontend/node_modules
@@ -136,11 +133,8 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            (
-              poetry install &
-              yarn install &
-              FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
-            )
+            poetry install
+            yarn install
       - save_cache:
           paths:
             - ./frontend/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v4-{{ .Branch }}-
-            - backend-v4-
+            - backend-v8-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v8-{{ .Branch }}-
+            - backend-v8-
       - run:
           name: install dependencies
           command: |
@@ -35,7 +35,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /root/.cache/
-          key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v8-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
           command: poetry run yak test --api
@@ -61,9 +61,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v4-{{ .Branch }}-
-            - backend-v4-
+            - backend-v8-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v8-{{ .Branch }}-
+            - backend-v8-
       - run:
           name: install dependencies
           command: |
@@ -75,7 +75,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /root/.cache/
-          key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v8-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
           command: poetry run yak lint --api
@@ -91,9 +91,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v5-dependencies-{{ .Branch }}-
-            - frontend-v5-dependencies-
+            - frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v8-dependencies-{{ .Branch }}-
+            - frontend-v8-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -106,7 +106,7 @@ jobs:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -121,9 +121,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v5-dependencies-{{ .Branch }}-
-            - frontend-v5-dependencies-
+            - frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v8-dependencies-{{ .Branch }}-
+            - frontend-v8-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -136,7 +136,7 @@ jobs:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
       - save_cache:
           paths:
             - ./backend/.mypy_cache
-            - /home/circleci/.cache/pypoetry/
             - /root/.cache/
           key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
@@ -75,7 +74,6 @@ jobs:
       - save_cache:
           paths:
             - ./backend/.mypy_cache
-            - /home/circleci/.cache/pypoetry/
             - /root/.cache/
           key: backend-v4-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
@@ -93,9 +91,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v4-dependencies-{{ .Branch }}-
-            - frontend-v4-dependencies-
+            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v5-dependencies-{{ .Branch }}-
+            - frontend-v5-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -103,13 +101,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install
+            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
-            - ./frontend/node_modules
-            - /home/circleci/.cache/pypoetry/
+            - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -124,9 +121,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v4-dependencies-{{ .Branch }}-
-            - frontend-v4-dependencies-
+            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v5-dependencies-{{ .Branch }}-
+            - frontend-v5-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -134,13 +131,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install
+            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
-            - ./frontend/node_modules
-            - /home/circleci/.cache/pypoetry/
+            - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v4-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v2-{{ .Branch }}-
-            - backend-v2-
+            - backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v3-{{ .Branch }}-
+            - backend-v3-
       - run:
           name: install dependencies
           command: |
@@ -36,7 +36,7 @@ jobs:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
             - $HOME/.cache/
-          key: backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
           command: poetry run yak test --api
@@ -62,9 +62,9 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
-            - backend-v2-{{ .Branch }}-
-            - backend-v2-
+            - backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v3-{{ .Branch }}-
+            - backend-v3-
       - run:
           name: install dependencies
           command: |
@@ -77,7 +77,7 @@ jobs:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
             - $HOME/.cache/
-          key: backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v3-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
           command: poetry run yak lint --api
@@ -93,9 +93,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v2-dependencies-{{ .Branch }}-
-            - frontend-v2-dependencies-
+            - frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v3-dependencies-{{ .Branch }}-
+            - frontend-v3-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -109,7 +109,7 @@ jobs:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
             - $HOME/.cache/
-          key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -124,9 +124,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v2-dependencies-{{ .Branch }}-
-            - frontend-v2-dependencies-
+            - frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v3-dependencies-{{ .Branch }}-
+            - frontend-v3-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -140,7 +140,7 @@ jobs:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
             - $HOME/.cache/
-          key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v6-dependencies-{{ .Branch }}-
-            - frontend-v6-dependencies-
+            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v5-dependencies-{{ .Branch }}-
+            - frontend-v5-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -101,12 +101,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install --frozen-lockfile
+            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -121,9 +121,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v6-dependencies-{{ .Branch }}-
-            - frontend-v6-dependencies-
+            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v5-dependencies-{{ .Branch }}-
+            - frontend-v5-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -131,12 +131,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install --frozen-lockfile
+            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v5-dependencies-{{ .Branch }}-
-            - frontend-v5-dependencies-
+            - frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v6-dependencies-{{ .Branch }}-
+            - frontend-v6-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -101,12 +101,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
+            yarn install --frozen-lockfile
       - save_cache:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           working_directory: frontend
@@ -121,9 +121,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - frontend-v5-dependencies-{{ .Branch }}-
-            - frontend-v5-dependencies-
+            - frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v6-dependencies-{{ .Branch }}-
+            - frontend-v6-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -131,12 +131,12 @@ jobs:
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
             poetry install
-            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
+            yarn install --frozen-lockfile
       - save_cache:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v5-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v6-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
       - save_cache:
           paths:
             - ./frontend/node_modules
+            - /home/circleci/.cache/pypoetry/
           key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
@@ -134,6 +135,7 @@ jobs:
       - save_cache:
           paths:
             - ./frontend/node_modules
+            - /home/circleci/.cache/pypoetry/
           key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
+            - $HOME/.cache/
           key: backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
@@ -75,6 +76,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /home/circleci/.cache/pypoetry/
+            - $HOME/.cache/
           key: backend-v2-{{ .Branch }}-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
@@ -106,6 +108,7 @@ jobs:
           paths:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
+            - $HOME/.cache/
           key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
@@ -136,6 +139,7 @@ jobs:
           paths:
             - ./frontend/node_modules
             - /home/circleci/.cache/pypoetry/
+            - $HOME/.cache/
           key: frontend-v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,11 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            poetry install &
-            yarn install &
-            FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
+            (
+              poetry install &
+              yarn install &
+              FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
+            )
       - save_cache:
           paths:
             - ./frontend/node_modules
@@ -134,9 +136,11 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            poetry install &
-            yarn install &
-            FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
+            (
+              poetry install &
+              yarn install &
+              FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
+            )
       - save_cache:
           paths:
             - ./frontend/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,9 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            poetry install
-            yarn install
+            poetry install &
+            yarn install &
+            FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
       - save_cache:
           paths:
             - ./frontend/node_modules
@@ -133,8 +134,9 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             # Use our new PATH so we can call poetry from bash
             source $BASH_ENV
-            poetry install
-            yarn install
+            poetry install &
+            yarn install &
+            FAIL=0; for job in $(jobs -p); do wait $job || FAIL=1; done; exit $FAIL
       - save_cache:
           paths:
             - ./frontend/node_modules


### PR DESCRIPTION
Caching was kind of busted by the introduction of the cli. This PR fixes that.

### changes
- cache yarn global cache
- correct caching for node_modules (this was accidentally broken when we reorganized the repo)

### performance
job | cached run time | no cache run time * | master run time with partial caching
--- | --- | ---| ---
frontend_test | 1:00 | 4:07 | 4:18
frontend_lint | 2:20 | 3:59 | 2:51
backend_test | 0:34 | 1:27 | 2:39
backend_lint | 1:11 | 2:00 | 3:26

\* this will only happen when we increment the cache versions. Typically we'll get a partial cache hit which should improve install performance.