### PR TITLE
fix(css): calendar page scrolling on Chrome 75

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -29,6 +29,8 @@ import {
 import { subWeeks, addWeeks, startOfWeek, endOfWeek } from "date-fns"
 import { Select } from "@/components/Forms"
 import chunk from "lodash/chunk"
+import { classNames } from "@/classnames"
+import { isSafari } from "@/utils/general"
 
 function monthYearFromDate(date: Date) {
   return format(date, "MMM D | YYYY")
@@ -72,7 +74,8 @@ interface IDaysProps {
 
 function Days({ start, end, days, teamID }: IDaysProps) {
   return (
-    <section className="mb-2 h-100">
+    <section
+      className={classNames("mb-2", "flex-grow-1", { "h-100": isSafari() })}>
       {chunk(eachDay(start, end), WEEK_DAYS).map(dates => (
         <section className="d-flex calendar-week">
           {dates.map(date => (

--- a/frontend/src/utils/general.ts
+++ b/frontend/src/utils/general.ts
@@ -6,3 +6,11 @@ export function hasSelection(): boolean {
 export function notUndefined<T>(x: T | undefined): x is T {
   return x != null
 }
+
+/** Check if the current browser is Safari
+ * Note: Chrome on iOS is also considered Safari
+ * from: https://stackoverflow.com/a/40921270/3720597
+ */
+export function isSafari(): boolean {
+  return navigator.vendor === "Apple Computer, Inc."
+}


### PR DESCRIPTION
Chrome 75 now results in the calendar scrolling.
Change h-100 to flex-grow but need to conditionally add h-100 for Safari.