### PR TITLE
remove: unused cli commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ jobs:
           key: frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
-          working_directory: frontend
           command: poetry run yak test --web
 
   frontend_lint:

--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -1,10 +1,8 @@
 import io
 import os
 import subprocess
-import sys
 from datetime import datetime
-from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List
 
 import click
 from dotenv import load_dotenv
@@ -15,7 +13,7 @@ from cli.config import set_default_testing_variables as set_default_config
 from cli.config import setup_django as configure_django
 from cli.config import setup_django_sites
 from cli.decorators import load_env, setup_django
-from cli.docker_machine import docker_machine_env, docker_machine_unset_env
+from cli.docker_machine import docker_machine_env
 
 
 @click.group()
@@ -70,10 +68,10 @@ def typecheck(api: bool, web: bool, watch: bool) -> None:
         raise click.ClickException("No services were selected.")
 
     if web:
-        subprocess.run(cmds.typescript(watch=watch).split())
+        subprocess.run(cmds.typescript(watch=watch).split(), check=True)
         return
     if api:
-        subprocess.run(cmds.mypy().split())
+        subprocess.run(cmds.mypy().split(), check=True)
 
 
 @cli.command(help="format code")
@@ -120,10 +118,10 @@ def test(api: bool, web: bool, watch: bool, test_args: List[str]) -> None:
             m.add_process("web", jest)
 
     if web:
-        subprocess.run(jest)
+        subprocess.run(jest, check=True)
 
     if api:
-        subprocess.run(pytest, cwd="backend")
+        subprocess.run(pytest, cwd="backend", check=True)
 
 
 @cli.command(help="start dev services")
@@ -143,10 +141,6 @@ def dev(ctx: click.core.Context, api: bool, web: bool, migrate: bool) -> None:
     run_web = web or is_all
     services = []
     if run_django:
-        # start postgres
-        if sys.platform == "darwin" and Path("/Applications/Postgres.app").exists():
-            subprocess.run(["open", "/Applications/Postgres.app"])
-
         from django.core.management import call_command
 
         if migrate:
@@ -324,7 +318,8 @@ def maintenance_mode(machine_name: str, action: Literal["on", "off"]) -> None:
                 "nginx",
                 "touch",
                 "maintenance_on",
-            ]
+            ],
+            check=True,
         )
         click.echo("Maintenance mode: ON")
     if action == "off":
@@ -339,7 +334,8 @@ def maintenance_mode(machine_name: str, action: Literal["on", "off"]) -> None:
                 "rm",
                 "-f",
                 "maintenance_on",
-            ]
+            ],
+            check=True,
         )
         click.echo("Maintenance mode: OFF")
 
@@ -412,99 +408,4 @@ def connect(machine_name: str) -> None:
     connect via ssh to docker `machine_name`
     """
     docker_machine_env(machine_name)
-    subprocess.run(["docker-machine", "ssh", machine_name])
-
-
-@cli.command()
-@click.option("--ignore-staged", is_flag=True)
-@click.option("--web", is_flag=True)
-@click.option("--api", is_flag=True)
-@click.option("--nginx", is_flag=True)
-@load_env
-def docker_build(ignore_staged: bool, web: bool, api: bool, nginx: bool) -> None:
-    """
-    build prod containers
-    """
-    docker_machine_unset_env()
-
-    git_changes = subprocess.check_output(["git", "status", "-s"])
-    if git_changes and not ignore_staged:
-        click.echo("Please stash your changes before building.")
-        exit(1)
-
-    project_root = Path(__file__).parent.parent.parent
-
-    git_rev = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode()
-
-    is_all = not any([web, api, nginx])
-
-    def build_container(
-        path: Path, name: str, build_args: Optional[List[Tuple[str, str]]] = None
-    ) -> None:
-        build_args = build_args or []
-
-        args: List[str] = []
-        for arg_name, arg_value in build_args:
-            args += ["--build-arg", f"{arg_name}={arg_value}"]
-
-        subprocess.run(
-            [
-                "docker",
-                "build",
-                "-f",
-                path / "Dockerfile-prod",
-                path,
-                "--tag",
-                f"recipeyak/{name}:{git_rev}",
-                *args,
-            ]
-        )
-
-    if web or is_all:
-        OAUTH_VARS = [
-            "OAUTH_BITBUCKET_CLIENT_ID",
-            "OAUTH_FACEBOOK_CLIENT_ID",
-            "OAUTH_GITHUB_CLIENT_ID",
-            "OAUTH_GITLAB_CLIENT_ID",
-            "OAUTH_GOOGLE_CLIENT_ID",
-        ]
-
-        oauth_args = [(arg, os.getenv(arg, "")) for arg in OAUTH_VARS]
-
-        args = [
-            *oauth_args,
-            ("GIT_SHA", git_rev),
-            ("FRONTEND_SENTRY_DSN", os.environ["FRONTEND_SENTRY_DSN"]),
-        ]
-
-        build_container(name="react", path=project_root / "frontend", build_args=args)
-
-    if nginx or is_all:
-        build_container(name="nginx", path=project_root / "nginx")
-
-    if api or is_all:
-        build_container(
-            name="django",
-            path=project_root / "backend",
-            build_args=[("GIT_SHA", git_rev)],
-        )
-
-
-@cli.command()
-def docker_upload() -> None:
-    """
-    upload prod images to container registry
-    """
-    docker_machine_unset_env()
-
-    images = []
-    for rows in subprocess.check_output(["docker", "images"]).decode().split("\n"):
-        row = rows.split()
-        if row and "recipeyak" in row[0]:
-            images.append(row[0] + ":" + row[1])
-
-    from cli.manager import ProcessManager
-
-    with ProcessManager() as m:
-        for img in images:
-            m.add_process(img, "docker push " + img)
+    subprocess.run(["docker-machine", "ssh", machine_name], check=True)


### PR DESCRIPTION
We don't build or upload the container images via the CLI anymore
and the commands no longer work.

Let's just remove them.