### PR TITLE
build: fix vscode config for mypy and flake8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,11 +17,11 @@
         "--ignore-missing-imports",
         "--follow-imports=silent",
         "--show-column-numbers",
-        "--config-file tox.ini"
+        "--config-file", "tox.ini"
     ],
     "python.linting.flake8Enabled": true,
     "python.linting.flake8Args": [
-        "--config tox.ini"
+        "--config", "tox.ini"
     ],
     "python.linting.pylintEnabled": true
 }


### PR DESCRIPTION
We weren't passing the config files in vscode correctly so flake8 and
mypy were silently failing