### PR TITLE
fix(cumin): parsing of `oz` as ounce and quantities that are combined

### DIFF
--- a/backend/core/cumin/__init__.py
+++ b/backend/core/cumin/__init__.py
@@ -217,7 +217,7 @@ def get_unit(val: str) -> Unit:
         return Unit.GRAM
     if "gallon" in val:
         return Unit.GALLON
-    if "ounce" in val:
+    if "ounce" in val or val == "oz":
         return Unit.OUNCE
     if "milliliter" in val:
         return Unit.MILLILITER
@@ -288,6 +288,9 @@ def _parse_quantity(val: str) -> Quantity:
             break
 
     for c in value:
+        if c in quantity_chars:
+            break
+        # handle case of two units and quantities next to each other
         unit_str += c
 
     # strip out misplaced words, e.g., `1 large` `lemon` instead of `1` `large lemon`

--- a/backend/core/cumin/test_parsing.py
+++ b/backend/core/cumin/test_parsing.py
@@ -24,6 +24,8 @@ from core.renderers import JSONEncoder
         ("1/2 Tablespoon", Quantity(quantity=Decimal(0.5), unit=Unit.TABLESPOON)),
         ("3 1/2 Tablespoon", Quantity(quantity=Decimal(3.5), unit=Unit.TABLESPOON)),
         ("1 tsp", Quantity(quantity=Decimal(1), unit=Unit.TEASPOON)),
+        ("4 oz", Quantity(quantity=Decimal(4), unit=Unit.OUNCE)),
+        ("4 ounces/112 grams", Quantity(quantity=Decimal(4), unit=Unit.OUNCE)),
         ("4 ounces", Quantity(quantity=Decimal(4), unit=Unit.OUNCE)),
         ("1 1/2 cups", Quantity(quantity=Decimal(1.5), unit=Unit.CUP)),
         ("3lbs", Quantity(quantity=Decimal(3), unit=Unit.POUND)),


### PR DESCRIPTION
Previously we weren't parsing `oz` as ounce and we weren't handling
cases where quantities are combined, e.g., `4 ounces/112 grams`.