### PR TITLE
fix(ui): clicking on recipe source link opening edit mode

### DIFF
--- a/frontend/src/components/MetaData.tsx
+++ b/frontend/src/components/MetaData.tsx
@@ -71,7 +71,7 @@ const MetaData = ({
   const _source = isValid(source) ? (
     <MetaPiece>
       from{" "}
-      <MetaBold onClick={onClick}>
+      <MetaBold>
         <SourceLink>{source}</SourceLink>
       </MetaBold>{" "}
     </MetaPiece>

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -279,7 +279,7 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
            
           <b
             className="cursor-pointer"
-            onClick={[Function]}
+            onClick={undefined}
             title="click  to edit"
           >
             <a
@@ -673,7 +673,7 @@ exports[`<Recipe/> snaps recipe all states 2`] = `
            
           <b
             className="cursor-pointer"
-            onClick={[Function]}
+            onClick={undefined}
             title="click  to edit"
           >
             <a


### PR DESCRIPTION
Previously, clicking on the link would open the edit mode while the
browser transitions you to the link's source.

Now we don't handle the click, so the edit panel isn't opened.