### PR TITLE
add(ui): drag and drop for reordering ingredients

### DIFF
--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -318,6 +318,25 @@ def test_updating_ingredient_of_recipe(client, user, recipe):
     assert res.json().get("name") == ingredient.get("name"), "ingredient didn't update"
 
 
+def test_updating_ingredient_position(client, user, recipe):
+    """
+    ensure we can update the position, necessary for drag and drop in the ui
+    """
+    client.force_authenticate(user)
+
+    ingredient = recipe.ingredients[0]
+
+    data = {"position": 15}
+    assert data["position"] != ingredient.position
+
+    res = client.patch(
+        f"/api/v1/recipes/{recipe.id}/ingredients/{ingredient.id}/", data
+    )
+    assert res.status_code == status.HTTP_200_OK
+    ingredient.refresh_from_db()
+    assert res.json()["position"] == data["position"] == ingredient.position
+
+
 def test_deleting_ingredient_from_recipe(client, user, recipe):
     """
     ensure a user can remove a ingredient from a recipe

--- a/frontend/src/components/AddRecipe.tsx
+++ b/frontend/src/components/AddRecipe.tsx
@@ -249,6 +249,7 @@ export default class AddRecipe extends React.Component<
                 <Ingredient
                   key={x.name + i}
                   recipeID={-1}
+                  index={i}
                   id={i}
                   update={(ingre: IIngredientBasic) =>
                     this.props.updateIngredient(i, ingre)

--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -198,12 +198,7 @@ export function Ingredient(props: {
   const [{ isDragging }, drag, preview] = useDrag({
     item: {
       type: DragDrop.INGREDIENT,
-      id: props.id,
-      index: props.index,
-      position: props.index,
-      data: {
-        foo: "bar"
-      }
+      index: props.index
     },
     end: () => {
       props.completeMove?.({ id: props.id, to: props.index })

--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -192,7 +192,7 @@ export function Ingredient(props: {
 
   const [, drop] = useDrop({
     accept: DragDrop.INGREDIENT,
-    hover: handleDndHover({ ref, props })
+    hover: handleDndHover({ ref, index: props.index, move: props.move })
   })
 
   const [{ isDragging }, drag, preview] = useDrag({

--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonLink } from "@/components/Buttons"
 import { TextInput, selectTarget, CheckBox } from "@/components/Forms"
 import { hasSelection } from "@/utils/general"
 import { useDrop, useDrag } from "react-dnd"
-import { DragDrop } from "@/dragDrop"
+import { DragDrop, handleDndHover } from "@/dragDrop"
 
 const emptyField = ({
   quantity,
@@ -192,61 +192,7 @@ export function Ingredient(props: {
 
   const [, drop] = useDrop({
     accept: DragDrop.INGREDIENT,
-    hover: (_item, monitor) => {
-      if (!ref.current) {
-        return
-      }
-
-      // tslint:disable-next-line:no-unsafe-any
-      const dragIndex: number = monitor.getItem().index
-      const hoverIndex = props.index
-
-      // Don't replace items with themselves
-      if (dragIndex === hoverIndex) {
-        return
-      }
-
-      // Determine rectangle on screen
-      const el = ref.current
-      const hoverBoundingRect = el.getBoundingClientRect()
-
-      // Get vertical middle
-      const hoverMiddleY =
-        (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
-
-      // Determine mouse position
-      const clientOffset = monitor.getClientOffset()
-      if (clientOffset == null) {
-        return
-      }
-
-      // Get pixels to the top
-      const hoverClientY = clientOffset.y - hoverBoundingRect.top
-
-      // Only perform the move when the mouse has crossed half of the items height
-      // When dragging downwards, only move when the cursor is below 50%
-      // When dragging upwards, only move when the cursor is above 50%
-
-      // Dragging downwards
-      if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
-        return
-      }
-
-      // Dragging upwards
-      if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
-        return
-      }
-
-      // Time to actually perform the action
-      props.move?.({ from: dragIndex, to: hoverIndex })
-
-      // Note: we're mutating the monitor item here!
-      // Generally it's better to avoid mutations,
-      // but it's good here for the sake of performance
-      // to avoid expensive index searches.
-      // tslint:disable-next-line:no-unsafe-any
-      monitor.getItem().index = hoverIndex
-    }
+    hover: handleDndHover({ ref, props })
   })
 
   const [{ isDragging }, drag, preview] = useDrag({

--- a/frontend/src/components/IngredientView.test.tsx
+++ b/frontend/src/components/IngredientView.test.tsx
@@ -17,6 +17,7 @@ describe("<IngredientView/>", () => {
         .create(
           <TestProvider>
             <IngredientView
+              dragRef={undefined}
               quantity={quantity}
               name="salt"
               optional={false}

--- a/frontend/src/components/IngredientView.tsx
+++ b/frontend/src/components/IngredientView.tsx
@@ -1,24 +1,27 @@
 import React from "react"
 import { IIngredient } from "@/store/reducers/recipes"
 import { capitalizeUnits } from "@/text"
+import { DragElementWrapper, DragSourceOptions } from "react-dnd"
 
 interface IIngredientVIewProps {
   readonly quantity: IIngredient["quantity"]
   readonly name: IIngredient["name"]
   readonly description: IIngredient["description"]
   readonly optional: IIngredient["optional"]
+  readonly dragRef: DragElementWrapper<DragSourceOptions> | undefined
 }
 
 export default function IngredientView({
   quantity,
   name,
   description,
-  optional
+  optional,
+  dragRef
 }: IIngredientVIewProps) {
   const fmtDescription = description ? ", " + description : ""
 
   return (
-    <p className="listitem-text justify-space-between">
+    <p className="listitem-text justify-space-between" ref={dragRef}>
       {capitalizeUnits(quantity)} {name}
       {fmtDescription}{" "}
       {optional ? <span className="text-muted">[optional]</span> : ""}

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -24,6 +24,8 @@ import queryString from "query-string"
 import { RecipeTimeline } from "@/components/RecipeTimeline"
 import { useDispatch, useSelector } from "@/hooks"
 import { NoteContainer } from "@/components/Notes"
+import { getNewPos } from "@/position"
+import sortBy from "lodash/sortBy"
 
 interface IRecipeDetailsProps {
   readonly recipe: IRecipe
@@ -33,15 +35,67 @@ function RecipeDetails({ recipe }: IRecipeDetailsProps) {
   const [addStep, setAddStep] = React.useState(false)
   const dispatch = useDispatch()
 
+  const [ingredients, setIngre] = React.useState(recipe.ingredients)
+  React.useEffect(() => {
+    setIngre(sortBy(recipe.ingredients, "position"))
+  }, [recipe.ingredients])
+
+  const handleMove = ({
+    from,
+    to
+  }: {
+    readonly from: number
+    readonly to: number
+  }) => {
+    setIngre(prev => {
+      const newIngredients = [...prev]
+      const item = newIngredients[from]
+      newIngredients.splice(from, 1)
+      newIngredients.splice(to, 0, item)
+      return newIngredients
+    })
+  }
+
+  const handleCompleteMove = (args: {
+    readonly id: number
+    readonly to: number
+  }) => {
+    const newPosition = getNewPos(ingredients, args.to)
+    if (newPosition == null) {
+      return
+    }
+    setIngre(prev =>
+      prev.map(ingre => {
+        if (ingre.id === args.id) {
+          return {
+            ...ingre,
+            position: newPosition
+          }
+        }
+        return ingre
+      })
+    )
+    dispatch(
+      updateIngredient.request({
+        recipeID: recipe.id,
+        ingredientID: args.id,
+        content: { position: newPosition }
+      })
+    )
+  }
+
   return (
     <section className="ingredients-preparation-grid">
       <div>
         <SectionTitle>Ingredients</SectionTitle>
         <ul>
-          {recipe.ingredients.map(ingre => {
-            const handleUpdate = (
-              ingredient: Omit<IIngredient, "id" | "position">
-            ) =>
+          {ingredients.map((ingre, i) => {
+            const handleUpdate = (ingredient: {
+              readonly quantity: string
+              readonly name: string
+              readonly description: string
+              readonly optional: boolean
+            }) =>
               dispatch(
                 updateIngredient.request({
                   recipeID: recipe.id,
@@ -61,6 +115,7 @@ function RecipeDetails({ recipe }: IRecipeDetailsProps) {
             return (
               <Ingredient
                 key={ingre.id}
+                index={i}
                 recipeID={recipe.id}
                 id={ingre.id}
                 quantity={ingre.quantity}
@@ -71,6 +126,8 @@ function RecipeDetails({ recipe }: IRecipeDetailsProps) {
                 removing={ingre.removing}
                 description={ingre.description}
                 optional={ingre.optional}
+                completeMove={handleCompleteMove}
+                move={handleMove}
               />
             )
           })}

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -10,7 +10,6 @@ import RecipeTitle from "@/components/RecipeTitle"
 import { RouteComponentProps } from "react-router"
 import {
   IRecipe,
-  IIngredient,
   getRecipeById,
   fetchRecipe,
   deleteIngredient,

--- a/frontend/src/components/Step.tsx
+++ b/frontend/src/components/Step.tsx
@@ -58,7 +58,7 @@ function Step({ text, index, ...props }: IStepProps) {
   const ref = useRef<HTMLDivElement>(null)
   const [, drop] = useDrop({
     accept: DragDrop.STEP,
-    hover: handleDndHover({ ref, props: { index, move: props.move } })
+    hover: handleDndHover({ ref, index, move: props.move })
   })
 
   const [{ isDragging }, drag, preview] = useDrag({

--- a/frontend/src/components/Step.tsx
+++ b/frontend/src/components/Step.tsx
@@ -64,18 +64,14 @@ function Step({ text, index, ...props }: IStepProps) {
   const [{ isDragging }, drag, preview] = useDrag({
     item: {
       type: DragDrop.STEP,
-      id: props.id,
-      index,
-      position: props.position
+      index
     },
     end: () => {
       props.completeMove(props.id, index)
     },
-    collect: monitor => {
-      return {
-        isDragging: monitor.isDragging()
-      }
-    }
+    collect: monitor => ({
+      isDragging: monitor.isDragging()
+    })
   })
 
   const style = {

--- a/frontend/src/components/StepContainer.tsx
+++ b/frontend/src/components/StepContainer.tsx
@@ -60,12 +60,12 @@ function StepContainer(props: IStepContainerProps) {
     setSteps(sortBy(props.steps, "position"))
   }, [props.steps])
 
-  const move = (dragIndex: number, hoverIndex: number) =>
+  const move = ({ from, to }: { readonly to: number; readonly from: number }) =>
     setSteps(prevSteps => {
-      const dragCard = steps[dragIndex]
+      const dragCard = steps[from]
       const newSteps = [...prevSteps]
-      newSteps.splice(dragIndex, 1)
-      newSteps.splice(hoverIndex, 0, dragCard)
+      newSteps.splice(from, 1)
+      newSteps.splice(to, 0, dragCard)
       return newSteps
     })
 

--- a/frontend/src/components/StepContainer.tsx
+++ b/frontend/src/components/StepContainer.tsx
@@ -61,11 +61,11 @@ function StepContainer(props: IStepContainerProps) {
   }, [props.steps])
 
   const move = ({ from, to }: { readonly to: number; readonly from: number }) =>
-    setSteps(prevSteps => {
-      const dragCard = steps[from]
-      const newSteps = [...prevSteps]
+    setSteps(prev => {
+      const newSteps = [...prev]
+      const item = newSteps[from]
       newSteps.splice(from, 1)
-      newSteps.splice(to, 0, dragCard)
+      newSteps.splice(to, 0, item)
       return newSteps
     })
 
@@ -102,7 +102,7 @@ function StepContainer(props: IStepContainerProps) {
           id={card.id}
           recipeID={props.recipeID}
           text={card.text}
-          moveStep={move}
+          move={move}
           position={card.position}
           updating={card.updating}
           removing={card.removing}

--- a/frontend/src/components/StepContainer.tsx
+++ b/frontend/src/components/StepContainer.tsx
@@ -35,6 +35,7 @@ import { connect } from "react-redux"
 import Step from "@/components/Step"
 import { IRecipe, IStep, updateStep } from "@/store/reducers/recipes"
 import sortBy from "lodash/sortBy"
+import { getNewPos } from "@/position"
 
 interface IStepContainerProps {
   readonly steps: ReadonlyArray<IStep>
@@ -52,32 +53,6 @@ interface IStepContainerProps {
   }) => void
 }
 
-interface IListItem {
-  readonly position: number
-}
-
-function getNewPos(
-  list: ReadonlyArray<IListItem>,
-  index: number
-): number | null {
-  const nextCard = list[index + 1]
-  const prevCard = list[index - 1]
-  if (nextCard == null && prevCard == null) {
-    // there is only one card in the list, so we don't make any change
-    return null
-  }
-  if (nextCard == null && prevCard != null) {
-    return prevCard.position + 10.0
-  }
-  if (nextCard != null && prevCard == null) {
-    return nextCard.position / 2
-  }
-  if (nextCard != null && prevCard != null) {
-    return (nextCard.position - prevCard.position) / 2 + prevCard.position
-  }
-  return null
-}
-
 function StepContainer(props: IStepContainerProps) {
   const [steps, setSteps] = React.useState(props.steps)
 
@@ -85,16 +60,14 @@ function StepContainer(props: IStepContainerProps) {
     setSteps(sortBy(props.steps, "position"))
   }, [props.steps])
 
-  const move = (dragIndex: number, hoverIndex: number) => {
-    const dragCard = steps[dragIndex]
-
+  const move = (dragIndex: number, hoverIndex: number) =>
     setSteps(prevSteps => {
+      const dragCard = steps[dragIndex]
       const newSteps = [...prevSteps]
       newSteps.splice(dragIndex, 1)
       newSteps.splice(hoverIndex, 0, dragCard)
       return newSteps
     })
-  }
 
   const completeMove = (stepID: number, arrIndex: number) => {
     const newPosition = getNewPos(steps, arrIndex)

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -821,7 +821,14 @@ exports[`<Recipe/> snaps recipe all states 2`] = `
         Ingredients
       </h2>
       <ul>
-        <li>
+        <li
+          style={
+            Object {
+              "backgroundColor": "white",
+              "opacity": 1,
+            }
+          }
+        >
           <section
             className="cursor-pointer"
             onClick={[Function]}

--- a/frontend/src/dragDrop.ts
+++ b/frontend/src/dragDrop.ts
@@ -9,19 +9,18 @@ export const enum DragDrop {
 
 export const handleDndHover = ({
   ref,
-  props
+  index,
+  move
 }: {
   readonly ref: React.RefObject<HTMLElement>
-  readonly props: {
-    readonly index: number
-    readonly move?: ({
-      from,
-      to
-    }: {
-      readonly from: number
-      readonly to: number
-    }) => void
-  }
+  readonly index: number
+  readonly move?: ({
+    from,
+    to
+  }: {
+    readonly from: number
+    readonly to: number
+  }) => void
 }) => (_item: DragObjectWithType, monitor: DropTargetMonitor) => {
   if (!ref.current) {
     return
@@ -29,7 +28,7 @@ export const handleDndHover = ({
 
   // tslint:disable-next-line:no-unsafe-any
   const dragIndex: number = monitor.getItem().index
-  const hoverIndex = props.index
+  const hoverIndex = index
 
   // Don't replace items with themselves
   if (dragIndex === hoverIndex) {
@@ -67,7 +66,7 @@ export const handleDndHover = ({
   }
 
   // Time to actually perform the action
-  props.move?.({ from: dragIndex, to: hoverIndex })
+  move?.({ from: dragIndex, to: hoverIndex })
 
   // Note: we're mutating the monitor item here!
   // Generally it's better to avoid mutations,

--- a/frontend/src/dragDrop.ts
+++ b/frontend/src/dragDrop.ts
@@ -1,6 +1,78 @@
+import { DragObjectWithType, DropTargetMonitor } from "react-dnd"
+
 export const enum DragDrop {
   RECIPE = "RECIPE",
   CAL_RECIPE = "CAL_RECIPE",
   STEP = "STEP",
   INGREDIENT = "INGREDIENT"
+}
+
+export const handleDndHover = ({
+  ref,
+  props
+}: {
+  readonly ref: React.RefObject<HTMLElement>
+  readonly props: {
+    readonly index: number
+    readonly move?: ({
+      from,
+      to
+    }: {
+      readonly from: number
+      readonly to: number
+    }) => void
+  }
+}) => (_item: DragObjectWithType, monitor: DropTargetMonitor) => {
+  if (!ref.current) {
+    return
+  }
+
+  // tslint:disable-next-line:no-unsafe-any
+  const dragIndex: number = monitor.getItem().index
+  const hoverIndex = props.index
+
+  // Don't replace items with themselves
+  if (dragIndex === hoverIndex) {
+    return
+  }
+
+  // Determine rectangle on screen
+  const el = ref.current
+  const hoverBoundingRect = el.getBoundingClientRect()
+
+  // Get vertical middle
+  const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2
+
+  // Determine mouse position
+  const clientOffset = monitor.getClientOffset()
+  if (clientOffset == null) {
+    return
+  }
+
+  // Get pixels to the top
+  const hoverClientY = clientOffset.y - hoverBoundingRect.top
+
+  // Only perform the move when the mouse has crossed half of the items height
+  // When dragging downwards, only move when the cursor is below 50%
+  // When dragging upwards, only move when the cursor is above 50%
+
+  // Dragging downwards
+  if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+    return
+  }
+
+  // Dragging upwards
+  if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+    return
+  }
+
+  // Time to actually perform the action
+  props.move?.({ from: dragIndex, to: hoverIndex })
+
+  // Note: we're mutating the monitor item here!
+  // Generally it's better to avoid mutations,
+  // but it's good here for the sake of performance
+  // to avoid expensive index searches.
+  // tslint:disable-next-line:no-unsafe-any
+  monitor.getItem().index = hoverIndex
 }

--- a/frontend/src/dragDrop.ts
+++ b/frontend/src/dragDrop.ts
@@ -1,5 +1,6 @@
 export const enum DragDrop {
   RECIPE = "RECIPE",
   CAL_RECIPE = "CAL_RECIPE",
-  STEP = "STEP"
+  STEP = "STEP",
+  INGREDIENT = "INGREDIENT"
 }

--- a/frontend/src/position.ts
+++ b/frontend/src/position.ts
@@ -1,0 +1,21 @@
+export function getNewPos(
+  list: ReadonlyArray<{ readonly position: number }>,
+  index: number
+): number | null {
+  const nextCard = list[index + 1]
+  const prevCard = list[index - 1]
+  if (nextCard == null && prevCard == null) {
+    // there is only one card in the list, so we don't make any change
+    return null
+  }
+  if (nextCard == null && prevCard != null) {
+    return prevCard.position + 10.0
+  }
+  if (nextCard != null && prevCard == null) {
+    return nextCard.position / 2
+  }
+  if (nextCard != null && prevCard != null) {
+    return (nextCard.position - prevCard.position) / 2 + prevCard.position
+  }
+  return null
+}

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -166,7 +166,7 @@ export const deleteIngredient = createAsyncAction(
 interface IUpdateIngredientArg {
   recipeID: IRecipe["id"]
   ingredientID: IIngredient["id"]
-  content: Partial<Omit<IIngredient, "id" | "position">>
+  content: Partial<Omit<IIngredient, "id">>
 }
 
 export const updateIngredient = createAsyncAction(
@@ -1128,7 +1128,8 @@ export const recipes = (
             if (x.id === action.payload.ingredientID) {
               return {
                 ...x,
-                updating: true
+                updating: true,
+                position: action.payload.content.position ?? x.position
               }
             }
             return x


### PR DESCRIPTION
There was already a position field so this adds the UI to change that
field via drag and drop.

We do something similar with the recipe steps.

Didn't do the string based ordering, although we might want it when we
add sections.

rel: https://github.com/recipeyak/recipeyak/pull/130
rel: https://steve.dignam.xyz/2020/03/31/practical-ordering/