### PR TITLE
fix(cli): support passing unknown args to test command

### DIFF
--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -81,7 +81,7 @@ def fmt(api: bool, web: bool, check: bool) -> None:
             m.add_process("prettier", cmds.prettier(check=check))
 
 
-@cli.command(help="test services")
+@cli.command(help="test services", context_settings=dict(ignore_unknown_options=True))
 @click.option("-a", "--api/--no-api")
 @click.option("-w", "--web/--no-web")
 @click.option("--watch/--no-watch")


### PR DESCRIPTION
This is important for passing args to pytest, like `--testmon`