### PR TITLE
build: ignore formatting issues with pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -170,7 +170,10 @@ disable=print-statement,
         # doesn't handle python 3.7 scoping for type annotations
         undefined-variable,
         # style is handled by formatter
-        trailing-newlines
+        trailing-newlines,
+        trailing-whitespace,
+        bad-whitespace,
+        bad-indentation
 
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
There are probably other pylint lints to ignore too, be we probably need
to be systematic to find them. 