### PR TITLE
ref(api): combine team and personal calendar views

### DIFF
--- a/backend/core/auth/permissions.py
+++ b/backend/core/auth/permissions.py
@@ -22,6 +22,8 @@ class DisallowAny:
 class IsTeamMember(permissions.BasePermission):
     def has_permission(self, request, view) -> bool:
         team_pk = view.kwargs["team_pk"]
+        if team_pk == "me":
+            return True
         team: Team = get_object_or_404(Team, pk=team_pk)
         return team.is_member(request.user)
 

--- a/backend/core/schedule/test_calendar.py
+++ b/backend/core/schedule/test_calendar.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_creating_scheduled_recipe(client, recipe, user):
-    url = reverse("calendar-list")
+    url = reverse("calendar-list", kwargs=dict(team_pk="me"))
     data = {"recipe": recipe.id, "on": date(1976, 7, 6), "count": 1}
     client.force_authenticate(user)
     res = client.post(url, data)
@@ -34,7 +34,7 @@ def test_recipe_returns_last_scheduled_date(client, scheduled_recipe, recipe2):
 
 
 def test_updating_scheduled_recipe(client, user, scheduled_recipe):
-    url = reverse("calendar-detail", kwargs={"pk": scheduled_recipe.id})
+    url = reverse("calendar-detail", kwargs=dict(pk=scheduled_recipe.id, team_pk="me"))
     assert scheduled_recipe.count == 1
     data = {"count": 2}
     client.force_authenticate(user)
@@ -44,7 +44,7 @@ def test_updating_scheduled_recipe(client, user, scheduled_recipe):
 
 
 def test_deleting_scheduled_recipe(client, user, scheduled_recipe):
-    url = reverse("calendar-detail", kwargs={"pk": scheduled_recipe.id})
+    url = reverse("calendar-detail", kwargs=dict(pk=scheduled_recipe.id, team_pk="me"))
     client.force_authenticate(user)
     res = client.delete(url)
     assert res.status_code == status.HTTP_204_NO_CONTENT
@@ -52,7 +52,7 @@ def test_deleting_scheduled_recipe(client, user, scheduled_recipe):
 
 
 def test_fetching_scheduled_recipes(client, user, scheduled_recipe):
