### PR TITLE
fix(ical): support subscribing to calendars on iOS

### DIFF
--- a/backend/core/ical/test_ical_views.py
+++ b/backend/core/ical/test_ical_views.py
@@ -104,3 +104,18 @@ def test_ical_view_with_correct_id(
         "END:VEVENT\r\n"
         "END:VCALENDAR\r\n"
     )
+
+
+def test_get_ical_view_works_with_accept_encoding(
+    client: APIClient, user: MyUser, recipe: Recipe, team: Team
+) -> None:
+    """
+    Clicking an .ics link on iOS will trigger iOS to make a GET request to
+    the URL with accept header set to `text/calendar`.
+
+    When the view is setup using DRF this fails and returns a 406, which
+    prevents the Calendar app from using the "subscribed" calendar.
+    """
+    url = f"/t/{team.id}/ical/{team.ical_id}/schedule.ics"
+    res = client.get(url, HTTP_ACCEPT="text/calendar")
+    assert res.status_code == status.HTTP_200_OK

--- a/backend/core/ical/views.py
+++ b/backend/core/ical/views.py
@@ -1,21 +1,18 @@
 from datetime import timedelta
 from typing import Optional
 
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.http import http_date
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
-from rest_framework.request import Request
+from django.views.decorators.http import require_http_methods
 
 from core.ical.utils import create_calendar, create_event
 from core.models import ScheduledRecipe, Team
 
 
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def get_ical_view(request: Request, team_id: int, ical_id: str) -> HttpResponse:
+@require_http_methods(["GET", "HEAD"])
+def get_ical_view(request: HttpRequest, team_id: int, ical_id: str) -> HttpResponse:
     """
     Return an icalendar formatted string of scheduled recipes.
 


### PR DESCRIPTION
We were using DRF for this endpoint which didn't like it when iOS sent
a request with an accept header set to `text/calendar` and returned a
406. This meant adding calendars on iOS would fail.

Easy enough fix, don't use DRF, use plain Django.

Also update the endpoint to allow HEAD requests.