### PR TITLE
tools: bump test timeout

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ DJANGO_SETTINGS_MODULE = backend.settings
 python_files = tests.py test_*.py *_tests.py
 norecursedir = venv env .pytest_cache .mypy_cache .cache backup .venv
 addopts = -s --pdbcls IPython.terminal.debugger:TerminalPdb --reuse-db
-timeout = 5
+; prevent tests from hanging for too long
+timeout = 30
 filterwarnings =
   error
   ignore::django.utils.deprecation.RemovedInDjango30Warning


### PR DESCRIPTION
When tests are starting, the first one can take a while to setup the
database connection