-    url = reverse("calendar-list")
+    url = reverse("calendar-list", kwargs=dict(team_pk="me"))
     client.force_authenticate(user)
     res = client.get(url)
     assert (
@@ -88,7 +88,7 @@ def test_scheduling_the_same_recipe_twice_on_a_day(recipe, user):
 
 def test_dupe_scheduling_with_http(client, recipe, user):
     client.force_authenticate(user)
-    url = reverse("calendar-list")
+    url = reverse("calendar-list", kwargs=dict(team_pk="me"))
     data = {"recipe": recipe.id, "on": date(1976, 7, 6), "count": 1}
     client.force_authenticate(user)
     assert client.post(url, data).status_code == status.HTTP_201_CREATED

--- a/backend/core/schedule/test_team_calendar.py
+++ b/backend/core/schedule/test_team_calendar.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_adding_to_team_calendar(client, user, team, recipe):
-    url = reverse("team-calendar-list", kwargs={"team_pk": team.pk})
+    url = reverse("calendar-list", kwargs={"team_pk": team.pk})
     data = {"recipe": recipe.id, "on": date(1976, 7, 6), "count": 1}
     assert team.is_member(user)
     client.force_authenticate(user)
@@ -26,9 +26,7 @@ def test_adding_to_team_calendar(client, user, team, recipe):
 
 def test_removing_from_team_calendar(client, user, team, recipe):
     scheduled = recipe.schedule(on=date(1976, 1, 2), team=team)
-    url = reverse(
-        "team-calendar-detail", kwargs={"team_pk": team.pk, "pk": scheduled.id}
-    )
+    url = reverse("calendar-detail", kwargs={"team_pk": team.pk, "pk": scheduled.id})
     client.force_authenticate(user)
     res = client.delete(url)
     assert res.status_code == status.HTTP_204_NO_CONTENT
@@ -38,9 +36,7 @@ def test_removing_from_team_calendar(client, user, team, recipe):
 def test_updating_team_schedule_recipe(client, user, team, recipe):
     scheduled = recipe.schedule(on=date(1976, 1, 2), team=team)
     assert scheduled.count == 1
-    url = reverse(
-        "team-calendar-detail", kwargs={"team_pk": team.pk, "pk": scheduled.id}
-    )
+    url = reverse("calendar-detail", kwargs={"team_pk": team.pk, "pk": scheduled.id})
     data = {"count": 2}
     client.force_authenticate(user)
     res = client.patch(url, data)
@@ -49,7 +45,7 @@ def test_updating_team_schedule_recipe(client, user, team, recipe):
 
 
 def test_fetching_team_calendar(client, user, team, recipe):
-    url = reverse("team-calendar-list", kwargs={"team_pk": team.pk})
+    url = reverse("calendar-list", kwargs={"team_pk": team.pk})
 
     client.force_authenticate(user)
     res = client.get(url)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -17,7 +17,6 @@ from core.schedule.views import (
     CalendarViewSet,
     ReportBadMerge,
     ShoppingListView,
-    TeamCalendarViewSet,
     TeamShoppingListViewSet,
 )
 from core.stats.views import UserStats
@@ -32,7 +31,6 @@ router = DefaultRouter()
 router.register(r"recipes", RecipeViewSet, basename="recipes")
 router.register(r"t", TeamViewSet, basename="teams")
 router.register(r"invites", UserInvitesViewSet, basename="user-invites")
-router.register(r"calendar", CalendarViewSet, basename="calendar")
 
 recipes_router = routers.NestedSimpleRouter(router, r"recipes", lookup="recipe")
 recipes_router.register(r"steps", StepViewSet, basename="recipe-step")
@@ -45,7 +43,7 @@ teams_router.register(r"recipes", TeamRecipesViewSet, basename="team-recipes")
 teams_router.register(
     r"shoppinglist", TeamShoppingListViewSet, basename="team-shoppinglist"
 )
-teams_router.register(r"calendar", TeamCalendarViewSet, basename="team-calendar")
+teams_router.register(r"calendar", CalendarViewSet, basename="calendar")
 
 urlpatterns = [
     url(r"^api/v1/auth/", include("core.auth.urls")),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -250,15 +250,10 @@ export const declineInvite = (id: IInvite["id"]) =>
 export const reportBadMerge = () => http.post("/api/v1/report-bad-merge", {})
 
 export const getCalendarRecipeList = (teamID: TeamID, currentDay: Date) => {
-  const url =
-    teamID === "personal"
-      ? "/api/v1/calendar/"
-      : `/api/v1/t/${teamID}/calendar/`
-
   const start = toDateString(startOfWeek(subWeeks(currentDay, 1)))
   const end = toDateString(endOfWeek(addWeeks(currentDay, 1)))
-
-  return http.get<ICalRecipe[]>(url, {
+  const id = teamID === "personal" ? "me" : teamID
+  return http.get<ICalRecipe[]>(`/api/v1/t/${id}/calendar/`, {
     params: {
       start,
       end
@@ -272,11 +267,8 @@ export const scheduleRecipe = (
   on: Date,
   count: string | number
 ) => {
-  const url =
-    teamID === "personal"
-      ? "/api/v1/calendar/"
-      : `/api/v1/t/${teamID}/calendar/`
-  return http.post<ICalRecipe>(url, {
+  const id = teamID === "personal" ? "me" : teamID
+  return http.post<ICalRecipe>(`/api/v1/t/${id}/calendar/`, {
     recipe: recipeID,
     on: toDateString(on),
     count
@@ -284,25 +276,20 @@ export const scheduleRecipe = (
 }
 
 // TODO(sbdchd): we shouldn't need teamID here
-export const deleteScheduledRecipe = (id: ICalRecipe["id"], teamID: TeamID) => {
-  const url =
-    teamID === "personal"
-      ? `/api/v1/calendar/${id}/`
-      : `/api/v1/t/${teamID}/calendar/${id}/`
-
-  return http.delete(url)
+export const deleteScheduledRecipe = (
+  calId: ICalRecipe["id"],
+  teamID: TeamID
+) => {
+  const id = teamID === "personal" ? "me" : teamID
+  return http.delete(`/api/v1/t/${id}/calendar/${calId}/`)
 }
 
 // TODO(sbdchd): we shouldn't need teamID here
 export const updateScheduleRecipe = (
-  id: ICalRecipe["id"],
+  calId: ICalRecipe["id"],
   teamID: TeamID,
   recipe: Partial<ICalRecipe>
 ) => {
-  const url =
-    teamID === "personal"
-      ? `/api/v1/calendar/${id}/`
-      : `/api/v1/t/${teamID}/calendar/${id}/`
-
-  return http.patch<ICalRecipe>(url, recipe)
+  const id = teamID === "personal" ? "me" : teamID
+  return http.patch<ICalRecipe>(`/api/v1/t/${id}/calendar/${calId}/`, recipe)
 }

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 DJANGO_SETTINGS_MODULE = backend.settings
 python_files = tests.py test_*.py *_tests.py
 norecursedir = venv env .pytest_cache .mypy_cache .cache backup .venv
-addopts = -s --pdbcls IPython.terminal.debugger:TerminalPdb --reuse-db
+addopts = -s --pdbcls IPython.terminal.debugger:TerminalPdb --reuse-db -p no:warnings
 ; prevent tests from hanging for too long
 timeout = 30
 filterwarnings =


### PR DESCRIPTION
Now we just have `/t/:teamId/calendar` instead of an additional /calendar
endpoint.

A user's personal calendar can be queried with "me" as the teamId.