### PR TITLE
fix(nginx): missing security headers

### DIFF
--- a/nginx/general_headers.conf
+++ b/nginx/general_headers.conf
@@ -1,0 +1,16 @@
+add_header X-Response-Id $request_id;
+add_header X-Request-Time $request_time;
+
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Directives
+# https://sentry.io/magnus-montis/recipeyak/settings/csp/
+add_header Content-Security-Policy "default-src 'self' https://sentry.io; img-src *; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/250295/csp-report/?sentry_key=3b11e5eed068478390e1e8f01e2190a9";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+add_header Referrer-Policy "strict-origin-when-cross-origin";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+add_header X-Content-Type-Options "nosniff";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+add_header X-Frame-Options "SAMEORIGIN";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+add_header X-XSS-Protection "1; mode=block";
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";

--- a/nginx/nginx.Dockerfile
+++ b/nginx/nginx.Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:1.13.8-alpine@sha256:c8ff0187cc75e1f5002c7ca9841cb191d33c4080f38140b9d6f07902ababbe66
 
+COPY general_headers.conf /etc/nginx/headers.d/
 COPY nginx.conf /etc/nginx/conf.d/
 RUN rm /etc/nginx/conf.d/default.conf
 RUN mkdir -p /var/www

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -95,33 +95,22 @@ server {
     gzip_proxied any;
     gzip_vary on;
 
-    add_header X-Response-Id $request_id;
-    add_header X-Request-Time $request_time;
-
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Directives
-    # https://sentry.io/magnus-montis/recipeyak/settings/csp/
-    add_header Content-Security-Policy "default-src 'self' https://sentry.io; img-src *; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/250295/csp-report/?sentry_key=3b11e5eed068478390e1e8f01e2190a9";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
-    add_header X-Content-Type-Options "nosniff";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-    add_header X-Frame-Options "SAMEORIGIN";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-    add_header X-XSS-Protection "1; mode=block";
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    include headers.d/general_headers.conf;
 
     location /__static_landing {
+        include headers.d/general_headers.conf;
+        add_header Cache-Control "no-store";
         alias /var/app/dist;
         try_files $uri /landing.html;
     }
 
     location / {
+        include headers.d/general_headers.conf;
         # Ensure the browser doesn't cache the index.html.
         # Without cache-control headers, browsers use
         # heuristic caching.
         add_header Cache-Control "no-store";
+
         if (-f /var/www/maintenance_on) {
             return 503;
         }
@@ -163,6 +152,7 @@ server {
     # we route API endpoints and Django Admin as well as .json, .yaml, .yml
     # files returned by the backend
     location ~* ^/(api|rest-auth|admin|api-auth|.+\.(json|yaml|yml)) {
+        include headers.d/general_headers.conf;
         if (-f /var/www/maintenance_on) {
             return 503;
         }
@@ -174,6 +164,7 @@ server {
     }
 
     location /healthz {
+        include headers.d/general_headers.conf;
         add_header Content-Type text/plain;
         return 200 'OK';
     }


### PR DESCRIPTION
Turns out `add_header` removes all headers defined in the parent scope.

Now wherever we add a new header, we include the `general_headers.conf`
which includes the security headers with the response id and response
time.

rel: https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx