### PR TITLE
add(ui): links in notes

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -21,12 +21,14 @@ const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "strong",
   "emphasis",
   "list",
+  "linkReference",
+  "link",
   "listItem"
 ]
 
 interface IMarkdownProps {
   readonly children: string
-  readonly onClick?: () => void
+  readonly onClick?: (_: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   readonly className?: string
   readonly title?: string
 }

--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -18,7 +18,6 @@ import { isSuccessLike } from "@/webdata"
 import orderBy from "lodash/orderBy"
 import Textarea from "react-textarea-autosize"
 import { Markdown } from "@/components/Markdown"
-import { Link } from "@/components/Routing"
 
 interface IUseNoteEditHandlers {
   readonly note: INote

--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -18,6 +18,7 @@ import { isSuccessLike } from "@/webdata"
 import orderBy from "lodash/orderBy"
 import Textarea from "react-textarea-autosize"
 import { Markdown } from "@/components/Markdown"
+import { Link } from "@/components/Routing"
 
 interface IUseNoteEditHandlers {
   readonly note: INote
@@ -69,7 +70,12 @@ function useNoteEditHandlers({ note, recipeId }: IUseNoteEditHandlers) {
   const onEditorChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setNewText(e.target.value)
   }
-  const onNoteClick = () => {
+  const onNoteClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Opening edit when a user clicks links results in weird looking UI as edit
+    // opens right as they are navigating away navigation.
+    if (e.target instanceof Element && e.target.tagName === "A") {
+      return
+    }
     setEditing(true)
   }
   return {


### PR DESCRIPTION
Enable links as valid types in the markdown renderer.

Handle the case when a user clicks a link in the markdown component such
that we don't open edits.