### PR TITLE
fix: capitalization for units

### DIFF
--- a/frontend/src/text.test.ts
+++ b/frontend/src/text.test.ts
@@ -1,0 +1,10 @@
+import { capitalizeUnits } from "@/text"
+
+describe("text", () => {
+  test("capitalizeUnits", () => {
+    const input = "tablespoon tablespoons Teaspoon Teaspoons"
+    expect(capitalizeUnits(input)).toEqual(
+      "Tablespoon Tablespoons teaspoon teaspoons"
+    )
+  })
+})

--- a/frontend/src/text.ts
+++ b/frontend/src/text.ts
@@ -2,5 +2,7 @@
  * Mixing up Tablespoon and teaspoon is harder when they are consistently cased
  */
 export function capitalizeUnits(str: string): string {
-  return str.replace("tablespoon", "Tablespoon").replace("Teaspoon", "teaspoon")
+  return str
+    .replace(/tablespoon/g, "Tablespoon")
+    .replace(/Teaspoon/g, "teaspoon")
 }


### PR DESCRIPTION
We were only doing a singular replace across steps & ingredients instead
of all occurrences.