### PR TITLE
fix: pgdump container not building in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
       # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
       - run:
           name: build container
+          working_directory: pgdump
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f pgdump/pgdump.Dockerfile \


### PR DESCRIPTION
We didn't set the working_directory for the container build so COPY
wasn't working.