### PR TITLE
fix(calendar): extra browser history item due to search clearing

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -13,7 +13,7 @@ import { IState } from "@/store/store"
 import { WebData, isSuccessOrRefetching } from "@/webdata"
 import queryString from "query-string"
 import { useDispatch } from "@/hooks"
-import { push } from "connected-react-router"
+import { replace } from "connected-react-router"
 import { parseIntOrNull } from "@/parseIntOrNull"
 
 interface IRecipeList {
@@ -70,7 +70,7 @@ function useClearSearchOnLoad() {
   const dispatch = useDispatch()
   React.useEffect(() => {
     dispatch(
-      push({
+      replace({
         search: ""
       })
     )


### PR DESCRIPTION
We remove the search query on load for the calendar, but we were using
`push` instead of `replace`. This meant it would take 2 navigations back
instead of the expected 1.