### PR TITLE
fix: pgdump install

### DIFF
--- a/pgdump/pgdump.Dockerfile
+++ b/pgdump/pgdump.Dockerfile
@@ -1,10 +1,22 @@
 FROM debian:stretch-slim
 
+ENV PG_MAJOR 10
+
+# For more info on install PG
+# see: https://www.postgresql.org/download/linux/debian/
+RUN apt-get update && \
+      apt-get install -y \
+      curl \
+      gnupg && \
+      echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main $PG_MAJOR" > /etc/apt/sources.list.d/pgdg.list && \
+      curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+      apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
       mkdir -p /usr/share/man/man7 && \
       apt-get update && \
       apt-get install -y \
-      postgresql-client \
+      postgresql-client-10 \
       cron \
       python3-pip && \
       rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Previously we were just running apt-get install postgresql-client-10
instead of specifying. This downloaded the correct version locally but
failed to download the correct pgdump version on a different machine.

Now we specify the version according to the pg docs.