### PR TITLE
add(calendar): auto fetching on week change

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -310,7 +310,7 @@ export const declineInvite = (id: IInvite["id"]) =>
 
 export const reportBadMerge = () => http.post("/api/v1/report-bad-merge", {})
 
-export const getCalendarRecipeList = (teamID: TeamID, currentDay: Date) => {
+export const getCalendarRecipeList = (teamID: TeamID, currentDay: number) => {
   const start = toISODateString(startOfWeek(subWeeks(currentDay, 1)))
   const end = toISODateString(endOfWeek(addWeeks(currentDay, 1)))
   const id = teamID === "personal" ? "me" : teamID

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -310,9 +310,9 @@ export const declineInvite = (id: IInvite["id"]) =>
 
 export const reportBadMerge = () => http.post("/api/v1/report-bad-merge", {})
 
-export const getCalendarRecipeList = (teamID: TeamID, currentDay: number) => {
-  const start = toISODateString(startOfWeek(subWeeks(currentDay, 1)))
-  const end = toISODateString(endOfWeek(addWeeks(currentDay, 1)))
+export const getCalendarRecipeList = (teamID: TeamID, currentDayTs: number) => {
+  const start = toISODateString(startOfWeek(subWeeks(currentDayTs, 1)))
+  const end = toISODateString(endOfWeek(addWeeks(currentDayTs, 1)))
   const id = teamID === "personal" ? "me" : teamID
   return http.get<ICalRecipe[]>(`/api/v1/t/${id}/calendar/`, {
     params: {

--- a/frontend/src/components/Calendar.test.tsx
+++ b/frontend/src/components/Calendar.test.tsx
@@ -17,18 +17,7 @@ describe("<Calendar> Snap", () => {
     const tree = renderer
       .create(
         <TestProvider>
-          <Calendar
-            loadingTeams={false}
-            error={false}
-            fetchTeams={jest.fn()}
-            navTo={jest.fn()}
-            fetchData={jest.fn()}
-            teams={[]}
-            days={{}}
-            teamID={10}
-            type="recipes"
-            refetchShoppingListAndRecipes={jest.fn()}
-          />
+          <Calendar teamID={10} type="recipes" />
         </TestProvider>
       )
       .toJSON()

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -43,11 +43,11 @@ function monthYearFromDate(date: number) {
 }
 
 interface ICalTitleProps {
-  readonly day: number
+  readonly dayTs: number
 }
 
-function CalTitle({ day }: ICalTitleProps) {
-  return <p className="mr-2">{monthYearFromDate(day)}</p>
+function CalTitle({ dayTs }: ICalTitleProps) {
+  return <p className="mr-2">{monthYearFromDate(dayTs)}</p>
 }
 
 export interface IDays {
@@ -169,7 +169,7 @@ function TeamSelect({ onChange, value, teams }: ITeamSelectProps) {
 }
 
 interface INavProps {
-  readonly day: number
+  readonly dayTs: number
   readonly onPrev: () => void
   readonly onNext: () => void
   readonly onCurrent: () => void
@@ -177,13 +177,13 @@ interface INavProps {
   readonly type: "shopping" | "recipes"
 }
 
-function Nav({ day, teamID, onPrev, onNext, onCurrent, type }: INavProps) {
-  const { handleOwnerChange, teams } = useTeamSelect(day, type)
+function Nav({ dayTs, teamID, onPrev, onNext, onCurrent, type }: INavProps) {
+  const { handleOwnerChange, teams } = useTeamSelect(dayTs, type)
 
   return (
     <section className="d-flex flex-grow justify-space-between align-items-center">
       <div className="d-flex">
-        <CalTitle day={day} />
+        <CalTitle dayTs={dayTs} />
         <TeamSelect teams={teams} value={teamID} onChange={handleOwnerChange} />
       </div>
       <section>
@@ -242,9 +242,9 @@ function useCurrentWeek() {
     })
   }, [today])
 
-  const currentDate = startOfWeek(weekStartDate).getTime()
-  const startDate = startOfWeek(subWeeks(currentDate, 1))
-  const endDate = endOfWeek(addWeeks(currentDate, 1))
+  const currentDateTs = startOfWeek(weekStartDate).getTime()
+  const startDate = startOfWeek(subWeeks(currentDateTs, 1))
+  const endDate = endOfWeek(addWeeks(currentDateTs, 1))
 
   const navPrev = () => {
     setStart(prev => ({
@@ -267,7 +267,7 @@ function useCurrentWeek() {
     }))
   }
 
-  return { currentDate, startDate, endDate, navNext, navPrev, navCurrent }
+  return { currentDateTs, startDate, endDate, navNext, navPrev, navCurrent }
 }
 
 function useTeams(): WebData<ReadonlyArray<ITeam>> {
@@ -285,11 +285,11 @@ function useTeams(): WebData<ReadonlyArray<ITeam>> {
   return Success(teams)
 }
 
-function useDays(teamID: TeamID, currentDate: number): WebData<IDays> {
+function useDays(teamID: TeamID, currentDateTs: number): WebData<IDays> {
   const dispatch = useDispatch()
   useEffect(() => {
-    fetchCalendarAsync(dispatch)(teamID, currentDate)
-  }, [currentDate, dispatch, teamID])
+    fetchCalendarAsync(dispatch)(teamID, currentDateTs)
+  }, [currentDateTs, dispatch, teamID])
 
   const isTeam = teamID !== "personal"
   const days = useSelector(s => {
@@ -317,7 +317,7 @@ function useDays(teamID: TeamID, currentDate: number): WebData<IDays> {
   )
 }
 
-function useTeamSelect(currentDate: number, type: "shopping" | "recipes") {
+function useTeamSelect(currentDateTs: number, type: "shopping" | "recipes") {
   const teams = useTeams()
   const dispatch = useDispatch()
 
@@ -334,7 +334,7 @@ function useTeamSelect(currentDate: number, type: "shopping" | "recipes") {
 
     // navTo is async so we can't count on the URL to have changed by the time we refetch the data
     dispatch(push(urlWithEnding))
-    fetchCalendarAsync(dispatch)(teamID, currentDate)
+    fetchCalendarAsync(dispatch)(teamID, currentDateTs)
     fetchingRecipeListAsync(dispatch)(teamID)
     fetchingShoppingListAsync(dispatch)(teamID)
   }
@@ -349,7 +349,7 @@ interface ICalendarProps {
 
 export function Calendar({ teamID, type }: ICalendarProps) {
   const {
-    currentDate,
+    currentDateTs,
     startDate,
     endDate,
     navNext,
@@ -357,12 +357,12 @@ export function Calendar({ teamID, type }: ICalendarProps) {
     navPrev
   } = useCurrentWeek()
 
-  const days = useDays(teamID, currentDate)
+  const days = useDays(teamID, currentDateTs)
 
   return (
     <CalContainer>
       <Nav
-        day={currentDate}
+        dayTs={currentDateTs}
         teamID={teamID}
         onNext={navNext}
         onPrev={navPrev}

--- a/frontend/src/components/__snapshots__/Calendar.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Calendar.test.tsx.snap
@@ -149,7 +149,6 @@ exports[`<Calendar> Snap smoke test render with empty data 1`] = `
     >
       <p
         className="mr-2"
-        title="1776-1-1"
       >
         Dec 31 | 1775
       </p>
@@ -158,7 +157,7 @@ exports[`<Calendar> Snap smoke test render with empty data 1`] = `
       >
         <select
           className=""
-          disabled={false}
+          disabled={true}
           multiple={undefined}
           onChange={[Function]}
           value={10}

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -1011,6 +1011,6 @@ Object {
     "team": 1,
     "time": "1776",
   },
-  "kind": 3,
+  "kind": "Refetching",
 }
 `;

--- a/frontend/src/store/reducers/calendar.test.ts
+++ b/frontend/src/store/reducers/calendar.test.ts
@@ -46,7 +46,7 @@ describe("Calendar", () => {
     ]
 
     const afterState: ICalendarState = {
-      ...initialState,
+      status: "success",
       allIds: [recipes[0].id, recipes[1].id],
       byId: {
         [recipes[0].id]: recipes[0],
@@ -123,7 +123,7 @@ describe("Calendar", () => {
 
     const afterState: ICalendarState = {
       ...initialState,
-      loading: true,
+      status: "loading",
       allIds: []
     }
 
@@ -140,7 +140,7 @@ describe("Calendar", () => {
 
     const afterState: ICalendarState = {
       ...initialState,
-      error: true,
+      status: "failure",
       allIds: []
     }
 

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -985,7 +985,7 @@ export const reportBadMergeAsync = (dispatch: Dispatch) => async () => {
 
 export const fetchCalendarAsync = (dispatch: Dispatch) => async (
   teamID: TeamID,
-  month = new Date()
+  month: number
 ) => {
   dispatch(fetchCalendarRecipes.request())
   // we fetch current month plus and minus 1 week

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -985,11 +985,11 @@ export const reportBadMergeAsync = (dispatch: Dispatch) => async () => {
 
 export const fetchCalendarAsync = (dispatch: Dispatch) => async (
   teamID: TeamID,
-  month: number
+  monthTs: number
 ) => {
   dispatch(fetchCalendarRecipes.request())
   // we fetch current month plus and minus 1 week
-  const res = await api.getCalendarRecipeList(teamID, month)
+  const res = await api.getCalendarRecipeList(teamID, monthTs)
   if (isOk(res)) {
     dispatch(fetchCalendarRecipes.success(res.data))
   } else {

--- a/frontend/src/webdata.ts
+++ b/frontend/src/webdata.ts
@@ -1,8 +1,8 @@
 const enum RDK {
-  Loading,
-  Failure,
-  Success,
-  Refetching
+  Loading = "Loading",
+  Failure = "Failure",
+  Success = "Success",
+  Refetching = "Refetching"
 }
 
 export interface ILoading {


### PR DESCRIPTION
Previously, we wouldn't fetch the next week when the date rolled over.
This meant the UI would show the next week but it wouldn't have any data.

Now we re-fetch the calendar data when the current week changes.

There are some foot guns related using `Date` in a React.useEffect
dependency array so we've changed some of the function return types and
args to use `number` instead of `Date`.

```
new Date("1776") !== new Date("1776")
```

while

```
new Date("1776").getTime() === new Date("1776").getTime()
```