### PR TITLE
update(cumin): quantity parsing with `3 to 6` case

### DIFF
--- a/backend/core/cumin/__init__.py
+++ b/backend/core/cumin/__init__.py
@@ -258,6 +258,8 @@ def max_quantity(quantity: str) -> str:
     """
     take the '4-5' medium button mushrooms and find the max, 5
     """
+    if " to " in quantity:
+        return quantity.split(" to ")[-1]
     return quantity.split("-")[-1]
 
 

--- a/backend/core/cumin/test_parsing.py
+++ b/backend/core/cumin/test_parsing.py
@@ -42,6 +42,7 @@ from core.renderers import JSONEncoder
         ("1/8 T", Quantity(quantity=Decimal(1) / Decimal(8), unit=Unit.TABLESPOON)),
         ("1 tbs", Quantity(quantity=Decimal(1), unit=Unit.TABLESPOON)),
         ("4-5", Quantity(quantity=Decimal(5), unit=Unit.NONE)),
+        ("4 to 6", Quantity(quantity=Decimal(6), unit=Unit.NONE)),
         ("1lb", Quantity(quantity=Decimal(1), unit=Unit.POUND)),
         ("1 pound", Quantity(quantity=Decimal(1), unit=Unit.POUND)),
         ("1 bag", Quantity(quantity=Decimal(1), unit=Unit.UNKNOWN, unknown_unit="bag")),


### PR DESCRIPTION
Some recipes will give ranges with syntax like `3-5` or `4 to 6`. While
we don't support ranges in the ingredient model right now we can still
parse these and take the largest value.