### PR TITLE
Replace Microsoft Python language server with Jedi

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,11 @@
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "typescript.updateImportsOnFileMove.enabled": "always",
 
-    // use Miscrosoft's C#-based language server instead of jedi
     "python.pythonPath": ".venv/bin/python",
     "python.envFile": "${workspaceFolder}/.vscode/.env",
-    "python.jediEnabled": false,
+    // Use jedi instead of Microsoft's C# Python language server (MLS). I think
+    // MLS has introduced too many regressions to be depended on.
+    "python.jediEnabled": true,
     "python.linting.mypyEnabled": true,
     "python.linting.mypyArgs": [
         "--ignore-missing-imports",


### PR DESCRIPTION
The Microsoft language server is too unreliable to be useful. They've
introduced multiple regressions that make it basically useless. It seems
that Jedi works around all the issues I've found with the Microsoft
language server.