### PR TITLE
add(nginx): disable caching index.html

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -118,6 +118,10 @@ server {
     }
 
     location / {
+        # Ensure the browser doesn't cache the index.html.
+        # Without cache-control headers, browsers use
+        # heuristic caching.
+        add_header Cache-Control "no-store";
         if (-f /var/www/maintenance_on) {
             return 503;
         }


### PR DESCRIPTION
For static files we use nginx's `expires: max;` to ensure the
browser can cache the files indefinitely.

With the index.html we don't want the browser caching since
the index contains references to the latest static files. If we let the
browser cache it via its heuristic then when we release a new version
the browser might not fetch it. Meaning the user could get stuck on an
older version for a bit.

rel: <http://nginx.org/en/docs/http/ngx_http_headers_module.html#expires>
rel: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Preventing_caching>
rel: <https://paulcalvano.com/index.php/2018/03/14/http-heuristic-caching-missing-cache-control-and-expires-headers-explained/>