### PR TITLE
fix(ui): hover handling for calendar items

### DIFF
--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -94,7 +94,7 @@ export function CalendarItem({
   id
 }: ICalendarItemProps) {
   const [count, setCount] = React.useState(propsCount)
-  const [hover, setHover] = React.useState(false)
+  const ref = React.useRef<HTMLLIElement>(null)
 
   React.useEffect(() => {
     setCount(propsCount)
@@ -116,7 +116,7 @@ export function CalendarItem({
   }
 
   const handleKeyPress = (e: KeyboardEvent) => {
-    if (!hover) {
+    if (!ref.current?.matches(":hover")) {
       return
     }
 
@@ -137,9 +137,6 @@ export function CalendarItem({
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     updateCount(parseInt(e.target.value, 10))
-
-  const handleMouseEnter = () => setHover(true)
-  const handleMouseLeave = () => setHover(false)
 
   const dragItem: ICalendarDragItem = {
     type: DragDrop.CAL_RECIPE,
@@ -169,12 +166,10 @@ export function CalendarItem({
 
   useGlobalEvent({ keyUp: handleKeyPress })
 
+  drag(ref)
+
   return (
-    <CalendarListItem
-      ref={drag}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      visibility={visibility}>
+    <CalendarListItem ref={ref} visibility={visibility}>
       <RecipeLink name={recipeName} id={recipeID} />
       <Count value={count} onChange={handleChange} />
     </CalendarListItem>

--- a/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
@@ -35,8 +35,6 @@ exports[`<CalendarDayItem> Snap smoke test render with styled components 1`] = `
 
 <li
   className="c0"
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
   visibility="visible"
 >
   <a


### PR DESCRIPTION
We were depending on the mouseEvent and mouseLeave events to fire to
keep track of the hover state for scheduled recipes.

This works okay when deleting a single item as when you drag your mouse
over to the item, the onMouseEnter handler fires.

However, when you have a couple items on the same day and delete the
first one, the next item will move up in the calendar day and the event
handlers won't fire. So the component will have its hover state set to
false when we are in fact hovering.

Instead of keeping track of hover state ourselves, we instead query the
DOM with `.matches()`

https://developer.mozilla.org/en-US/docs/Web/API/Element/matches