### PR TITLE
ref(frontend): scripts to use bash instead of python cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
   frontend_test:
     docker:
-      - image: recipeyak/base:v3
+      - image: circleci/node:12.4.0
     steps:
       - checkout
       - restore_cache:
@@ -101,10 +101,6 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
-            # Use our new PATH so we can call poetry from bash
-            source $BASH_ENV
-            poetry install
             yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
@@ -113,11 +109,11 @@ jobs:
           key: frontend-v8-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
-          command: poetry run yak test --web
+          command: ./frontend/s/test
 
   frontend_lint:
     docker:
-      - image: recipeyak/base:v3
+      - image: circleci/node:12.4.0
     steps:
       - checkout
       - restore_cache:
@@ -126,10 +122,6 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
-            # Use our new PATH so we can call poetry from bash
-            source $BASH_ENV
-            poetry install
             yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
       - save_cache:
           paths:
@@ -139,8 +131,8 @@ jobs:
       - run:
           name: run linter
           command: |
-            poetry run yak lint --web
-            poetry run yak build --web
+            ./frontend/s/lint
+            ./frontend/s/build
       - run:
           name: move artifacts
           working_directory: frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,16 +97,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v8-dependencies-{{ checksum "yarn.lock" }}
+            - frontend-v9-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: |
-            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
+            yarn install --frozen-lockfile --non-interactive
       - save_cache:
           paths:
-            - /root/project/node_modules
-            - /root/.cache/
-          key: frontend-v8-dependencies-{{ checksum "yarn.lock" }}
+            - ./node_modules
+          key: frontend-v9-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: run tests
           command: ./frontend/s/test
@@ -118,16 +117,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - frontend-v8-dependencies-{{ checksum "yarn.lock" }}
+            - frontend-v9-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: install dependencies
           command: |
-            yarn install --frozen-lockfile --cache-folder /root/.cache/yarn
+            yarn install --frozen-lockfile --non-interactive
       - save_cache:
           paths:
-            - /root/project/node_modules
-            - /root/.cache/
-          key: frontend-v8-dependencies-{{ checksum "yarn.lock" }}
+            - ./node_modules
+          key: frontend-v9-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: run linter
           command: |

--- a/frontend/s/build
+++ b/frontend/s/build
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ex
+
+main() {
+  node frontend/scripts/build.js
+  bash frontend/scripts/crawl.sh
+}
+
+main "$@"

--- a/frontend/s/lint
+++ b/frontend/s/lint
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+
+main() {
+  if [ "$CI" ]; then
+    node_modules/.bin/prettier '**/*.{js,jsx,scss,css,ts,tsx,json,yaml,yml,md}' --list-different
+    node_modules/.bin/eslint '**/*.{ts,tsx,js,jsx}'
+  else
+    node_modules/.bin/prettier '**/*.{js,jsx,scss,css,ts,tsx,json,yaml,yml,md}' --write
+    node_modules/.bin/eslint '**/*.{ts,tsx,js,jsx}' --fix
+  fi
+
+  node_modules/.bin/tslint --project tsconfig.json --format 'codeFrame'
+  node_modules/.bin/tsc --noEmit
+}
+
+main "$@"

--- a/frontend/s/test
+++ b/frontend/s/test
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+main() {
+  if [ "$CI" ]; then
+    node ./scripts/test.js --env=jsdom --coverage --runInBand
+  else
+    node ./scripts/test.js --env=jsdom --watch "$@"
+  fi
+}
+
+main "$@"

--- a/frontend/s/test
+++ b/frontend/s/test
@@ -3,9 +3,9 @@ set -ex
 
 main() {
   if [ "$CI" ]; then
-    node ./scripts/test.js --env=jsdom --coverage --runInBand
+    node ./frontend/scripts/test.js --env=jsdom --coverage --runInBand
   else
-    node ./scripts/test.js --env=jsdom --watch "$@"
+    node ./frontend/scripts/test.js --env=jsdom --watch "$@"
   fi
 }
 

--- a/frontend/s/typecheck
+++ b/frontend/s/typecheck
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+
+main() {
+  node_modules/.bin/tsc --noEmit "$@"
+}
+
+main "$@"


### PR DESCRIPTION
We need to update nodejs for the eslint upgrade but that is more
complicated than it should be because we're using the python cli for
frontend related tasks.

In another PR we can remove the frontend portion of the cli.