### PR TITLE
ref(ui): ingredient component to use hooks

### DIFF
--- a/frontend/src/components/AddRecipe.tsx
+++ b/frontend/src/components/AddRecipe.tsx
@@ -4,7 +4,7 @@ import { Helmet } from "@/components/Helmet"
 import ListItem from "@/components/ListItem"
 import AddIngredientForm from "@/components/AddIngredientForm"
 import AddStepForm from "@/components/AddStepForm"
-import Ingredient from "@/components/Ingredient"
+import { Ingredient } from "@/components/Ingredient"
 import { ButtonPrimary, Button } from "@/components/Buttons"
 import {
   IStepBasic,

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -5,7 +5,7 @@ import Loader from "@/components/Loader"
 import AddStep from "@/components/AddStep"
 import AddIngredient from "@/components/AddIngredient"
 import StepContainer from "@/components/StepContainer"
-import Ingredient from "@/components/Ingredient"
+import { Ingredient } from "@/components/Ingredient"
 import RecipeTitle from "@/components/RecipeTitle"
 import { RouteComponentProps } from "react-router"
 import {

--- a/tslint.json
+++ b/tslint.json
@@ -26,6 +26,7 @@
   },
   "rules": {
     "react-anchor-blank-noopener": true,
+    "interface-over-type-literal": false,
     "object-index-must-return-possibly-undefined": true,
     "unnecessary-else": true,
     "no-implicit-to-string": false,


### PR DESCRIPTION
This is in preparation for adding positioning & drag and drop to
ingredients along with sections. The hooks api for React DND is much
nicer to work with.

I also changed the export from a default to a named export.

Also disable the tslint rule since `type` has inferred index signatures
making it support more features than interface.