### PR TITLE
ref(schedule): replace schedule button with drag handle for recipe item

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -153,9 +153,9 @@ function Nav({
           <ButtonPlain size="small" onClick={prev}>
             {"←"}
           </ButtonPlain>
-          <ButtonPrimary size="small" className="ml-1 mr-1" onClick={current}>
+          <ButtonPlain size="small" className="ml-1 mr-1" onClick={current}>
             Today
-          </ButtonPrimary>
+          </ButtonPlain>
           <ButtonPlain size="small" onClick={next}>
             {"→"}
           </ButtonPlain>
@@ -167,7 +167,7 @@ function Nav({
 
 function HelpPrompt() {
   return (
-    <p className="mt-2 mb-1">
+    <p className="mt-2 mb-1 hide-sm">
       press <kbd>?</kbd> for help
     </p>
   )

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -17,7 +17,7 @@ import { teamsFrom } from "@/store/mapState"
 
 import { push } from "react-router-redux"
 
-import { ButtonPrimary, ButtonPlain } from "@/components/Buttons"
+import { ButtonPlain } from "@/components/Buttons"
 import CalendarDay from "@/components/CalendarDay"
 import { IState } from "@/store/store"
 import { ITeam } from "@/store/reducers/teams"

--- a/frontend/src/components/RecipeItem.tsx
+++ b/frontend/src/components/RecipeItem.tsx
@@ -1,25 +1,27 @@
-import React, { useState } from "react"
+import React from "react"
 import { Link } from "react-router-dom"
 import { DragSource, ConnectDragSource } from "react-dnd"
 import DatePickerForm from "@/components/DatePickerForm"
-import { ButtonPlain } from "@/components/Buttons"
 import { classNames } from "@/classnames"
 import { recipeURL } from "@/urls"
 import { DragDrop } from "@/dragDrop"
 import { IRecipe } from "@/store/reducers/recipes"
 import Dropdown from "@/components/Dropdown"
+import { DragIcon } from "@/components/icons"
 
 interface IRecipeTitleProps {
   readonly url: string
   readonly name: string
+  readonly dragable: boolean
 }
 
-function RecipeTitle({ url, name }: IRecipeTitleProps) {
+function RecipeTitle({ url, name, dragable }: IRecipeTitleProps) {
   return (
-    <div className="flex-grow">
+    <div className="flex-grow d-flex justify-between">
       <Link tabIndex={0} to={url} className="align-self-start mb-1">
         {name}
       </Link>
+      {dragable && <DragIcon />}
     </div>
   )
 }
@@ -40,33 +42,13 @@ export function Schedule({ id, show, onClose, trigger }: IScheduleProps) {
 }
 
 interface IMetaProps {
-  readonly id: IRecipe["id"]
   readonly author: string
-  readonly show: boolean
-  readonly onClose: () => void
-  readonly onToggle: () => void
 }
 
-function Meta({ id, author, show, onClose, onToggle }: IMetaProps) {
+function Meta({ author }: IMetaProps) {
   return (
-    <div
-      className={classNames(
-        "content",
-        "d-flex",
-        "align-items-center",
-        author !== "" ? "justify-space-between" : "justify-content-end"
-      )}>
+    <div className={classNames("content", "d-flex", "align-items-center")}>
       {author !== "" ? <small>{author}</small> : null}
-      <Schedule
-        id={id}
-        show={show}
-        onClose={onClose}
-        trigger={
-          <ButtonPlain size="small" onClick={onToggle}>
-            schedule
-          </ButtonPlain>
-        }
-      />
     </div>
   )
 }
@@ -92,27 +74,19 @@ export function RecipeItem({
   isDragging,
   ...props
 }: IRecipeItemProps & ICollectedProps) {
-  const [show, setShow] = useState(false)
-
-  const drag = !show && props.drag
+  const drag = !!props.drag
 
   const url = props.url || recipeURL(id, name)
 
   const component = (
     <section
       className={classNames("card", {
-        "cursor-move": !!drag
+        "cursor-move": drag
       })}
       style={{ opacity: isDragging ? 0.5 : 1 }}>
       <div className="card-content h-100 d-flex flex-column">
-        <RecipeTitle name={name} url={url} />
-        <Meta
-          id={id}
-          author={author}
-          show={show}
-          onClose={() => setShow(false)}
-          onToggle={() => setShow(prev => !prev)}
-        />
+        <RecipeTitle name={name} url={url} dragable={drag} />
+        <Meta author={author} />
       </div>
     </section>
   )

--- a/frontend/src/components/Schedule.tsx
+++ b/frontend/src/components/Schedule.tsx
@@ -43,7 +43,7 @@ function Sidebar({ teamID, isRecipes }: ISidebarProps) {
   return (
     <>
       <div
-        className="d-grid grid-gap-2 grid-auto-rows-min-content w-300px-if-not-sm hide-sm"
+        className="d-grid grid-gap-2 grid-auto-rows-min-content w-300px flex-shrink-0 hide-sm"
         style={sideBarStyle}>
         <Tabs small className="mb-0 no-print">
           <Tab isActive={!isRecipes}>

--- a/frontend/src/components/ShoppingList.tsx
+++ b/frontend/src/components/ShoppingList.tsx
@@ -35,6 +35,7 @@ import {
   isSuccessOrRefetching,
   isRefetching
 } from "@/webdata"
+import { classNames } from "@/classnames"
 
 const selectElementText = (el: Element) => {
   const sel = window.getSelection()
@@ -63,8 +64,9 @@ interface IShoppingListItemProps {
 function ShoppingListItem({ item, isFirst }: IShoppingListItemProps) {
   // padding serves to prevent the button from appearing in front of text
   // we also use <section>s instead of <p>s to avoid extra new lines in Chrome
+  const cls = classNames("text-small", { "mr-15": isFirst })
   return (
-    <section className={isFirst ? "mr-15" : ""} key={item.unit + item.name}>
+    <section className={cls} key={item.unit + item.name}>
       {item.unit} {item.name}
     </section>
   )
@@ -120,11 +122,11 @@ class ShoppingListList extends React.Component<IShoppingListContainerProps> {
       : []
 
     return (
-      <div className={`box p-rel min-height-75px mb-0 ${loadingClass}`}>
+      <div className={`box p-rel min-height-75px mb-0 p-3 ${loadingClass}`}>
         <Button
           onClick={this.handleSelectList}
           size="small"
-          className="r-5 p-abs">
+          className="r-3 p-abs">
           Copy
         </Button>
         <section ref={this.shoppingList}>

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+
+export function DragIcon() {
+  const size = 18
+  return (
+    <svg
+      className="flex-shrink-0"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#4a4a4a"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <circle cx="8" cy="5" r="1" />
+      <circle cx="8" cy="12" r="1" />
+      <circle cx="8" cy="19" r="1" />
+
+      <circle cx="16" cy="5" r="1" />
+      <circle cx="16" cy="12" r="1" />
+      <circle cx="16" cy="19" r="1" />
+    </svg>
+  )
+}

--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -310,7 +310,7 @@
   }
 }
 
-@each $i in (120px, 200px, 350px, 400px, 50px) {
+@each $i in (120px, 200px, 300px, 350px, 400px, 50px) {
   .w-#{$i},
   .width-#{$i} {
     width: $i;
@@ -321,13 +321,6 @@
 @for $i from 1 through 4 {
   .w-#{$i}rem {
     width: #{$i}rem;
-  }
-}
-
-.w-300px-if-not-sm {
-  @media (min-width: $small) {
-    width: 300px;
-    min-width: 300px;
   }
 }
 


### PR DESCRIPTION
- replace schedule button with drag handle. Schedule button isn't used but dragging isn't obvious.
- reduce padding on shopping list and decrease font size on shopping list
- make today button on schedule default instead of primary