### PR TITLE
add(cumin): better handling of unknown units

### DIFF
--- a/backend/core/cumin/__init__.py
+++ b/backend/core/cumin/__init__.py
@@ -1,9 +1,9 @@
 import decimal
+import enum
 from collections import defaultdict
 from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum
-import enum
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from core.schedule.inflect import singularize

--- a/backend/core/renderers.py
+++ b/backend/core/renderers.py
@@ -1,5 +1,5 @@
 import dataclasses
-from decimal import Decimal, getcontext
+from decimal import Decimal
 
 from rest_framework.renderers import JSONRenderer as DRFJSONRenderer
 from rest_framework.utils.encoders import JSONEncoder as DRFEncoder

--- a/backend/core/renderers.py
+++ b/backend/core/renderers.py
@@ -1,8 +1,10 @@
 import dataclasses
-from decimal import Decimal
+from decimal import Decimal, getcontext
 
 from rest_framework.renderers import JSONRenderer as DRFJSONRenderer
 from rest_framework.utils.encoders import JSONEncoder as DRFEncoder
+
+MAX_DECIMAL_PLACES = 8
 
 
 def fmt_decimal(d: Decimal) -> str:
@@ -11,6 +13,7 @@ def fmt_decimal(d: Decimal) -> str:
 
     Decimal("4.0000") -> "4"
     """
+    d = round(d, MAX_DECIMAL_PLACES)
     if d == d.to_integral():
         return str(d.quantize(Decimal(1)))
     return str(d.normalize())

--- a/backend/core/schedule/test_shopping_list.py
+++ b/backend/core/schedule/test_shopping_list.py
@@ -37,8 +37,14 @@ def test_fetching_shoppinglist(client, user, recipe):
     res = client.get(url, params)
     assert res.status_code == status.HTTP_200_OK
     assert res.json() == {
-        "egg": {"quantities": [{"quantity": "2", "unit": "POUND"}]},
-        "soy sauce": {"quantities": [{"quantity": "4", "unit": "TABLESPOON"}]},
+        "egg": {
+            "quantities": [{"quantity": "2", "unit": "POUND", "unknown_unit": None}]
+        },
+        "soy sauce": {
+            "quantities": [
+                {"quantity": "4", "unit": "TABLESPOON", "unknown_unit": None}
+            ]
+        },
     }
 
 
@@ -65,8 +71,14 @@ def test_fetching_shoppinglist_with_team_recipe(client, team, user, recipe):
     assert res.json() != []
 
     assert res.json() == {
-        "egg": {"quantities": [{"quantity": "2", "unit": "POUND"}]},
-        "soy sauce": {"quantities": [{"quantity": "4", "unit": "TABLESPOON"}]},
+        "egg": {
+            "quantities": [{"quantity": "2", "unit": "POUND", "unknown_unit": None}]
+        },
+        "soy sauce": {
+            "quantities": [
+                {"quantity": "4", "unit": "TABLESPOON", "unknown_unit": None}
+            ]
+        },
     }
 
 
@@ -103,7 +115,9 @@ def test_scheduling_multiple_times_some_ingredient(
     res = client.get(url, params)
     assert res.status_code == status.HTTP_200_OK
     assert res.json() == {
-        "black pepper": {"quantities": [{"quantity": "3", "unit": "SOME"}]}
+        "black pepper": {
+            "quantities": [{"quantity": "3", "unit": "SOME", "unknown_unit": None}]
+        }
     }
 
 
@@ -313,6 +327,11 @@ def test_combining_feta(user, client, empty_recipe):
         ("some", "katamata olives"),
         ("some", "red pepper flakes"),
         ("2 tablespoon", "molasses"),
+        # duplicate the ingredient to replicate scheduling the recipe multiple
+        # times
+        ("1 bag", "tortilla chips"),
+        ("1 bag", "tortilla chips"),
+        ("1 container", "tortilla chips"),
     ]
 
     for quantity, name in ingredients:
@@ -331,9 +350,27 @@ def test_combining_feta(user, client, empty_recipe):
     assert res.status_code == status.HTTP_200_OK
 
     assert res.json() == {
-        "all purpose flour": {"quantities": [{"quantity": "1.25", "unit": "CUP"}]},
-        "feta": {"quantities": [{"quantity": "1", "unit": "SOME"}]},
-        "katamata olives": {"quantities": [{"quantity": "1", "unit": "SOME"}]},
-        "molasses": {"quantities": [{"quantity": "2", "unit": "TABLESPOON"}]},
-        "red pepper flakes": {"quantities": [{"quantity": "1", "unit": "SOME"}]},
+        "all purpose flour": {
+            "quantities": [{"quantity": "1.25", "unit": "CUP", "unknown_unit": None}]
+        },
+        "feta": {
+            "quantities": [{"quantity": "1", "unit": "SOME", "unknown_unit": None}]
+        },
+        "katamata olives": {
+            "quantities": [{"quantity": "1", "unit": "SOME", "unknown_unit": None}]
+        },
+        "molasses": {
+            "quantities": [
+                {"quantity": "2", "unit": "TABLESPOON", "unknown_unit": None}
+            ]
+        },
+        "red pepper flakes": {
+            "quantities": [{"quantity": "1", "unit": "SOME", "unknown_unit": None}]
+        },
+        "tortilla chips": {
+            "quantities": [
+                {"quantity": "2", "unit": "UNKNOWN", "unknown_unit": "bag"},
+                {"quantity": "1", "unit": "UNKNOWN", "unknown_unit": "container"},
+            ]
+        },
     }

--- a/backend/core/test_renderers.py
+++ b/backend/core/test_renderers.py
@@ -12,11 +12,14 @@ def test_decimal_encoding() -> None:
         # In this case, some formatting solutions would fail because they would
         # cast the `Decimal` to `float` and we'd lose precision.
         larger_than_float=Decimal("2000000.123456789"),
+        # rounding errors
+        rounding_errors=Decimal("6.500000000000000000000000002"),
     )
 
     assert json.loads(json.dumps(data, cls=JSONEncoder)) == dict(
         whole_number="750",
         trailing_zeros="4",
         decimal="0.125",
-        larger_than_float="2000000.123456789",
+        larger_than_float="2000000.12345679",
+        rounding_errors="6.5",
     )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -121,7 +121,7 @@ export const enum Unit {
 export interface IQuantity {
   readonly quantity: string
   readonly unit: Unit
-  readonly unknown_unit: string | null
+  readonly unknown_unit?: string | null
 }
 
 export interface IIngredientItem {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -114,12 +114,14 @@ export const enum Unit {
   LITER = "LITER",
   MILLILITER = "MILLILITER",
   SOME = "SOME",
+  UNKNOWN = "UNKNOWN",
   NONE = "NONE"
 }
 
 export interface IQuantity {
   readonly quantity: string
   readonly unit: Unit
+  readonly unknown_unit: string | null
 }
 
 export interface IIngredientItem {

--- a/frontend/src/components/ShoppingList.test.ts
+++ b/frontend/src/components/ShoppingList.test.ts
@@ -1,0 +1,18 @@
+import { toQuantity } from "@/components/ShoppingList"
+import { IQuantity, Unit } from "@/api"
+
+describe("shoppinglist", () => {
+  test("#toQuantity", () => {
+    const testCases: ReadonlyArray<[IQuantity, string]> = [
+      [{ quantity: "1", unit: Unit.CUP }, "1 cup"],
+      [{ quantity: "1", unit: Unit.SOME }, "some"],
+      [{ quantity: "1", unit: Unit.UNKNOWN }, "1"],
+      [{ quantity: "1", unit: Unit.UNKNOWN, unknown_unit: "bag" }, "1 bag"],
+      [{ quantity: "1", unit: Unit.NONE }, "1"]
+    ]
+
+    testCases.forEach(([quantity, expected]) => {
+      expect(toQuantity(quantity)).toEqual(expected)
+    })
+  })
+})

--- a/frontend/src/components/ShoppingList.tsx
+++ b/frontend/src/components/ShoppingList.tsx
@@ -73,9 +73,18 @@ interface IShoppingListItemProps {
   readonly isFirst: boolean
 }
 
-function toQuantity(x: IQuantity): string {
+export function toQuantity(x: IQuantity): string {
   if (x.unit === Unit.NONE) {
     return x.quantity
+  }
+  if (x.unit === Unit.SOME) {
+    return "some"
+  }
+  if (x.unit === Unit.UNKNOWN && x.unknown_unit == null) {
+    return x.quantity
+  }
+  if (x.unit === Unit.UNKNOWN && x.unknown_unit != null) {
+    return x.quantity + " " + x.unknown_unit
   }
   const unit = x.unit.toLowerCase()
   return x.quantity + " " + unit


### PR DESCRIPTION
Previously we were largely ignoring unknown units which wasn't great as
the rendered shopping list had some gaps.

Ideally we'd have the ingredients be something like

```
enum Unit {
    TABLESPOON,
    // ...
    UNKNOWN(String)
}
```

But alas, we can't easily achieve that so instead we add a `unknown_unit`
field to the Quantity() which is nullable.

Also round decimals to prevent issues with combining resulting in:

`6.500000000000000000000000002` Tablespoons