### PR TITLE
fix calendar day height

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -74,7 +74,7 @@ function Days({ start, end, days, teamID }: IDaysProps) {
   return (
     <section className="mb-2 h-100">
       {chunk(eachDay(start, end), WEEK_DAYS).map(dates => (
-        <section className="d-flex flex-grow-1 calendar-week">
+        <section className="d-flex calendar-week">
           {dates.map(date => (
             <CalendarDay
               scheduledRecipes={days[toDateString(date)]}

--- a/frontend/src/components/scss/schedule.scss
+++ b/frontend/src/components/scss/schedule.scss
@@ -74,7 +74,7 @@
   width: (1/7) * 100%;
   @media (max-width: $medium) {
     width: 100%;
-    height: (1/7) * 100%;
+    min-height: 75px;
   }
 }
 


### PR DESCRIPTION
previously had a limit that was causing text to overflow out of the
container