### PR TITLE
fix(ui): unintended global usage

### DIFF
--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -74,5 +74,5 @@ export function useDropdown() {
   const closeDropdown = React.useCallback(() => setIsOpen(false), [])
   const toggle = React.useCallback(() => setIsOpen(p => !p), [])
   const ref = useOnClickOutside<HTMLDivElement>(closeDropdown)
-  return { ref, toggle, close, isOpen, setIsOpen }
+  return { ref, toggle, close: closeDropdown, isOpen, setIsOpen }
 }


### PR DESCRIPTION
Turns out that `close` is a global

https://developer.mozilla.org/en-US/docs/Web/API/Window/close

similar to the annoying `name`.

Would have been prevented by something like:

https://eslint.org/docs/rules/no-restricted-globals

This resulted in some buggy behavior where clicking on a nav button
would cause a full page reload instead of a smoother react based name.