### PR TITLE
fix: decimal fmt in json encoder

### DIFF
--- a/backend/core/renderers.py
+++ b/backend/core/renderers.py
@@ -5,12 +5,23 @@ from rest_framework.renderers import JSONRenderer as DRFJSONRenderer
 from rest_framework.utils.encoders import JSONEncoder as DRFEncoder
 
 
+def fmt_decimal(d: Decimal) -> str:
+    """
+    remove trailing zeros
+
+    Decimal("4.0000") -> "4"
+    """
+    if d == d.to_integral():
+        return str(d.quantize(Decimal(1)))
+    return str(d.normalize())
+
+
 class JSONEncoder(DRFEncoder):
     def default(self, o):
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)
         if isinstance(o, Decimal):
-            return str(o.normalize())
+            return fmt_decimal(o)
         return super().default(o)
 
 

--- a/backend/core/test_renderers.py
+++ b/backend/core/test_renderers.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+
 from core.renderers import JSONEncoder
 
 
@@ -19,4 +20,3 @@ def test_decimal_encoding() -> None:
         decimal="0.125",
         larger_than_float="2000000.123456789",
     )
-

--- a/backend/core/test_renderers.py
+++ b/backend/core/test_renderers.py
@@ -1,0 +1,22 @@
+import json
+from decimal import Decimal
+from core.renderers import JSONEncoder
+
+
+def test_decimal_encoding() -> None:
+    data = dict(
+        whole_number=Decimal(750),
+        trailing_zeros=Decimal("4.000000000000000000000000000"),
+        decimal=Decimal(1) / Decimal(8),
+        # In this case, some formatting solutions would fail because they would
+        # cast the `Decimal` to `float` and we'd lose precision.
+        larger_than_float=Decimal("2000000.123456789"),
+    )
+
+    assert json.loads(json.dumps(data, cls=JSONEncoder)) == dict(
+        whole_number="750",
+        trailing_zeros="4",
+        decimal="0.125",
+        larger_than_float="2000000.123456789",
+    )
+


### PR DESCRIPTION
Previous `.normalize()` setup removed trailing zeros but it had the
unwanted side effect of formatting `250` as `2.5E+2`.

Now we use the solution recommended in the std lib decimal docs.