### PR TITLE
fix: building pgdump container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
           working_directory: pgdump
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f pgdump/pgdump.Dockerfile \
+            docker build -f pgdump.Dockerfile \
               --tag recipeyak/pgdump:$CIRCLE_SHA1 \
               --build-arg GIT_SHA=$CIRCLE_SHA1 .
             docker push recipeyak/pgdump:$CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
       # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
       - run:
           name: build container
+          working_directory: pgdump
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f pgdump/pgdump.Dockerfile \


### PR DESCRIPTION
We had the working_directory appended in the build script when we are
already in it.