### PR TITLE
fix(tools): loading of env vars

### DIFF
--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -36,8 +36,8 @@ def lint(ctx: click.core.Context, api: bool, web: bool) -> None:
     is_all = not api and not web
     from cli.manager import ProcessManager
 
-    set_default_config()
     load_dotenv()
+    set_default_config()
 
     with ProcessManager() as m:
         if web or is_all:


### PR DESCRIPTION
we were overriding the DATABASE_URL in `.env` by calling load_dotenv()
after set_default_config()