### PR TITLE
fix: n+1 serializer mixin type error

### DIFF
--- a/backend/core/conftest.py
+++ b/backend/core/conftest.py
@@ -104,6 +104,12 @@ def recipe(user):
     )
 
     Note.objects.create(recipe=recipe, text="Use a small pot.", created_by=user)
+    Note.objects.create(
+        recipe=recipe,
+        text="I'd say we should use an even smaller pot next time.",
+        created_by=user,
+        last_modified_by=user,
+    )
 
     return recipe
 

--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -256,17 +256,21 @@ def test_modifying_note_of_recipe(client, user, user2, recipe):
 def test_delete_note_of_recipe(client, user, user2, recipe):
     note = recipe.note_set.first()
     client.force_authenticate(user2)
+    before_count = recipe.note_set.count()
+    assert before_count > 0
     res = client.delete(f"/api/v1/recipes/{recipe.id}/notes/{note.id}/")
     assert status.is_success(res.status_code)
-    assert recipe.note_set.count() == 0
+    assert recipe.note_set.count() == before_count - 1
 
 
 def test_delete_note(client, user, user2, recipe):
     note = recipe.note_set.first()
     client.force_authenticate(user2)
+    before_count = recipe.note_set.count()
+    assert before_count > 0
     res = client.delete(f"/api/v1/notes/{note.id}/")
     assert status.is_success(res.status_code)
-    assert recipe.note_set.count() == 0
+    assert recipe.note_set.count() == before_count - 1
 
 
 def test_adding_ingredient_to_recipe(client, user, recipe):

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -252,6 +252,7 @@ class TeamRecipesViewSet(APIView):
             "scheduledrecipe_set",
             "note_set",
             "note_set__created_by",
+            "note_set__last_modified_by",
         )
         serializer = RecipeSerializer(
             queryset, many=True, context={"request": self.request}

--- a/backend/core/serialization.py
+++ b/backend/core/serialization.py
@@ -8,12 +8,21 @@ from rest_framework import serializers
 log = getLogger(__name__)
 
 
+class UnexpectedDatabaseAccess(Exception):
+    pass
+
+
 def blocker(*args):
-    raise Exception("No database access allowed here.")
+    raise UnexpectedDatabaseAccess
 
 
-def warning_blocker(*args):
+def warning_blocker(execute, sql, params, many, context):
+    """
+    expected to call `execute` and return the call's result:
+    https://docs.djangoproject.com/en/dev/topics/db/instrumentation/#connection-execute-wrapper
+    """
     log.warning("Database access in serializer.")
+    return execute(sql, params, many, context)
 
 
 class DBBlockerSerializerMixin:

--- a/backend/core/teams/test_teams.py
+++ b/backend/core/teams/test_teams.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from core.models import Invite, Membership, Recipe, Team
+from core.models import Invite, Membership, Recipe, Team, Note
 
 pytestmark = pytest.mark.django_db
 
@@ -774,6 +774,8 @@ def test_fetching_team_recipes(client, team_with_recipes, user, user2):
     client.force_authenticate(user2)
     res = client.get(url)
     assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    assert Note.objects.exists() is True
 
     client.force_authenticate(user)
     res = client.get(url)

--- a/backend/core/teams/test_teams.py
+++ b/backend/core/teams/test_teams.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from core.models import Invite, Membership, Recipe, Team, Note
+from core.models import Invite, Membership, Note, Recipe, Team
 
 pytestmark = pytest.mark.django_db
 

--- a/backend/core/test_serialization.py
+++ b/backend/core/test_serialization.py
@@ -1,7 +1,8 @@
 import pytest
+
 from core.models import Recipe
-from core.serialization import UnexpectedDatabaseAccess
 from core.recipes.serializers import RecipeSerializer
+from core.serialization import UnexpectedDatabaseAccess
 
 
 @pytest.mark.django_db

--- a/backend/core/test_serialization.py
+++ b/backend/core/test_serialization.py
@@ -1,0 +1,28 @@
+import pytest
+from core.models import Recipe
+from core.serialization import UnexpectedDatabaseAccess
+from core.recipes.serializers import RecipeSerializer
+
+
+@pytest.mark.django_db
+def test_db_blocker_warn_still_calls_db(settings, recipe) -> None:
+    """
+    Shouldn't fail, but still fetch from database with a warning logged
+    """
+    settings.ERROR_ON_SERIALIZER_DB_ACCESS = False
+    queryset = Recipe.objects.all()
+
+    assert len(RecipeSerializer(queryset, many=True).data) > 0
+
+
+@pytest.mark.django_db
+def test_db_blocker_fails_with_proper_settings(settings, recipe) -> None:
+    """
+    When the proper config setting is specified, database access should raise
+    an exception inside a serializer.
+    """
+    settings.ERROR_ON_SERIALIZER_DB_ACCESS = True
+    queryset = Recipe.objects.all()
+
+    with pytest.raises(UnexpectedDatabaseAccess):
+        RecipeSerializer(queryset, many=True).data

--- a/backend/core/test_serialization.py
+++ b/backend/core/test_serialization.py
@@ -13,7 +13,7 @@ def test_db_blocker_warn_still_calls_db(settings, recipe) -> None:
     settings.ERROR_ON_SERIALIZER_DB_ACCESS = False
     queryset = Recipe.objects.all()
 
-    assert len(RecipeSerializer(queryset, many=True).data) > 0
+    assert RecipeSerializer(queryset, many=True).data
 
 
 @pytest.mark.django_db
@@ -26,4 +26,5 @@ def test_db_blocker_fails_with_proper_settings(settings, recipe) -> None:
     queryset = Recipe.objects.all()
 
     with pytest.raises(UnexpectedDatabaseAccess):
+        # pylint:disable=expression-not-assigned
         RecipeSerializer(queryset, many=True).data


### PR DESCRIPTION
Turns out the wrappers passed to connection.execute_wrappers are expected
to call the `execute` arg and return its value.

https://docs.djangoproject.com/en/dev/topics/db/instrumentation/#connection-execute-wrapper

We were returning None and this resulted in some strange errors with django.

```
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/backend-py3.7/lib/python3.7/site-packages/django/db/models/fields/related_descriptors.py", line 164, in __get__
    rel_obj = self.field.get_cached_value(instance)
  File "/root/.cache/pypoetry/virtualenvs/backend-py3.7/lib/python3.7/site-packages/django/db/models/fields/mixins.py", line 13, in get_cached_value
    return instance._state.fields_cache[cache_name]
KeyError: 'last_modified_by'
```