### PR TITLE
Remove dependency on .env file for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ jobs:
     docker:
       - image: recipeyak/base:v3
         environment:
-          DEBUG: 1
           DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres
-          PIPENV_VENV_IN_PROJECT: 1
       # https://circleci.com/docs/2.0/postgres-config/#optimizing-postgres-images
       - image: circleci/postgres:9.5-alpine-ram
         command: [
@@ -46,9 +44,7 @@ jobs:
     docker:
       - image: recipeyak/base:v3
         environment:
-          DEBUG: 1
           DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres
-          PIPENV_VENV_IN_PROJECT: 1
       # https://circleci.com/docs/2.0/postgres-config/#optimizing-postgres-images
       - image: circleci/postgres:9.5-alpine-ram
         command: [
@@ -85,8 +81,6 @@ jobs:
   frontend_test:
     docker:
       - image: recipeyak/base:v3
-        environment:
-          DEBUG: 1
     steps:
       - checkout
       - restore_cache:
@@ -115,8 +109,6 @@ jobs:
   frontend_lint:
     docker:
       - image: recipeyak/base:v3
-        environment:
-          DEBUG: 1
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
   backend_test:
     docker:
       - image: recipeyak/base:v3
-        environment:
-          DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres
       # https://circleci.com/docs/2.0/postgres-config/#optimizing-postgres-images
       - image: circleci/postgres:9.5-alpine-ram
         command: [
@@ -43,8 +41,6 @@ jobs:
   backend_lint:
     docker:
       - image: recipeyak/base:v3
-        environment:
-          DATABASE_URL: postgres://postgres@127.0.0.1:5432/postgres
       # https://circleci.com/docs/2.0/postgres-config/#optimizing-postgres-images
       - image: circleci/postgres:9.5-alpine-ram
         command: [

--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -9,7 +9,11 @@ from pathlib import Path
 import click
 from dotenv import load_dotenv
 
-from cli.config import setup_django_sites, setup_django as configure_django
+from cli.config import (
+    setup_django_sites,
+    setup_django as configure_django,
+    set_default as set_default_config,
+)
 from cli.decorators import setup_django, load_env
 from cli.docker_machine import docker_machine_env, docker_machine_unset_env
 from cli import cmds
@@ -34,8 +38,7 @@ def lint(ctx: click.core.Context, api: bool, web: bool) -> None:
     is_all = not api and not web
     from cli.manager import ProcessManager
 
-    os.environ["DEBUG"] = "1"
-    os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"
+    set_default_config()
     load_dotenv()
 
     with ProcessManager() as m:

--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -34,6 +34,7 @@ def lint(ctx: click.core.Context, api: bool, web: bool) -> None:
     from cli.manager import ProcessManager
 
     os.environ["DEBUG"] = "1"
+    os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"
 
     with ProcessManager() as m:
         if web or is_all:

--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -33,6 +33,8 @@ def lint(ctx: click.core.Context, api: bool, web: bool) -> None:
     is_all = not api and not web
     from cli.manager import ProcessManager
 
+    os.environ["DEBUG"] = "1"
+
     with ProcessManager() as m:
         if web or is_all:
             m.add_process("tslint", cmds.tslint())

--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import click
+from dotenv import load_dotenv
 
 from cli.config import setup_django_sites, setup_django as configure_django
 from cli.decorators import setup_django, load_env
@@ -35,6 +36,7 @@ def lint(ctx: click.core.Context, api: bool, web: bool) -> None:
 
     os.environ["DEBUG"] = "1"
     os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"
+    load_dotenv()
 
     with ProcessManager() as m:
         if web or is_all:

--- a/backend/cli/config.py
+++ b/backend/cli/config.py
@@ -28,3 +28,14 @@ def setup_django_sites():
         obj.secret = os.environ[f"OAUTH_{provider}_SECRET".upper()]
         obj.sites.add(settings.SITE_ID)
         obj.save()
+
+
+def set_default():
+    """
+    Default configuration to load for testing and linting
+
+    load_dotenv() should be called after this to allow overriding these
+    variables.
+    """
+    os.environ["DEBUG"] = "1"
+    os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"

--- a/backend/cli/config.py
+++ b/backend/cli/config.py
@@ -37,5 +37,7 @@ def set_default():
     load_dotenv() should be called after this to allow overriding these
     variables.
     """
+    import os
+
     os.environ["DEBUG"] = "1"
     os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"

--- a/backend/pytest_plugin/plugin.py
+++ b/backend/pytest_plugin/plugin.py
@@ -1,0 +1,8 @@
+import pytest
+import os
+from dotenv import load_dotenv
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_load_initial_conftests(args, early_config, parser):
+    os.environ['DEBUG'] = "1"
+    load_dotenv()

--- a/backend/pytest_plugin/plugin.py
+++ b/backend/pytest_plugin/plugin.py
@@ -1,10 +1,10 @@
 import pytest
 import os
+from cli import config
 from dotenv import load_dotenv
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(args, early_config, parser):
-    os.environ["DEBUG"] = "1"
-    os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"
+    config.set_default()
     load_dotenv()

--- a/backend/pytest_plugin/plugin.py
+++ b/backend/pytest_plugin/plugin.py
@@ -2,7 +2,8 @@ import pytest
 import os
 from dotenv import load_dotenv
 
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(args, early_config, parser):
-    os.environ['DEBUG'] = "1"
+    os.environ["DEBUG"] = "1"
     load_dotenv()

--- a/backend/pytest_plugin/plugin.py
+++ b/backend/pytest_plugin/plugin.py
@@ -6,4 +6,5 @@ from dotenv import load_dotenv
 @pytest.hookimpl(tryfirst=True)
 def pytest_load_initial_conftests(args, early_config, parser):
     os.environ["DEBUG"] = "1"
+    os.environ["DATABASE_URL"] = "postgres://postgres@127.0.0.1:5432/postgres"
     load_dotenv()

--- a/backend/pytest_plugin/plugin.py
+++ b/backend/pytest_plugin/plugin.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from cli import config
 from dotenv import load_dotenv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["Steve Dignam <steve@dignam.xyz>", "Christopher Dignam <chris@dignam.xyz>"]
 packages = [
     { include = "cli", from = "backend" },
+    { include = "pytest_plugin", from = "backend" },
 ]
 
 [tool.poetry.dependencies]
@@ -51,6 +52,9 @@ pywatchman = "^1.4"
 
 [tool.poetry.scripts]
 yak = 'cli:cli'
+
+[tool.poetry.plugins."pytest11"]
+"pytest_plugin" = "pytest_plugin.plugin"
 
 [tool.black]
 py36 = true


### PR DESCRIPTION
Loading the environment in pytest allows us to use the vscode python test discovery feature. Previously exceptions would be raised because the environment wasn't set correctly for plain calls to pytest.

This change also simplifies circleci and allows us to run our tests without a .env file.