### PR TITLE
add: webdata style type for teams

### DIFF
--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -281,9 +281,16 @@ function useTeams(): WebData<ReadonlyArray<ITeam>> {
   useEffect(() => {
     fetchingTeamsAsync(dispatch)()
   }, [dispatch])
-  const isLoading = useSelector(s => !!s.teams.loading)
 
-  if (isLoading) {
+  const status = useSelector(s => s.teams.status)
+
+  if (status === "initial") {
+    return undefined
+  }
+  if (status === "failure") {
+    return Failure()
+  }
+  if (status === "loading") {
     return Loading()
   }
 

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -288,7 +288,7 @@ function useTeams(): WebData<ReadonlyArray<ITeam>> {
     return undefined
   }
   if (status === "failure") {
-    return Failure()
+    return Failure(undefined)
   }
   if (status === "loading") {
     return Loading()

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -36,7 +36,9 @@ function useTeams() {
   React.useEffect(() => {
     fetchingTeamsAsync(dispatch)()
   }, [dispatch])
-  const loading = useSelector(s => !!s.teams.loading)
+  const loading = useSelector(
+    s => s.teams.status === "loading" || s.teams.status === "initial"
+  )
   const teams = useSelector(teamsFrom)
   if (loading) {
     return Loading()

--- a/frontend/src/containers/AddRecipe.ts
+++ b/frontend/src/containers/AddRecipe.ts
@@ -44,7 +44,8 @@ const mapStateToProps = (state: IState) => ({
   error: state.recipes.errorCreatingRecipe,
   // we remove the loading
   teams: teamsFrom(state),
-  loadingTeams: !!state.teams.loading,
+  loadingTeams:
+    state.teams.status === "loading" || state.teams.status === "initial",
   teamID: state.user.teamID
 })
 

--- a/frontend/src/store/reducers/teams.test.ts
+++ b/frontend/src/store/reducers/teams.test.ts
@@ -687,7 +687,7 @@ describe("Teams", () => {
           }
         }
       }),
-      loading: true
+      status: "loading"
     }
 
     expect(teams(beforeState, fetchTeams.request())).toEqual(afterState)
@@ -727,6 +727,7 @@ describe("Teams", () => {
     })
 
     const afterState: ITeamsState = {
+      status: "initial",
       creating: true,
       byId: {
         1: {
@@ -774,6 +775,7 @@ describe("Teams", () => {
     }
 
     const beforeState: ITeamsState = {
+      status: "initial",
       byId: {
         1: {
           id: 1,
@@ -785,6 +787,7 @@ describe("Teams", () => {
     }
 
     const afterState: ITeamsState = {
+      status: "initial",
       byId: {
         1: {
           id: 1,
@@ -838,10 +841,12 @@ describe("Teams", () => {
 
   it("sets copying team status", () => {
     const beforeState: ITeamsState = {
+      status: "initial",
       byId: {},
       allIds: []
     }
     const afterState: ITeamsState = {
+      status: "initial",
       copying: true,
       byId: {},
       allIds: []

--- a/frontend/src/store/reducers/teams.test.ts
+++ b/frontend/src/store/reducers/teams.test.ts
@@ -122,7 +122,7 @@ describe("Teams", () => {
       }
     ]
 
-    const afterState = {
+    const afterState: ITeamsState = {
       byId: {
         1: {
           id: 1,
@@ -147,7 +147,7 @@ describe("Teams", () => {
         }
       },
       allIds: [1, 4, 2, 3],
-      loading: false
+      status: "success"
     }
 
     expect(teams(beforeState, fetchTeams.success(data))).toEqual(afterState)

--- a/frontend/src/store/reducers/teams.ts
+++ b/frontend/src/store/reducers/teams.ts
@@ -122,7 +122,7 @@ export interface ITeam {
 
 export interface ITeamsState {
   readonly allIds: number[]
-  readonly loading?: boolean
+  readonly status: "initial" | "loading" | "failure" | "success" | "refetching"
   readonly creating?: boolean
   readonly copying?: boolean
   readonly moving?: boolean
@@ -152,7 +152,8 @@ function mapById(
 // TODO(sbdchd): teams should use WebData<T>
 const initialState: ITeamsState = {
   byId: {},
-  allIds: []
+  allIds: [],
+  status: "initial"
 }
 
 export const teams = (
@@ -284,7 +285,7 @@ export const teams = (
     case getType(fetchTeams.success):
       return {
         ...state,
-        loading: false,
+        status: "success",
         byId: action.payload.reduce(
           (a, b) => ({
             ...a,
@@ -300,8 +301,10 @@ export const teams = (
     case getType(fetchTeams.request):
       return {
         ...state,
-        loading: true
+        status: state.status === "initial" ? "loading" : "refetching"
       }
+    case getType(fetchTeams.failure):
+      return { ...state, status: "failure" }
     case getType(setTeam):
       return {
         ...state,


### PR DESCRIPTION
Previously we had a `loading: boolean` for the teams info which meant
that even if the UI was refetching the data, it would show loading.

Now we have a more descriptive type so we show the stale data while we
refetch.