### PR TITLE
fix: building of react & django containers in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,10 +150,9 @@ jobs:
       # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
       - run:
           name: build container
-          working_directory: backend
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f django.Dockerfile \
+            docker build -f backend/django.Dockerfile \
               --tag recipeyak/django:$CIRCLE_SHA1 \
               --build-arg GIT_SHA=$CIRCLE_SHA1 .
             docker push recipeyak/django:$CIRCLE_SHA1
@@ -168,10 +167,9 @@ jobs:
       # https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
       - run:
           name: build container
-          working_directory: frontend
           command: |
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-            docker build -f react.Dockerfile \
+            docker build -f frontend/react.Dockerfile \
               --tag recipeyak/react:$CIRCLE_SHA1 \
               --build-arg OAUTH_BITBUCKET_CLIENT_ID=${OAUTH_BITBUCKET_CLIENT_ID-""} \
               --build-arg OAUTH_FACEBOOK_CLIENT_ID=${OAUTH_FACEBOOK_CLIENT_ID-""} \

--- a/backend/django.Dockerfile
+++ b/backend/django.Dockerfile
@@ -15,6 +15,4 @@ ARG GIT_SHA
 RUN poetry run yak build --api
 HEALTHCHECK CMD curl --fail http://localhost:8000/healthz
 
-COPY ./bootstrap.sh /var/
-
-CMD ["/var/bootstrap.sh"]
+CMD ["/var/app/backend/bootstrap.sh"]

--- a/frontend/react.Dockerfile
+++ b/frontend/react.Dockerfile
@@ -26,6 +26,4 @@ COPY --from=builder /var/app/frontend/build /var/app/build
 COPY --from=builder /var/app/frontend/bootstrap.sh /var/app/
 WORKDIR /var/app
 
-COPY ./bootstrap.sh /var/
-
-CMD ["/var/bootstrap.sh"]
+CMD ["/var/app/frontend/bootstrap.sh"]


### PR DESCRIPTION
we need to have the context be at the top level where we store the
pyproject.toml and yarn files.