### PR TITLE
add(test): pytest-randomly

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -607,6 +607,17 @@ pytest = ">=2.9"
 
 [[package]]
 category = "dev"
+description = "Pytest plugin to randomly order tests and control random.seed."
+name = "pytest-randomly"
+optional = false
+python-versions = ">=3.4"
+version = "2.1.1"
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
+category = "dev"
 description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
 name = "pytest-sugar"
 optional = false
@@ -828,7 +839,7 @@ python-versions = "*"
 version = "1.11.1"
 
 [metadata]
-content-hash = "fc87586adb3fb9f7019277ce4217cc5f6d5b5dcde20d7f0ac6b85775412c674b"
+content-hash = "4f4fcbcc910f89aaaf242825b297969c3253cf4c6b28121c90ce2ef15604d2c5"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -892,6 +903,7 @@ pyparsing = ["66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
 pytest = ["6074ea3b9c999bd6d0df5fa9d12dd95ccd23550df2a582f5f5b848331d2e82ca", "95fa025cd6deb5d937e04e368a00552332b58cae23f63b76c8c540ff1733ab6d"]
 pytest-cov = ["03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d", "890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"]
 pytest-django = ["00995c2999b884a38ae9cd30a8c00ed32b3d38c1041250ea84caf18085589662", "038ccc5a9daa1b1b0eb739ab7dce54e495811eca5ea3af4815a2a3ac45152309"]
+pytest-randomly = ["0ff564fabb638ab52d535d8ce1da71353c7ecd54edcc5dc117f6f21f8269cfef", "f76a068dcadb4ffbd4f6c55dd447cf95fb78cfe4f3f1445c3bee5657fdf5b3d1"]
 pytest-sugar = ["26cf8289fe10880cbbc130bd77398c4e6a8b936d8393b116a5c16121d95ab283", "fcd87a74b2bce5386d244b49ad60549bfbc4602527797fac167da147983f58ab"]
 pytest-watch = ["06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9"]
 python-dotenv = ["a84569d0e00d178bc5b957f7ff208bf49287cbf61857c31c258c4a91f571527b", "c9b1ddd3cdbe75c7d462cb84674d87130f4b948f090f02c7d7144779afb99ae0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ flake8-pie = "^0.0.4"
 flake8-print = "^3.1"
 pylint = "^2.3"
 pytest-sugar = "^0.9.2"
+pytest-randomly = "^2.1"
 
 [tool.poetry.scripts]
 yak = 'cli:cli'


### PR DESCRIPTION
pytest-randomly will randomly order tests between each run. This can
help catch unintentional dependencies between tests.