### PR TITLE
fix(calendar): moving cal recipe on same day

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -274,7 +274,9 @@ const mapStateToProps = (
 ) => {
   const isTeam = teamID !== "personal"
 
-  const days = isTeam ? getTeamRecipes(state) : getPersonalRecipes(state)
+  const days = isTeam
+    ? getTeamRecipes(state.calendar)
+    : getPersonalRecipes(state.calendar)
 
   const transformedDays: IDays = days.reduce(
     (a, b) => {

--- a/frontend/src/store/reducers/calendar.test.ts
+++ b/frontend/src/store/reducers/calendar.test.ts
@@ -546,9 +546,8 @@ describe("calendar selectors", () => {
     // get undefined.
     expect(
       a.getExistingRecipe({
-        state: emptyState,
+        state: emptyState.calendar,
         on: toDate,
-        teamID,
         from
       })
     ).toEqual(undefined)
@@ -576,15 +575,18 @@ describe("calendar selectors", () => {
     )
 
     expect(
-      a.getExistingRecipe({ state: nextState, on: toDate, teamID, from })
+      a.getExistingRecipe({
+        state: nextState.calendar,
+        on: toDate,
+        from
+      })
     ).not.toBeUndefined()
 
     // moving recipe from its location and back to its location in one
     // drag-and-drop go.
     const calRecipe = a.getExistingRecipe({
-      state: nextState,
+      state: nextState.calendar,
       on: toDate,
-      teamID,
       from: calRecipeOnSameDay
     })
     expect(calRecipe).toBeUndefined()

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -1110,9 +1110,13 @@ export const moveScheduledRecipeAsync = (dispatch: Dispatch) => async (
       from.count
     )
   }
-  const existing = getAllCalRecipes(state)
-    .filter(x => isSameDay(x.on, to) && isSameTeam(x, teamID))
-    .find(x => x.recipe.id === from.recipe.id)
+  const existing = getAllCalRecipes(state).find(
+    x =>
+      isSameDay(x.on, to) &&
+      isSameTeam(x, teamID) &&
+      x.id !== from.id &&
+      x.recipe.id === from.recipe.id
+  )
 
   // Note(sbdchd): we need move to be after the checking of the store so we
   // don't delete the `from` recipe and update the `existing`

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -1,12 +1,11 @@
 import pickBy from "lodash/pickBy"
-import isSameDay from "date-fns/is_same_day"
 import { random32Id } from "@/uuid"
 import { toDateString, second } from "@/date"
 import { push, replace } from "react-router-redux"
 import { Dispatch as ReduxDispatch } from "redux"
 import { AxiosError, AxiosResponse } from "axios"
 import raven from "raven-js"
-import { store, Action, IState } from "@/store/store"
+import { store, Action } from "@/store/store"
 import {
   SocialProvider,
   updateEmail,
@@ -1084,7 +1083,7 @@ export const moveScheduledRecipeAsync = (dispatch: Dispatch) => async (
 ) => {
   // HACK(sbdchd): With an endpoint we can eliminate this
   const state = store.getState()
-  const from = getCalRecipeById(state, id)
+  const from = getCalRecipeById(state.calendar, id)
 
   if (from == null) {
     return
@@ -1103,7 +1102,7 @@ export const moveScheduledRecipeAsync = (dispatch: Dispatch) => async (
       from.count
     )
   }
-  const existing = getExistingRecipe({ state, on: to, teamID, from })
+  const existing = getExistingRecipe({ state: state.calendar, on: to, from })
 
   // Note(sbdchd): we need move to be after the checking of the store so we
   // don't delete the `from` recipe and update the `existing`

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -6,7 +6,7 @@ import { push, replace } from "react-router-redux"
 import { Dispatch as ReduxDispatch } from "redux"
 import { AxiosError, AxiosResponse } from "axios"
 import raven from "raven-js"
-import { store, Action } from "@/store/store"
+import { store, Action, IState } from "@/store/store"
 import {
   SocialProvider,
   updateEmail,
@@ -30,8 +30,8 @@ import {
   deleteCalendarRecipe,
   moveCalendarRecipe,
   fetchCalendarRecipes,
-  getAllCalRecipes,
-  getCalRecipeById
+  getCalRecipeById,
+  getExistingRecipe
 } from "@/store/reducers/calendar"
 import {
   IInvite,
@@ -1077,13 +1077,6 @@ export const deletingScheduledRecipeAsync = (dispatch: Dispatch) => async (
   return Ok(undefined)
 }
 
-function isSameTeam(x: ICalRecipe, teamID: TeamID): boolean {
-  if (teamID === "personal") {
-    return x.user != null
-  }
-  return x.team === teamID
-}
-
 export const moveScheduledRecipeAsync = (dispatch: Dispatch) => async (
   id: ICalRecipe["id"],
   teamID: TeamID,
@@ -1110,13 +1103,7 @@ export const moveScheduledRecipeAsync = (dispatch: Dispatch) => async (
       from.count
     )
   }
-  const existing = getAllCalRecipes(state).find(
-    x =>
-      isSameDay(x.on, to) &&
-      isSameTeam(x, teamID) &&
-      x.id !== from.id &&
-      x.recipe.id === from.recipe.id
-  )
+  const existing = getExistingRecipe({ state, on: to, teamID, from })
 
   // Note(sbdchd): we need move to be after the checking of the store so we
   // don't delete the `from` recipe and update the `existing`

--- a/package.json
+++ b/package.json
@@ -144,6 +144,11 @@
       "^.+\\.css$": "<rootDir>/frontend/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|ts|tsx|css|json)$)": "<rootDir>/frontend/config/jest/fileTransform.js"
     },
+    "globals": {
+      "ts-jest": {
+        "diagnostics": false
+      }
+    },
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$"
     ],


### PR DESCRIPTION
- Previously, when moving a calendar recipe away from its current day and
then back to its current day, the recipe would be deleted.
- fix issue when scheduling a recipe when one is already scheduled for a different team
- disable ts-jest diagnostics which break tests on typescript failures like unused imports