### PR TITLE
update(tools): circle ci config to not cache based on branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v9-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v9-{{ checksum "poetry.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -32,7 +32,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /root/.cache/
-          key: backend-v9-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v9-{{ checksum "poetry.lock" }}
       - run:
           name: run tests
           command: poetry run yak test --api
@@ -49,7 +49,7 @@ jobs:
       # https://circleci.com/docs/2.0/caching/
       - restore_cache:
           keys:
-            - backend-v9-{{ .Branch }}-{{ checksum "poetry.lock" }}
+            - backend-v9-{{ checksum "poetry.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -61,7 +61,7 @@ jobs:
           paths:
             - ./backend/.mypy_cache
             - /root/.cache/
-          key: backend-v9-{{ .Branch }}-{{ checksum "poetry.lock" }}
+          key: backend-v9-{{ checksum "poetry.lock" }}
       - run:
           name: run lints
           command: poetry run yak lint --api
@@ -75,7 +75,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v8-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -88,7 +88,7 @@ jobs:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v8-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           command: poetry run yak test --web
@@ -100,7 +100,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - frontend-v8-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: |
@@ -113,7 +113,7 @@ jobs:
           paths:
             - /root/project/node_modules
             - /root/.cache/
-          key: frontend-v8-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: frontend-v8-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |


### PR DESCRIPTION
If the lock files are equivalent for two runs of CI, then their deps
should be equivalent.

rel: https://github.com/chdsbd/kodiak/pull/353