### PR TITLE
add(ui): linking directly to notes in recipes

### DIFF
--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -18,6 +18,7 @@ import { isSuccessLike } from "@/webdata"
 import orderBy from "lodash/orderBy"
 import Textarea from "react-textarea-autosize"
 import { Markdown } from "@/components/Markdown"
+import { useLocation } from "react-router-dom"
 
 interface IUseNoteEditHandlers {
   readonly note: INote
@@ -119,12 +120,35 @@ export function Note({ recipeId, note, className }: INoteProps) {
     onNoteClick,
     onSave
   } = useNoteEditHandlers({ note, recipeId })
+
+  const ref = React.useRef<HTMLDivElement>(null)
+  const noteId = `note-${note.id}`
+  const location = useLocation()
+  const isSharedNote = location.hash === `#${noteId}`
+
+  React.useEffect(() => {
+    if (isSharedNote) {
+      ref.current?.scrollIntoView()
+    }
+  }, [isSharedNote])
   return (
-    <div className={classNames("d-flex align-items-start", className)}>
+    <div
+      ref={ref}
+      className={classNames(
+        "d-flex align-items-start",
+        {
+          "bg-highlight": isSharedNote
+        },
+        className
+      )}
+      id={noteId}>
       <Avatar avatarURL={note.created_by.avatar_url} className="mr-2" />
       <div className="w-100">
         <p>
-          {note.created_by.email} | <NoteTimeStamp created={note.created} />
+          {note.created_by.email} |{" "}
+          <a href={`#${noteId}`}>
+            <NoteTimeStamp created={note.created} />
+          </a>
         </p>
         {!isEditing ? (
           <Markdown

--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -350,6 +350,21 @@
   background-color: white;
 }
 
+.bg-highlight {
+  animation: bg-highlighted-fade 3s;
+  animation-timing-function: ease-out;
+}
+
+@keyframes bg-highlighted-fade {
+  0% {
+    background-color: rgba(251, 242, 212, 1);
+  }
+
+  100% {
+    background-color: rgba(0, 0, 0, 0);
+  }
+}
+
 .height-100 {
   height: 100%;
 }


### PR DESCRIPTION
On component mount we check if the hash is equal to the note id, if it
is we add the class to highlight the comment.

Initially tried using a `:target` pseudo selector approach but that
didn't end up working because we aren't SSR so we have a spinner and
the browser doesn't highlight the `:target` if it isn't initially in
the html it seems.