### PR TITLE
fix: off-by-one error in optimistic scheduling

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,7 +7,7 @@ import {
   ISession
 } from "@/store/reducers/user"
 import { ITeam, IMember } from "@/store/reducers/teams"
-import { toDateString } from "@/date"
+import { toISODateString } from "@/date"
 import { IRecipeBasic } from "@/components/RecipeTitle"
 import { IRecipe, IIngredient, IStep } from "@/store/reducers/recipes"
 import { IInvite } from "@/store/reducers/invites"
@@ -134,8 +134,8 @@ export const getShoppingList = (teamID: TeamID, start: Date, end: Date) => {
   const id = teamID === "personal" ? "me" : teamID
   return http.get<IGetShoppingListResponse>(`/api/v1/t/${id}/shoppinglist/`, {
     params: {
-      start: toDateString(start),
-      end: toDateString(end)
+      start: toISODateString(start),
+      end: toISODateString(end)
     }
   })
 }
@@ -291,8 +291,8 @@ export const declineInvite = (id: IInvite["id"]) =>
 export const reportBadMerge = () => http.post("/api/v1/report-bad-merge", {})
 
 export const getCalendarRecipeList = (teamID: TeamID, currentDay: Date) => {
-  const start = toDateString(startOfWeek(subWeeks(currentDay, 1)))
-  const end = toDateString(endOfWeek(addWeeks(currentDay, 1)))
+  const start = toISODateString(startOfWeek(subWeeks(currentDay, 1)))
+  const end = toISODateString(endOfWeek(addWeeks(currentDay, 1)))
   const id = teamID === "personal" ? "me" : teamID
   return http.get<ICalRecipe[]>(`/api/v1/t/${id}/calendar/`, {
     params: {
@@ -311,7 +311,7 @@ export const scheduleRecipe = (
   const id = teamID === "personal" ? "me" : teamID
   return http.post<ICalRecipe>(`/api/v1/t/${id}/calendar/`, {
     recipe: recipeID,
-    on: toDateString(on),
+    on: toISODateString(on),
     count
   })
 }

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -12,7 +12,7 @@ import {
   fetchingShoppingListAsync
 } from "@/store/thunks"
 
-import { toDateString } from "@/date"
+import { toISODateString } from "@/date"
 
 import { teamsFrom } from "@/store/mapState"
 
@@ -121,7 +121,7 @@ function Days({ start, end, days, teamID }: IDaysProps) {
         return (
           <CalendarWeekContainer key={week}>
             {dates.map(date => {
-              const scheduledRecipes = days[toDateString(date)] || []
+              const scheduledRecipes = days[toISODateString(date)] || []
               return (
                 <CalendarDay
                   scheduledRecipes={scheduledRecipes}

--- a/frontend/src/date.test.ts
+++ b/frontend/src/date.test.ts
@@ -5,8 +5,9 @@ test("toISODateString", () => {
   // Regression test for previous toString util function that didn't handle
   // timezones correctly so each call would shift the time back a day
 
-  // We want to be using a local date like the browser, since `new
-  // Date("2011-11-09")` is different in the browser depending on the timezone.
+  // We want to be using a local date like the browser, since
+  // `new Date("2011-11-09")` is different in the browser depending on the
+  // timezone.
   mockTimezone("US/Pacific", () => {
     expect(new Date().getTimezoneOffset()).not.toBe(0)
     expect(toISODateString(new Date())).toEqual(

--- a/frontend/src/date.test.ts
+++ b/frontend/src/date.test.ts
@@ -1,0 +1,9 @@
+import { toISODateString } from "@/date"
+
+test("toISODateString", () => {
+  // Regression test for previous toString util function that didn't handle
+  // timezones correctly so each call would shift the time back a day
+  expect(toISODateString(new Date())).toEqual(
+    toISODateString(toISODateString(toISODateString(new Date())))
+  )
+})

--- a/frontend/src/date.test.ts
+++ b/frontend/src/date.test.ts
@@ -1,9 +1,21 @@
 import { toISODateString } from "@/date"
+import { mockTimezone } from "@/testUtils"
 
 test("toISODateString", () => {
   // Regression test for previous toString util function that didn't handle
   // timezones correctly so each call would shift the time back a day
-  expect(toISODateString(new Date())).toEqual(
-    toISODateString(toISODateString(toISODateString(new Date())))
-  )
+
+  // We want to be using a local date like the browser, since `new
+  // Date("2011-11-09")` is different in the browser depending on the timezone.
+  mockTimezone("US/Pacific", () => {
+    expect(new Date().getTimezoneOffset()).not.toBe(0)
+    expect(toISODateString(new Date())).toEqual(
+      toISODateString(toISODateString(toISODateString(new Date())))
+    )
+  })
+  expect(new Date().getTimezoneOffset()).toBe(0)
+})
+
+test("timezone set to UTC", () => {
+  expect(new Date().getTimezoneOffset()).toBe(0)
 })

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -4,9 +4,12 @@ import lastDayOfMonth from "date-fns/lastDayOfMonth"
 import eachDayOfInterval from "date-fns/eachDayOfInterval"
 import isBefore from "date-fns/isBefore"
 import startOfDay from "date-fns/startOfDay"
+import parseISO from "date-fns/parseISO"
 
 export function toISODateString(date: Date | string): string {
-  return format(new Date(date), "yyyy-MM-dd")
+  // Note(sbdchd): parseISO("2019-11-09") !== new Date("2019-11-09")
+  const dateObj = typeof date === "string" ? parseISO(date) : date
+  return format(dateObj, "yyyy-MM-dd")
 }
 
 export function daysOfMonth(date: Date) {

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -5,7 +5,7 @@ import eachDayOfInterval from "date-fns/eachDayOfInterval"
 import isBefore from "date-fns/isBefore"
 import startOfDay from "date-fns/startOfDay"
 
-export function toDateString(date: Date | string) {
+export function toISODateString(date: Date | string): string {
   return format(new Date(date), "yyyy-MM-dd")
 }
 

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -1,6 +1,6 @@
 import pickBy from "lodash/pickBy"
 import { random32Id } from "@/uuid"
-import { toDateString, second } from "@/date"
+import { toISODateString, second } from "@/date"
 import { push, replace } from "connected-react-router"
 // eslint-disable-next-line no-restricted-imports
 import { Dispatch as ReduxDispatch } from "redux"
@@ -1010,7 +1010,7 @@ function toCalRecipe(
       id: recipe.id,
       name: recipe.name
     },
-    on: toDateString(on),
+    on: toISODateString(on),
     count,
     user: recipe.owner.type === "user" ? recipe.owner.id : null,
     team: recipe.owner.type === "team" ? recipe.owner.id : null
@@ -1045,7 +1045,7 @@ export const addingScheduledRecipeAsync = async (
   //    if failed, then we remove the preemptively added one, and display an error
 
   dispatch(
-    setCalendarRecipe(toCalRecipe(recipe.data, tempId, toDateString(on), count))
+    setCalendarRecipe(toCalRecipe(recipe.data, tempId, toISODateString(on), count))
   )
   const res = await api.scheduleRecipe(recipeID, teamID, on, count)
 
@@ -1127,7 +1127,7 @@ export const moveScheduledRecipe = async (
 
   // Note(sbdchd): we need move to be after the checking of the store so we
   // don't delete the `from` recipe and update the `existing`
-  dispatch(moveCalendarRecipe({ id, to: toDateString(to) }))
+  dispatch(moveCalendarRecipe({ id, to: toISODateString(to) }))
 
   if (existing) {
     // HACK(sbdchd): this should be an endpoint so we can have this be in a transaction
@@ -1137,16 +1137,16 @@ export const moveScheduledRecipe = async (
         count: existing.count + from.count
       })
     } else {
-      dispatch(moveCalendarRecipe({ id, to: toDateString(from.on) }))
+      dispatch(moveCalendarRecipe({ id, to: toISODateString(from.on) }))
     }
   }
 
   const res = await api.updateScheduleRecipe(id, teamID, {
-    on: toDateString(to)
+    on: toISODateString(to)
   })
   if (isErr(res)) {
     // on error we want to move it back to the old position
-    dispatch(moveCalendarRecipe({ id, to: toDateString(from.on) }))
+    dispatch(moveCalendarRecipe({ id, to: toISODateString(from.on) }))
   }
 }
 

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -1045,7 +1045,9 @@ export const addingScheduledRecipeAsync = async (
   //    if failed, then we remove the preemptively added one, and display an error
 
   dispatch(
-    setCalendarRecipe(toCalRecipe(recipe.data, tempId, toISODateString(on), count))
+    setCalendarRecipe(
+      toCalRecipe(recipe.data, tempId, toISODateString(on), count)
+    )
   )
   const res = await api.scheduleRecipe(recipeID, teamID, on, count)
 

--- a/frontend/src/testUtils.tsx
+++ b/frontend/src/testUtils.tsx
@@ -9,11 +9,18 @@ import { getCmd } from "redux-loop"
 import { ThemeProvider, theme } from "@/theme"
 import { baseHttp } from "@/http"
 import MockAdapter from "axios-mock-adapter"
+import timezoneMock, { TimeZone } from "timezone-mock"
 
 export const mockDate = MockDate
 
 export function createHttpMocker() {
   return new MockAdapter(baseHttp)
+}
+
+export function mockTimezone(timezone: TimeZone, cb: () => void) {
+  timezoneMock.register(timezone)
+  cb()
+  timezoneMock.unregister()
 }
 
 export function assertCmdFuncEq<T, F>(state: T, expected: F) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-test-renderer": "16.8.0",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",
+    "timezone-mock": "^1.0.8",
     "ts-jest": "^23.10.5",
     "ts-loader": "^5.3.3",
     "tslint": "^5.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11549,6 +11549,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+timezone-mock@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.0.8.tgz#1b9f7af13f2bf84b7aa3d3d6e24aa17255b6037d"
+  integrity sha512-7dgx34HJPY8O/c5dbqG+I9S3TVDjrfssXmS8BNqiy8sdYvYDfM7shHpNA6VTDQWcDGyv43bE3El6YuFDQf1X3g==
+
 timm@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/timm/-/timm-1.6.1.tgz#5f8aafc932248c76caf2c6af60542a32d3c30701"


### PR DESCRIPTION
Our previous implementation of `toISODateString` was bugged in that calling it on its output would result in the date shifting back a day. This only occurred in non-UTC environments so it wouldn't appear in tests since we set the env TZ to UTC.


TL;DR: `parseISO("2019-11-09") !== new Date("2019-11-09")`


rel SO Answer: https://stackoverflow.com/a/31732581/
