### PR TITLE
update: theme's white color to be less gray

### DIFF
--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -104,7 +104,7 @@ def test(api: bool, web: bool, watch: bool, test_args: List[str]) -> None:
 
     os.environ["TESTING"] = "1"
 
-    jest = ["node", "frontend/scripts/test.js", "--env=jsdom"]
+    jest = ["node", "frontend/scripts/test.js", "--env=jsdom", *test_args]
     if os.getenv("CI"):
         jest += ["--coverage", "--runInBand"]
     if watch:

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -41,15 +41,15 @@ interface IRecipeLink {
 
 const StyledLink = styled(Link)`
   line-height: 1.3;
-  font-size: ${props => props.theme.textSmall};
+  font-size: ${props => props.theme.text.small};
   word-break: break-word;
-  background-color: ${props => props.theme.primaryColor};
+  background-color: ${props => props.theme.color.primary};
   border-radius: 5px;
   padding: 0.35rem;
-  color: whitesmoke;
+  color: ${props => props.theme.color.white};
   font-weight: 600;
   :hover {
-    color: whitesmoke;
+    color: ${props => props.theme.color.white};
   }
 `
 

--- a/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
@@ -8,12 +8,12 @@ exports[`<CalendarDayItem> Snap smoke test render with styled components 1`] = `
   background-color: #ff7247;
   border-radius: 5px;
   padding: 0.35rem;
-  color: whitesmoke;
+  color: #f9f9f9;
   font-weight: 600;
 }
 
 .c0:hover {
-  color: whitesmoke;
+  color: #f9f9f9;
 }
 
 <li

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,13 +1,23 @@
 import * as styledComponents from "styled-components"
 
 export interface ITheme {
-  readonly primaryColor: string
-  readonly textSmall: string
+  readonly color: {
+    readonly white: string
+    readonly primary: string
+  }
+  readonly text: {
+    readonly small: string
+  }
 }
 
 export const theme: ITheme = {
-  primaryColor: "#ff7247",
-  textSmall: "0.875rem"
+  color: {
+    white: "#f9f9f9",
+    primary: "#ff7247"
+  },
+  text: {
+    small: "0.875rem"
+  }
 }
 
 const {


### PR DESCRIPTION
The previous white was difficult to see against the primary orange
with f.lux running.