### PR TITLE
add(recipe): markdown list items for steps & notes

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,5 +1,18 @@
 import React from "react"
 import ReactMarkdown, { NodeType } from "react-markdown"
+import { styled } from "@/theme"
+
+const MarkdownWrapper = styled.div`
+  ul {
+    list-style-type: disc;
+    padding-left: 1.5rem;
+  }
+
+  ol {
+    padding-left: 1.5rem;
+  }
+`
+
 const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "root",
   "text",
@@ -7,25 +20,30 @@ const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "paragraph",
   "strong",
   "emphasis",
-  "paragraph"
+  "list",
+  "listItem"
 ]
 
-interface IMarkdownProps
-  extends React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLDivElement>,
-    HTMLDivElement
-  > {
+interface IMarkdownProps {
   readonly children: string
+  readonly onClick?: () => void
+  readonly className?: string
+  readonly title?: string
 }
 
-export function Markdown({ children: text, ...rest }: IMarkdownProps) {
+export function Markdown({
+  children: text,
+  className,
+  title,
+  onClick
+}: IMarkdownProps) {
   return (
-    <div {...rest}>
+    <MarkdownWrapper className={className} title={title} onClick={onClick}>
       <ReactMarkdown
         allowedTypes={ALLOWED_MARKDOWN_TYPES}
         source={text}
         unwrapDisallowed
       />
-    </div>
+    </MarkdownWrapper>
   )
 }

--- a/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
@@ -1,13 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ListItem/> snap with capitalization 1`] = `
+.c0 ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+
+.c0 ol {
+  padding-left: 1.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
     onClick={[Function]}
     title="click to edit"
   >
-    <div>
+    <div
+      className="c0"
+      onClick={undefined}
+      title={undefined}
+    >
       <p>
         Add 3 Tablespoons of tomato paste. Cook 1 minute.
       </p>
@@ -17,13 +30,26 @@ exports[`<ListItem/> snap with capitalization 1`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 2`] = `
+.c0 ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+
+.c0 ol {
+  padding-left: 1.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
     onClick={[Function]}
     title="click to edit"
   >
-    <div>
+    <div
+      className="c0"
+      onClick={undefined}
+      title={undefined}
+    >
       <p>
         Measure 1 teaspoon of rice vinegar.
       </p>
@@ -33,13 +59,26 @@ exports[`<ListItem/> snap with capitalization 2`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 3`] = `
+.c0 ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+
+.c0 ol {
+  padding-left: 1.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
     onClick={[Function]}
     title="click to edit"
   >
-    <div>
+    <div
+      className="c0"
+      onClick={undefined}
+      title={undefined}
+    >
       <p>
         Add 1 Tablespoon + 2 teaspoons of soy sauce.
       </p>
@@ -49,13 +88,26 @@ exports[`<ListItem/> snap with capitalization 3`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 4`] = `
+.c0 ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+
+.c0 ol {
+  padding-left: 1.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
     onClick={[Function]}
     title="click to edit"
   >
-    <div>
+    <div
+      className="c0"
+      onClick={undefined}
+      title={undefined}
+    >
       <p>
         Stir in 1 teaspoon salt
       </p>

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -451,6 +451,15 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
 `;
 
 exports[`<Recipe/> snaps recipe all states 2`] = `
+.c6 ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+
+.c6 ol {
+  padding-left: 1.5rem;
+}
+
 .c0 {
   position: relative;
 }
@@ -870,7 +879,11 @@ exports[`<Recipe/> snaps recipe all states 2`] = `
             onClick={[Function]}
             title="click to edit"
           >
-            <div>
+            <div
+              className="c6"
+              onClick={undefined}
+              title={undefined}
+            >
               <p>
                 foo
               </p>


### PR DESCRIPTION
We didn't initially include `ol` and `ul` in markdown. They can be handy
for some cases so let's enable them.