### PR TITLE
fix: request.is_secure returning incorrect info due to proxy

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -78,6 +78,11 @@ REST_FRAMEWORK = {
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
 
+# Ensure request.is_secure returns true with the correct header since we're
+# running behind a proxy
+# see: https://docs.djangoproject.com/en/2.2/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # https://stackoverflow.com/questions/25468676/django-sites-model-what-is-and-why-is-site-id-1#25468782
 SITE_ID = 1
 


### PR DESCRIPTION
We run the django server behind nginx so to get the require.is_secure
to work we have to configure the forwarded header.