### PR TITLE
tools(prettier): update config to include more commas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,13 @@ module.exports = {
     sourceType: "module",
     project: "./tsconfig.json",
     ecmaFeatures: {
-      jsx: true
-    }
+      jsx: true,
+    },
   },
   plugins: ["html", "react", "react-hooks", "@typescript-eslint", "import"],
   extends: ["prettier"],
   env: {
-    browser: true
+    browser: true,
   },
   rules: {
     "react-hooks/rules-of-hooks": "error",
@@ -25,7 +25,7 @@ module.exports = {
       "name",
       "length",
       "origin",
-      "event"
+      "event",
     ],
     "no-restricted-imports": [
       "error",
@@ -34,28 +34,28 @@ module.exports = {
           {
             name: "redux",
             importNames: ["Dispatch", "useDispatch"],
-            message: "Please import 'Dispatch' from '@/store/thunks' instead."
+            message: "Please import 'Dispatch' from '@/store/thunks' instead.",
           },
           {
             name: "styled-components",
             message:
-              "Please import from '@/theme' for type safe versions of 'styled-components' instead."
+              "Please import from '@/theme' for type safe versions of 'styled-components' instead.",
           },
           {
             name: "typesafe-actions",
             importNames: ["action"],
             message:
-              "Please use 'createStandardAction' or 'createAsyncAction' instead as they allow for easy discrimination with 'getType()'. see: https://github.com/piotrwitek/typesafe-actions#action"
-          }
-        ]
-      }
+              "Please use 'createStandardAction' or 'createAsyncAction' instead as they allow for easy discrimination with 'getType()'. see: https://github.com/piotrwitek/typesafe-actions#action",
+          },
+        ],
+      },
     ],
     "react/self-closing-comp": [
       "error",
       {
         component: true,
-        html: true
-      }
+        html: true,
+      },
     ],
     "no-unneeded-ternary": ["error", { defaultAssignment: false }],
     "@typescript-eslint/no-non-null-assertion": "error",
@@ -70,11 +70,11 @@ module.exports = {
     "@typescript-eslint/consistent-type-assertions": [
       "error",
       {
-        assertionStyle: "never"
-      }
+        assertionStyle: "never",
+      },
     ],
     "react/jsx-key": ["error", { checkFragmentShorthand: true }],
     "react/no-danger": "error",
-    eqeqeq: ["error", "smart"]
-  }
+    eqeqeq: ["error", "smart"],
+  },
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,8 +4,8 @@ module.exports = {
   useTabs: false,
   tabWidth: 2,
   singleQuote: false,
-  trailingComma: "none",
+  trailingComma: "all",
   bracketSpacing: true,
   jsxBracketSameLine: true,
-  arrowParens: "avoid"
+  arrowParens: "avoid",
 }

--- a/frontend/config/env.js
+++ b/frontend/config/env.js
@@ -16,7 +16,7 @@ const WHITELIST = [
 
   "OAUTH_GOOGLE_CLIENT_ID",
 
-  "FRONTEND_SENTRY_DSN"
+  "FRONTEND_SENTRY_DSN",
 ]
 
 /** @typedef IClientEnv
@@ -44,8 +44,8 @@ function getClientEnvironment(publicUrl) {
         // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
         // This should only be used as an escape hatch. Normally you would put
         // images into the `src` and `import` them in code to get their paths.
-        PUBLIC_URL: publicUrl
-      }
+        PUBLIC_URL: publicUrl,
+      },
     )
   // Stringify all values so we can feed into Webpack DefinePlugin
   const stringified = {
@@ -53,7 +53,7 @@ function getClientEnvironment(publicUrl) {
       // @ts-ignore
       env[key] = JSON.stringify(raw[key])
       return env
-    }, {})
+    }, {}),
   }
 
   return { raw, stringified }

--- a/frontend/config/jest/cssTransform.js
+++ b/frontend/config/jest/cssTransform.js
@@ -8,5 +8,5 @@ module.exports = {
   getCacheKey() {
     // The output is always the same.
     return "cssTransform"
-  }
+  },
 }

--- a/frontend/config/jest/fileTransform.js
+++ b/frontend/config/jest/fileTransform.js
@@ -7,5 +7,5 @@ module.exports = {
   /** @param {string} _src @param {string} filename */
   process(_src, filename) {
     return "module.exports = " + JSON.stringify(path.basename(filename)) + ""
-  }
+  },
 }

--- a/frontend/config/open-graph-plugin.js
+++ b/frontend/config/open-graph-plugin.js
@@ -45,10 +45,10 @@ class OpenGraphPlugin {
           const filesToInclude = this.options.map(format).join("\n")
           htmlPluginData.html = htmlPluginData.html.replace(
             "</head>",
-            filesToInclude + "\n</head>"
+            filesToInclude + "\n</head>",
           )
           callbk(null, htmlPluginData)
-        }
+        },
       )
       return callback()
     })

--- a/frontend/config/paths.js
+++ b/frontend/config/paths.js
@@ -80,5 +80,5 @@ module.exports = {
   appNodeModules: resolveApp("node_modules"),
   nodePaths,
   publicUrl: getPublicUrl(resolveApp("../package.json")),
-  servedPath: getServedPath(resolveApp("../package.json"))
+  servedPath: getServedPath(resolveApp("../package.json")),
 }

--- a/frontend/config/webpack.config.dev.js
+++ b/frontend/config/webpack.config.dev.js
@@ -23,7 +23,7 @@ module.exports = {
   devtool: "cheap-module-source-map",
   entry: [
     require.resolve("react-dev-utils/webpackHotDevClient"),
-    paths.appIndexTsx
+    paths.appIndexTsx,
   ],
   output: {
     // Next line is not used in dev but WebpackDevServer crashes without it:
@@ -35,14 +35,14 @@ module.exports = {
     // containing code from all our entry points, and the Webpack runtime.
     filename: "static/js/bundle.js",
     // This is the URL that app is served from. We use "/" in development.
-    publicPath
+    publicPath,
   },
   resolve: {
     modules: ["node_modules", paths.appNodeModules, paths.appSrc],
     extensions: [".js", ".json", ".jsx", ".ts", ".tsx"],
     alias: {
-      "@": paths.appSrc
-    }
+      "@": paths.appSrc,
+    },
   },
 
   module: {
@@ -65,13 +65,13 @@ module.exports = {
           /\.json$/,
           /\.svg$/,
           /\.png$/,
-          /\.jpg$/
+          /\.jpg$/,
         ],
         loader: "url-loader",
         query: {
           limit: 10000,
-          name: "static/media/[name].[hash:8].[ext]"
-        }
+          name: "static/media/[name].[hash:8].[ext]",
+        },
       },
       {
         test: /\.(js|jsx)$/,
@@ -83,9 +83,9 @@ module.exports = {
             // It enables caching results in ./node_modules/.cache/babel-loader/
             // directory for faster rebuilds.
             cacheDirectory: true,
-            plugins: ["react-hot-loader/babel"]
-          }
-        }
+            plugins: ["react-hot-loader/babel"],
+          },
+        },
       },
       {
         test: /\.(ts|tsx)$/,
@@ -98,16 +98,16 @@ module.exports = {
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.
               cacheDirectory: true,
-              plugins: ["react-hot-loader/babel"]
-            }
+              plugins: ["react-hot-loader/babel"],
+            },
           },
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: true
-            }
-          }
-        ]
+              transpileOnly: true,
+            },
+          },
+        ],
       },
       // "postcss" loader applies autoprefixer to our CSS.
       // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -121,8 +121,8 @@ module.exports = {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 1
-            }
+              importLoaders: 1,
+            },
           },
           {
             loader: "postcss-loader",
@@ -135,14 +135,14 @@ module.exports = {
                     ">1%",
                     "last 4 versions",
                     "Firefox ESR",
-                    "not ie < 9" // React doesn't support IE8 anyway
+                    "not ie < 9", // React doesn't support IE8 anyway
                   ],
-                  flexbox: "no-2009"
-                })
-              ]
-            }
-          }
-        ]
+                  flexbox: "no-2009",
+                }),
+              ],
+            },
+          },
+        ],
       },
       {
         test: /\.(scss|sass)$/,
@@ -151,33 +151,33 @@ module.exports = {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 1
-            }
+              importLoaders: 1,
+            },
           },
-          "sass-loader"
-        ]
+          "sass-loader",
+        ],
       },
       {
         test: /\.(svg|png|jpg)$/,
         use: {
           loader: "file-loader",
           query: {
-            name: "static/media/[name].[hash:8].[ext]"
-          }
-        }
-      }
+            name: "static/media/[name].[hash:8].[ext]",
+          },
+        },
+      },
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "url" loader exclusion list.
-    ]
+    ],
   },
   plugins: [
     new InterpolateHtmlPlugin(HtmlWebpackPlugin, env.raw),
     new HtmlWebpackPlugin({
-      template: paths.appHtml
+      template: paths.appHtml,
     }),
     new webpack.DefinePlugin(env.stringified),
     new webpack.HotModuleReplacementPlugin(),
     new CaseSensitivePathsPlugin(),
-    new WatchMissingNodeModulesPlugin(paths.appNodeModules)
-  ]
+    new WatchMissingNodeModulesPlugin(paths.appNodeModules),
+  ],
 }

--- a/frontend/config/webpack.config.prod.js
+++ b/frontend/config/webpack.config.prod.js
@@ -30,14 +30,14 @@ if (env.stringified["process.env"].NODE_ENV !== '"production"') {
 
 const openGraphConfig = {
   title: "RecipeYak",
-  type: "Website"
+  type: "Website",
 }
 
 const faviconConfig = {
   faviconPath: paths.appSrc + "/static/images/logo/recipeyak-logo.svg",
   appName: "RecipeYak",
   themeColor: "#ff7247",
-  backgroundColor: "#fff"
+  backgroundColor: "#fff",
 }
 
 module.exports = {
@@ -46,48 +46,48 @@ module.exports = {
   bail: true,
   devtool: "source-map",
   performance: {
-    hints: false
+    hints: false,
   },
   optimization: {
     splitChunks: {
-      chunks: "all"
+      chunks: "all",
     },
     minimizer: [
       new TerserPlugin({
         terserOptions: {
           compress: {
             comparisons: false,
-            inline: 2 // inline functions with arguments
+            inline: 2, // inline functions with arguments
           },
           output: {
-            ascii_only: true
-          }
+            ascii_only: true,
+          },
         },
         parallel: true,
         cache: true,
-        sourceMap: true
+        sourceMap: true,
       }),
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
           inline: false,
-          annotation: true
-        }
-      })
-    ]
+          annotation: true,
+        },
+      }),
+    ],
   },
   entry: [paths.appIndexTsx],
   output: {
     path: paths.appBuild,
     filename: "static/js/[name].[contenthash:8].js",
     chunkFilename: "static/js/[name].[contenthash:8].chunk.js",
-    publicPath
+    publicPath,
   },
   resolve: {
     modules: ["node_modules", paths.appNodeModules, paths.appSrc],
     extensions: [".js", ".json", ".jsx", ".ts", ".tsx"],
     alias: {
-      "@": paths.appSrc
-    }
+      "@": paths.appSrc,
+    },
   },
 
   module: {
@@ -110,13 +110,13 @@ module.exports = {
           /\.json$/,
           /\.svg$/,
           /\.png$/,
-          /\.jpg$/
+          /\.jpg$/,
         ],
         loader: "url-loader",
         query: {
           limit: 10000,
-          name: "static/media/[name].[hash:8].[ext]"
-        }
+          name: "static/media/[name].[hash:8].[ext]",
+        },
       },
       {
         test: /\.(js|jsx)$/,
@@ -127,9 +127,9 @@ module.exports = {
             // This is a feature of `babel-loader` for webpack (not Babel itself).
             // It enables caching results in ./node_modules/.cache/babel-loader/
             // directory for faster rebuilds.
-            cacheDirectory: true
-          }
-        }
+            cacheDirectory: true,
+          },
+        },
       },
       {
         test: /\.(ts|tsx)$/,
@@ -139,10 +139,10 @@ module.exports = {
           {
             loader: "ts-loader",
             options: {
-              transpileOnly: true
-            }
-          }
-        ]
+              transpileOnly: true,
+            },
+          },
+        ],
       },
       {
         test: /\.css$/,
@@ -151,8 +151,8 @@ module.exports = {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 1
-            }
+              importLoaders: 1,
+            },
           },
           {
             loader: "postcss-loader",
@@ -163,14 +163,14 @@ module.exports = {
                     ">1%",
                     "last 4 versions",
                     "Firefox ESR",
-                    "not ie < 9" // React doesn't support IE8 anyway
+                    "not ie < 9", // React doesn't support IE8 anyway
                   ],
-                  flexbox: "no-2009"
-                })
-              ]
-            }
-          }
-        ]
+                  flexbox: "no-2009",
+                }),
+              ],
+            },
+          },
+        ],
       },
       {
         test: /\.(scss|sass)$/,
@@ -179,24 +179,24 @@ module.exports = {
           {
             loader: "css-loader",
             options: {
-              importLoaders: 1
-            }
+              importLoaders: 1,
+            },
           },
-          "sass-loader"
-        ]
+          "sass-loader",
+        ],
       },
       {
         test: /\.(svg|png|jpg)$/,
         use: {
           loader: "file-loader",
           query: {
-            name: "static/media/[name].[hash:8].[ext]"
-          }
-        }
-      }
+            name: "static/media/[name].[hash:8].[ext]",
+          },
+        },
+      },
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "url" loader exclusion list.
-    ]
+    ],
   },
 
   plugins: [
@@ -213,18 +213,18 @@ module.exports = {
         keepClosingSlash: true,
         minifyJS: true,
         minifyCSS: true,
-        minifyURLs: true
-      }
+        minifyURLs: true,
+      },
     }),
     new OpenGraphPlugin([
       {
         property: "og:title",
-        content: openGraphConfig.title
+        content: openGraphConfig.title,
       },
       {
         property: "og:type",
-        content: openGraphConfig.type
-      }
+        content: openGraphConfig.type,
+      },
     ]),
     new WebappWebpackPlugin({
       logo: faviconConfig.faviconPath,
@@ -241,27 +241,27 @@ module.exports = {
           appleStartup: false,
           firefox: false,
           coast: false,
-          yandex: false
-        }
-      }
+          yandex: false,
+        },
+      },
     }),
     new webpack.DefinePlugin(env.stringified),
     new MiniCssExtractPlugin({
       filename: "static/css/[name].[contenthash:8].css",
-      chunkFilename: "static/css/[name].[contenthash:8].chunk.css"
+      chunkFilename: "static/css/[name].[contenthash:8].chunk.css",
     }),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without
     // having to parse `index.html`.
     new ManifestPlugin({
       // @ts-ignore
-      fileName: "asset-manifest.json"
+      fileName: "asset-manifest.json",
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: "static",
       generateStatsFile: true,
       openAnalyzer: false,
-      statsFilename: "webpack-stats.json"
-    })
-  ]
+      statsFilename: "webpack-stats.json",
+    }),
+  ],
 }

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -67,7 +67,7 @@ function build(previousFileSizes) {
       if (process.env.CI && stats.compilation.warnings.length) {
         printErrors(
           "Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.",
-          stats.compilation.warnings
+          stats.compilation.warnings,
         )
         process.exit(1)
       }
@@ -78,13 +78,13 @@ function build(previousFileSizes) {
       console.log("File sizes after gzip:\n")
       printFileSizesAfterBuild(stats, previousFileSizes, paths.appBuild)
       console.log()
-    }
+    },
   )
 }
 
 function copyPublicFolder() {
   fs.copySync(paths.appPublic, paths.appBuild, {
     dereference: true,
-    filter: file => file !== paths.appHtml
+    filter: file => file !== paths.appHtml,
   })
 }

--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -95,14 +95,14 @@ function setupCompiler(host, port, protocol) {
         console.log("The app is running at:")
         console.log()
         console.log(
-          "  " + chalk.cyan(protocol + "://" + host + ":" + port + "/")
+          "  " + chalk.cyan(protocol + "://" + host + ":" + port + "/"),
         )
         console.log()
         console.log("Note that the development build is not optimized.")
         console.log(
           "To create a production build, use " +
             chalk.cyan(cli + " run build") +
-            "."
+            ".",
         )
         console.log()
         isFirstCompile = false
@@ -132,15 +132,15 @@ function setupCompiler(host, port, protocol) {
         console.log(
           "Use " +
             chalk.yellow("// eslint-disable-next-line") +
-            " to ignore the next line."
+            " to ignore the next line.",
         )
         console.log(
           "Use " +
             chalk.yellow("/* eslint-disable */") +
-            " to ignore all warnings in a file."
+            " to ignore all warnings in a file.",
         )
       }
-    }
+    },
   )
 }
 
@@ -151,7 +151,7 @@ function onProxyError(proxy) {
   return /** @param {any} err @param {any} req @param {any} res */ function(
     err,
     req,
-    res
+    res,
   ) {
     const host = req.headers && req.headers.host
     console.log(
@@ -162,12 +162,12 @@ function onProxyError(proxy) {
         chalk.cyan(host) +
         " to " +
         chalk.cyan(proxy) +
-        "."
+        ".",
     )
     console.log(
       "See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (" +
         chalk.cyan(err.code) +
-        ")."
+        ").",
     )
     console.log()
 
@@ -185,7 +185,7 @@ function onProxyError(proxy) {
         proxy +
         " (" +
         err.code +
-        ")."
+        ").",
     )
   }
 }
@@ -205,8 +205,8 @@ function addMiddleware(devServer) {
           from: /.*\.(json|yaml|yml)\/?$/,
           to(ctx) {
             return proxy + ctx.parsedUrl.pathname
-          }
-        }
+          },
+        },
       ],
       // For single page apps, we generally want to fallback to /index.html.
       // However we also want to respect `proxy` for API calls.
@@ -215,21 +215,21 @@ function addMiddleware(devServer) {
       // Modern browsers include text/html into `accept` header when navigating.
       // However API calls like `fetch()` won’t generally accept text/html.
       // If this heuristic doesn’t work well for you, don’t use `proxy`.
-      htmlAcceptHeaders: proxy ? ["text/html"] : ["text/html", "*/*"]
-    })
+      htmlAcceptHeaders: proxy ? ["text/html"] : ["text/html", "*/*"],
+    }),
   )
   if (proxy) {
     if (typeof proxy !== "string") {
       console.log(
-        chalk.red('When specified, "proxy" in package.json must be a string.')
+        chalk.red('When specified, "proxy" in package.json must be a string.'),
       )
       console.log(
-        chalk.red('Instead, the type of "proxy" was "' + typeof proxy + '".')
+        chalk.red('Instead, the type of "proxy" was "' + typeof proxy + '".'),
       )
       console.log(
         chalk.red(
-          'Either remove "proxy" from package.json, or make it a string.'
-        )
+          'Either remove "proxy" from package.json, or make it a string.',
+        ),
       )
       process.exit(1)
     }
@@ -256,13 +256,13 @@ function addMiddleware(devServer) {
         }
       },
       router: {
-        "/avatar": "https://www.gravatar.com"
+        "/avatar": "https://www.gravatar.com",
       },
       onError: onProxyError(proxy),
       secure: false,
       changeOrigin: true,
       ws: true,
-      xfwd: true
+      xfwd: true,
     })
     devServer.use(mayProxy, hpm)
 
@@ -321,11 +321,11 @@ function runDevServer(host, port, protocol) {
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebookincubator/create-react-app/issues/293
     watchOptions: {
-      ignored: /node_modules/
+      ignored: /node_modules/,
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === "https",
-    host
+    host,
   })
 
   // Our custom middleware proxies requests to /index.html or a remote API.
@@ -346,7 +346,7 @@ function runDevServer(host, port, protocol) {
       console.log()
 
       openBrowser(protocol + "://" + host + ":" + port + "/")
-    }
+    },
   )
 }
 
@@ -375,9 +375,9 @@ detect(DEFAULT_PORT).then(port => {
       message:
         chalk.yellow(
           `Something is already running on port ${DEFAULT_PORT}.` +
-            `${existingProcess ? ` Probably:\n  ${existingProcess}` : ""}`
+            `${existingProcess ? ` Probably:\n  ${existingProcess}` : ""}`,
         ) + "\n\nWould you like to run the app on another port instead?",
-      default: true
+      default: true,
     }
 
     inquirer.prompt(question).then(answer => {
@@ -387,7 +387,7 @@ detect(DEFAULT_PORT).then(port => {
     })
   } else {
     console.log(
-      chalk.red("Something is already running on port " + DEFAULT_PORT + ".")
+      chalk.red("Something is already running on port " + DEFAULT_PORT + "."),
     )
   }
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,7 +4,7 @@ import {
   ISocialConnection,
   SocialProvider,
   IUserStats,
-  ISession
+  ISession,
 } from "@/store/reducers/user"
 import { ITeam, IMember } from "@/store/reducers/teams"
 import { toISODateString } from "@/date"
@@ -29,25 +29,25 @@ interface IUserResponse {
 
 export const loginUserWithSocial = (service: SocialProvider, token: string) =>
   http.post<IUserResponse>(`/api/v1/auth/${service}/`, {
-    code: token
+    code: token,
   })
 
 export const connectSocial = (service: SocialProvider, code: unknown) =>
   http.post<void>(`/api/v1/auth/${service}/connect/`, {
-    code
+    code,
   })
 
 export const signup = (email: string, password1: string, password2: string) =>
   http.post<IUserResponse>("/api/v1/auth/registration/", {
     email,
     password1,
-    password2
+    password2,
   })
 
 export const loginUser = (email: string, password: string) =>
   http.post<IUserResponse>("/api/v1/auth/login/", {
     email,
-    password
+    password,
   })
 
 export const getSocialConnections = () =>
@@ -55,7 +55,7 @@ export const getSocialConnections = () =>
 
 export const disconnectSocialAccount = async (providerName: SocialProvider) => {
   const res = await http.post<ISocialConnection[]>(
-    `/api/v1/auth/socialaccounts/${providerName}/disconnect/`
+    `/api/v1/auth/socialaccounts/${providerName}/disconnect/`,
   )
   if (isOk(res)) {
     return res
@@ -70,20 +70,20 @@ interface IDetailResponse {
 
 export const resetPassword = (email: string) =>
   http.post<IDetailResponse>("/api/v1/auth/password/reset/", {
-    email
+    email,
   })
 
 export const resetPasswordConfirm = (
   uid: string,
   token: string,
   newPassword1: string,
-  newPassword2: string
+  newPassword2: string,
 ) =>
   http.post<IDetailResponse>("/api/v1/auth/password/reset/confirm/", {
     uid,
     token,
     new_password1: newPassword1,
-    new_password2: newPassword2
+    new_password2: newPassword2,
   })
 
 export const getUserStats = () => http.get<IUserStats>("api/v1/user_stats/")
@@ -91,12 +91,12 @@ export const getUserStats = () => http.get<IUserStats>("api/v1/user_stats/")
 export const changePassword = (
   password1: string,
   password2: string,
-  oldPassword: string
+  oldPassword: string,
 ) =>
   http.post("/api/v1/auth/password/change/", {
     new_password1: password1,
     new_password2: password2,
-    old_password: oldPassword
+    old_password: oldPassword,
   })
 
 export const enum Unit {
@@ -115,7 +115,7 @@ export const enum Unit {
   MILLILITER = "MILLILITER",
   SOME = "SOME",
   UNKNOWN = "UNKNOWN",
-  NONE = "NONE"
+  NONE = "NONE",
 }
 
 export interface IQuantity {
@@ -137,8 +137,8 @@ export const getShoppingList = (teamID: TeamID, start: Date, end: Date) => {
   return http.get<IGetShoppingListResponse>(`/api/v1/t/${id}/shoppinglist/`, {
     params: {
       start: toISODateString(start),
-      end: toISODateString(end)
-    }
+      end: toISODateString(end),
+    },
   })
 }
 
@@ -161,7 +161,7 @@ export interface IRecipeTimelineEvent {
 
 export const getRecipeTimeline = (id: IRecipe["id"]) =>
   http.get<ReadonlyArray<IRecipeTimelineEvent>>(
-    `/api/v1/recipes/${id}/timeline`
+    `/api/v1/recipes/${id}/timeline`,
   )
 
 export const deleteRecipe = (id: IRecipe["id"]) =>
@@ -182,26 +182,26 @@ export const getRecipeList = (teamID: TeamID) => {
 
 export const addIngredientToRecipe = (
   recipeID: IRecipe["id"],
-  ingredient: unknown
+  ingredient: unknown,
 ) =>
   http.post<IIngredient>(`/api/v1/recipes/${recipeID}/ingredients/`, ingredient)
 
 export const addSectionToRecipe = ({
   recipeId,
-  section
+  section,
 }: {
   readonly recipeId: number
   readonly section: string
 }) =>
   http.post<{ title: string; position: number; id: number }>(
     `/api/v1/recipes/${recipeId}/sections`,
-    { title: section }
+    { title: section },
   )
 
 export const updateSection = ({
   sectionId,
   position,
-  title
+  title,
 }: {
   readonly sectionId: number
   readonly position?: number
@@ -209,7 +209,7 @@ export const updateSection = ({
 }) =>
   http.patch<{ title: string; position: number; id: number }>(
     `/api/v1/sections/${sectionId}/`,
-    { title, position }
+    { title, position },
   )
 
 export const deleteSection = ({ sectionId }: { readonly sectionId: number }) =>
@@ -217,24 +217,24 @@ export const deleteSection = ({ sectionId }: { readonly sectionId: number }) =>
 
 export const addStepToRecipe = (recipeID: IRecipe["id"], step: unknown) =>
   http.post<IStep>(`/api/v1/recipes/${recipeID}/steps/`, {
-    text: step
+    text: step,
   })
 
 // TODO(sbdchd): this shouldn't require recipeID
 export const updateIngredient = (
   recipeID: IRecipe["id"],
   ingredientID: IIngredient["id"],
-  content: unknown
+  content: unknown,
 ) =>
   http.patch<IIngredient>(
     `/api/v1/recipes/${recipeID}/ingredients/${ingredientID}/`,
-    content
+    content,
   )
 
 // TODO(sbdchd): this shouldn't require recipeID
 export const deleteIngredient = (
   recipeID: IRecipe["id"],
-  ingredientID: IIngredient["id"]
+  ingredientID: IIngredient["id"],
 ) => http.delete(`/api/v1/recipes/${recipeID}/ingredients/${ingredientID}/`)
 
 interface IAddNoteToRecipe {
@@ -267,7 +267,7 @@ interface IUpdateStepPayload {
 export const updateStep = (
   recipeID: IRecipe["id"],
   stepID: IStep["id"],
-  data: IUpdateStepPayload
+  data: IUpdateStepPayload,
 ) => http.patch<IStep>(`/api/v1/recipes/${recipeID}/steps/${stepID}/`, data)
 
 // TODO(sbdchd): this shouldn't require recipeID
@@ -285,13 +285,13 @@ export const getTeamRecipes = (id: ITeam["id"]) =>
 export const updateTeamMemberLevel = (
   teamID: ITeam["id"],
   membershipID: IMember["id"],
-  level: IMember["level"]
+  level: IMember["level"],
 ) =>
   http.patch<IMember>(`/api/v1/t/${teamID}/members/${membershipID}/`, { level })
 
 export const deleteTeamMember = (
   teamID: ITeam["id"],
-  memberID: IMember["id"]
+  memberID: IMember["id"],
 ) => http.delete(`/api/v1/t/${teamID}/members/${memberID}/`)
 
 export const deleteTeam = (teamID: ITeam["id"]) =>
@@ -300,7 +300,7 @@ export const deleteTeam = (teamID: ITeam["id"]) =>
 export const sendTeamInvites = (
   teamID: ITeam["id"],
   emails: string[],
-  level: IMember["level"]
+  level: IMember["level"],
 ) => http.post<void>(`/api/v1/t/${teamID}/invites/`, { emails, level })
 
 export const getTeamList = () => http.get<ITeam[]>("/api/v1/t/")
@@ -308,7 +308,7 @@ export const getTeamList = () => http.get<ITeam[]>("/api/v1/t/")
 export const createTeam = (
   name: string,
   emails: string[],
-  level: IMember["level"]
+  level: IMember["level"],
 ) => http.post<ITeam>("/api/v1/t/", { name, emails, level })
 
 export const updateTeam = (teamId: ITeam["id"], data: unknown) =>
@@ -318,14 +318,14 @@ export const updateTeam = (teamId: ITeam["id"], data: unknown) =>
 export const moveRecipe = (
   recipeId: IRecipe["id"],
   ownerId: IUser["id"],
-  type: unknown
+  type: unknown,
 ) =>
   http.post<IRecipe>(`/api/v1/recipes/${recipeId}/move/`, { id: ownerId, type })
 
 export const copyRecipe = (
   recipeId: IRecipe["id"],
   ownerId: IUser["id"],
-  type: unknown
+  type: unknown,
 ) =>
   http.post<IRecipe>(`/api/v1/recipes/${recipeId}/copy/`, { id: ownerId, type })
 
@@ -342,7 +342,7 @@ export const reportBadMerge = () => http.post("/api/v1/report-bad-merge", {})
 export function getCalendarRecipeList({
   teamID,
   start,
-  end
+  end,
 }: {
   readonly teamID: TeamID
   readonly start: string
@@ -363,26 +363,26 @@ export function getCalendarRecipeList({
           user: t.union([t.number, t.null]),
           recipe: t.type({
             id: t.number,
-            name: t.string
-          })
-        })
+            name: t.string,
+          }),
+        }),
       ),
       settings: t.type({
         syncEnabled: t.boolean,
-        calendarLink: t.string
-      })
+        calendarLink: t.string,
+      }),
     }),
     params: {
       v2: 1,
       start,
-      end
-    }
+      end,
+    },
   })
 }
 
 export function updateCalendarSettings({
   teamID,
-  data
+  data,
 }: {
   readonly teamID: TeamID
   readonly data: {
@@ -395,8 +395,8 @@ export function updateCalendarSettings({
     data,
     shape: t.type({
       syncEnabled: t.boolean,
-      calendarLink: t.string
-    })
+      calendarLink: t.string,
+    }),
   })
 }
 
@@ -405,28 +405,28 @@ export function generateCalendarLink({ teamID }: { readonly teamID: TeamID }) {
     method: "POST",
     url: `/api/v1/t/${teamID}/calendar/generate_link/`,
     shape: t.type({
-      calendarLink: t.string
-    })
+      calendarLink: t.string,
+    }),
   })
 }
 export const scheduleRecipe = (
   recipeID: IRecipe["id"],
   teamID: TeamID,
   on: Date,
-  count: string | number
+  count: string | number,
 ) => {
   const id = teamID === "personal" ? "me" : teamID
   return http.post<ICalRecipe>(`/api/v1/t/${id}/calendar/`, {
     recipe: recipeID,
     on: toISODateString(on),
-    count
+    count,
   })
 }
 
 // TODO(sbdchd): we shouldn't need teamID here
 export const deleteScheduledRecipe = (
   calId: ICalRecipe["id"],
-  teamID: TeamID
+  teamID: TeamID,
 ) => {
   const id = teamID === "personal" ? "me" : teamID
   return http.delete(`/api/v1/t/${id}/calendar/${calId}/`)
@@ -436,7 +436,7 @@ export const deleteScheduledRecipe = (
 export const updateScheduleRecipe = (
   calId: ICalRecipe["id"],
   teamID: TeamID,
-  recipe: Partial<ICalRecipe>
+  recipe: Partial<ICalRecipe>,
 ) => {
   const id = teamID === "personal" ? "me" : teamID
   return http.patch<ICalRecipe>(`/api/v1/t/${id}/calendar/${calId}/`, recipe)

--- a/frontend/src/components/AddIngredient.tsx
+++ b/frontend/src/components/AddIngredient.tsx
@@ -10,7 +10,7 @@ function AddIngredientSubForm({
   loading,
   onCancel,
   autoFocus,
-  onChangeSection
+  onChangeSection,
 }: {
   readonly onCancel: () => void
   readonly recipeId: number
@@ -59,8 +59,8 @@ function AddIngredientSubForm({
     dispatch(
       addIngredientToRecipe.request({
         recipeID: recipeId,
-        ingredient: { quantity, name, description }
-      })
+        ingredient: { quantity, name, description },
+      }),
     )
 
   return (
@@ -83,7 +83,7 @@ export default function AddIngredient({
   recipeId,
   addingIngredient,
   onCancel,
-  autoFocus
+  autoFocus,
 }: {
   readonly onCancel: () => void
   readonly recipeId: number

--- a/frontend/src/components/AddIngredientForm.tsx
+++ b/frontend/src/components/AddIngredientForm.tsx
@@ -18,7 +18,7 @@ function IngredientForm({
   error,
   optional,
   description,
-  name
+  name,
 }: {
   readonly handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   readonly quantity: string
@@ -96,7 +96,7 @@ function AddIngredientForm({
   optional,
   loading,
   error,
-  autoFocus = false
+  autoFocus = false,
 }: {
   readonly handleAddIngredient: () => void
   readonly cancelAddIngredient: () => void

--- a/frontend/src/components/AddRecipe.test.tsx
+++ b/frontend/src/components/AddRecipe.test.tsx
@@ -29,7 +29,7 @@ describe("<AddRecipe/>", () => {
           error={{
             errorWithName: false,
             errorWithIngredients: false,
-            errorWithSteps: false
+            errorWithSteps: false,
           }}
           loading={false}
           name={""}
@@ -43,7 +43,7 @@ describe("<AddRecipe/>", () => {
           teams={[]}
           teamID={0}
         />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/AddRecipe.tsx
+++ b/frontend/src/components/AddRecipe.tsx
@@ -10,7 +10,7 @@ import {
   IStepBasic,
   IRecipeBasic,
   IIngredientBasic,
-  IAddRecipeError
+  IAddRecipeError,
 } from "@/store/reducers/recipes"
 import { ITeam } from "@/store/reducers/teams"
 import { Select, TextInput } from "@/components/Forms"
@@ -35,7 +35,7 @@ interface IAddRecipeProps {
   readonly removeIngredient: (index: number) => void
   readonly updateIngredient: (
     index: number,
-    ingredient: IIngredientBasic
+    ingredient: IIngredientBasic,
   ) => void
   readonly addIngredient: (ingredient: IIngredientBasic) => void
   readonly error: IAddRecipeError
@@ -69,7 +69,7 @@ const emptyIngredient = {
   quantity: "",
   name: "",
   description: "",
-  optional: false
+  optional: false,
 }
 
 export default class AddRecipe extends React.Component<
@@ -79,7 +79,7 @@ export default class AddRecipe extends React.Component<
   state: IAddRecipeState = {
     ingredient: emptyIngredient,
     step: "",
-    loading: false
+    loading: false,
   }
 
   componentDidMount() {
@@ -90,7 +90,7 @@ export default class AddRecipe extends React.Component<
   handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as IAddRecipeState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
@@ -107,7 +107,7 @@ export default class AddRecipe extends React.Component<
       steps: this.props.steps,
       notes: [],
       sections: [],
-      team: this.props.teamID || undefined
+      team: this.props.teamID || undefined,
     })
   }
 
@@ -126,16 +126,16 @@ export default class AddRecipe extends React.Component<
       this.setState(prev => ({
         ingredient: {
           ...prev.ingredient,
-          [e.target.name]: !prev.ingredient[e.target.name]
-        }
+          [e.target.name]: !prev.ingredient[e.target.name],
+        },
       }))
       return
     }
     this.setState(prevState => ({
       ingredient: {
         ...prevState.ingredient,
-        [e.target.name]: e.target.value
-      }
+        [e.target.name]: e.target.value,
+      },
     }))
   }
 
@@ -166,20 +166,20 @@ export default class AddRecipe extends React.Component<
       handleSubmit,
       addIngredient,
       cancelAddIngredient,
-      handleIngredientChange
+      handleIngredientChange,
     } = this
 
     const {
       errorWithName,
       errorWithIngredients,
-      errorWithSteps
+      errorWithSteps,
     } = this.props.error
 
     const {
       quantity = "",
       name = "",
       description = "",
-      optional = false
+      optional = false,
     } = ingredient
 
     return (

--- a/frontend/src/components/AddSectionForm.tsx
+++ b/frontend/src/components/AddSectionForm.tsx
@@ -16,7 +16,7 @@ export function AddSectionFormInner({
   value,
   removing,
   onChange,
-  toggleShowAddSection
+  toggleShowAddSection,
 }: {
   readonly onSave: () => void
   readonly onCancel: () => void
@@ -104,7 +104,7 @@ type StateType = {
 export function AddSectionForm({
   toggleShowAddSection,
   onCancel,
-  recipeId
+  recipeId,
 }: {
   readonly toggleShowAddSection: () => void
   readonly onCancel: () => void
@@ -113,7 +113,7 @@ export function AddSectionForm({
   const dispatch = useDispatch()
   const [state, setState] = React.useState<StateType>({
     sectionTitle: "",
-    status: "initial"
+    status: "initial",
   })
   function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const sectionTitle = e.target.value
@@ -128,8 +128,8 @@ export function AddSectionForm({
           dispatch(
             addSectionToRecipe({
               recipeId,
-              section: res.data
-            })
+              section: res.data,
+            }),
           )
           setState(prev => ({ ...prev, status: "success", sectionTitle: "" }))
         } else {

--- a/frontend/src/components/AddStep.tsx
+++ b/frontend/src/components/AddStep.tsx
@@ -6,7 +6,7 @@ import {
   IStep,
   addStepToRecipe,
   setRecipeStepDraft,
-  IRecipe
+  IRecipe,
 } from "@/store/reducers/recipes"
 import { connect } from "react-redux"
 
@@ -59,7 +59,7 @@ function AddStep(props: IAddStepProps) {
 
 const mapDispatchToProps = {
   addStep: addStepToRecipe.request,
-  setStep: setRecipeStepDraft
+  setStep: setRecipeStepDraft,
 }
 
 export default connect(null, mapDispatchToProps)(AddStep)

--- a/frontend/src/components/AddStepForm.tsx
+++ b/frontend/src/components/AddStepForm.tsx
@@ -5,7 +5,7 @@ import { ButtonPrimary, Button } from "@/components/Buttons"
 
 interface IAddStepFormProps {
   readonly handleInputChange: (
-    e: React.ChangeEvent<HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLTextAreaElement>,
   ) => void
   readonly addStep: () => void
   readonly cancelAddStep: () => void
@@ -24,7 +24,7 @@ const AddStepForm = ({
   text,
   loading = false,
   error = false,
-  autoFocus = false
+  autoFocus = false,
 }: IAddStepFormProps) => (
   <form
     onSubmit={e => {

--- a/frontend/src/components/App.test.tsx
+++ b/frontend/src/components/App.test.tsx
@@ -10,7 +10,7 @@ describe("<App/>", () => {
       <TestProvider>
         <App />
       </TestProvider>,
-      div
+      div,
     )
   })
 })

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -39,7 +39,7 @@ interface IAuthRouteProps extends RouteProps {
 }
 
 const mapAuthenticated = (state: IState) => ({
-  authenticated: state.user.loggedIn
+  authenticated: state.user.loggedIn,
 })
 
 type ComponentProps = ArgumentsType<RouteProps["render"]>[0]
@@ -51,7 +51,7 @@ type ComponentProps = ArgumentsType<RouteProps["render"]>[0]
 const renderComponent = (
   props: ComponentProps,
   component: RouteProps["component"],
-  render: RouteProps["render"]
+  render: RouteProps["render"],
 ): React.ReactNode => {
   if (component) {
     return React.createElement(component, props)
@@ -78,13 +78,13 @@ const PrivateRoute = connect(mapAuthenticated)(
           <Redirect
             to={{
               pathname: "/login",
-              state: { from: props.location }
+              state: { from: props.location },
             }}
           />
         )
       }}
     />
-  )
+  ),
 )
 
 const PublicOnlyRoute = connect(mapAuthenticated)(
@@ -103,13 +103,13 @@ const PublicOnlyRoute = connect(mapAuthenticated)(
           <Redirect
             to={{
               pathname: "/",
-              state: { from: props.location }
+              state: { from: props.location },
             }}
           />
         )
       }}
     />
-  )
+  ),
 )
 
 function Base() {
@@ -201,7 +201,7 @@ function Base() {
 // see: https://github.com/gaearon/react-hot-loader
 setConfig({
   ignoreSFC: true,
-  pureRender: true
+  pureRender: true,
 })
 
 export default hot(Base)

--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -33,7 +33,7 @@ export const ButtonPlain = ({
     <button
       {...props}
       className={classNames("my-button", className, buttonSize, {
-        "is-loading": loading
+        "is-loading": loading,
       })}>
       {children}
     </button>

--- a/frontend/src/components/Calendar.test.tsx
+++ b/frontend/src/components/Calendar.test.tsx
@@ -18,7 +18,7 @@ describe("<Calendar> Snap", () => {
       .create(
         <TestProvider>
           <Calendar teamID={10} type="recipes" />
-        </TestProvider>
+        </TestProvider>,
       )
       .toJSON()
 

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -12,7 +12,7 @@ import {
   fetchCalendarAsync,
   fetchingRecipeListAsync,
   fetchingTeamsAsync,
-  fetchingShoppingListAsync
+  fetchingShoppingListAsync,
 } from "@/store/thunks"
 
 import { toISODateString } from "@/date"
@@ -30,7 +30,7 @@ import {
   getTeamRecipes,
   getPersonalRecipes,
   updateCalendarSettings,
-  regenerateCalendarLink as regenerateCalendarLinkAction
+  regenerateCalendarLink as regenerateCalendarLinkAction,
 } from "@/store/reducers/calendar"
 import { subWeeks, addWeeks, startOfWeek, endOfWeek } from "date-fns"
 import { Select } from "@/components/Forms"
@@ -43,7 +43,7 @@ import {
   Loading,
   WebData,
   isSuccessLike,
-  Failure
+  Failure,
 } from "@/webdata"
 
 function CalTitle({ dayTs }: { readonly dayTs: number }) {
@@ -188,7 +188,7 @@ function Nav({ dayTs, teamID, onPrev, onNext, onCurrent, type }: INavProps) {
   const {
     settings,
     setSyncEnabled,
-    regenerateCalendarLink
+    regenerateCalendarLink,
   } = useCalendarSettings(teamID)
 
   return (
@@ -259,16 +259,16 @@ function useCurrentWeek() {
   const navPrev = () => {
     history.push({
       search: queryString.stringify({
-        week: toISODateString(subWeeks(weekStartDate, 1))
-      })
+        week: toISODateString(subWeeks(weekStartDate, 1)),
+      }),
     })
   }
 
   const navNext = () => {
     history.push({
       search: queryString.stringify({
-        week: toISODateString(addWeeks(weekStartDate, 1))
-      })
+        week: toISODateString(addWeeks(weekStartDate, 1)),
+      }),
     })
   }
 
@@ -340,7 +340,7 @@ function useDays(teamID: TeamID, currentDateTs: number): WebData<IDays> {
     days.reduce<IDays>((a, b) => {
       a[b.on] = (a[b.on] || []).concat(b)
       return a
-    }, {})
+    }, {}),
   )
 }
 
@@ -376,15 +376,15 @@ function useCalendarSettings(teamID: TeamID) {
     dispatch(
       updateCalendarSettings.request({
         teamID,
-        syncEnabled
-      })
+        syncEnabled,
+      }),
     )
   }
   const regenerateCalendarLink = () => {
     dispatch(
       regenerateCalendarLinkAction.request({
-        teamID
-      })
+        teamID,
+      }),
     )
   }
   return { settings, setSyncEnabled, regenerateCalendarLink }
@@ -402,7 +402,7 @@ export function Calendar({ teamID, type }: ICalendarProps) {
     endDate,
     navNext,
     navCurrent,
-    navPrev
+    navPrev,
   } = useCurrentWeek()
 
   const days = useDays(teamID, currentDateTs)

--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -15,14 +15,14 @@ import {
   Dispatch,
   fetchingShoppingListAsync,
   IAddingScheduledRecipeProps,
-  IMoveScheduledRecipeProps
+  IMoveScheduledRecipeProps,
 } from "@/store/thunks"
 import { DragDrop } from "@/dragDrop"
 import { IState } from "@/store/store"
 import {
   ICalRecipe,
   moveOrCreateCalendarRecipe,
-  createCalendarRecipe
+  createCalendarRecipe,
 } from "@/store/reducers/calendar"
 import { IRecipeItemDrag } from "@/components/RecipeItem"
 import { Result } from "@/result"
@@ -102,7 +102,7 @@ interface ICalendarDayProps {
   readonly updateCount: (
     id: ICalRecipe["id"],
     teamID: TeamID,
-    count: ICalRecipe["count"]
+    count: ICalRecipe["count"],
   ) => Promise<Result<void, void>>
   readonly refetchShoppingList: (teamID: TeamID) => void
   readonly remove: (id: ICalRecipe["id"], teamID: TeamID) => void
@@ -111,7 +111,7 @@ interface ICalendarDayProps {
     recipeID,
     teamID,
     on,
-    count
+    count,
   }: IAddingScheduledRecipeProps) => void
   readonly teamID: TeamID
   readonly isSelected: boolean
@@ -126,7 +126,7 @@ function CalendarDay({
   teamID,
   isSelected,
   move,
-  create
+  create,
 }: ICalendarDayProps) {
   const today = useCurrentDay()
   const isToday = isSameDay(date, today)
@@ -150,9 +150,9 @@ function CalendarDay({
     collect: monitor => {
       return {
         isOver: monitor.isOver(),
-        canDrop: monitor.canDrop()
+        canDrop: monitor.canDrop(),
       }
-    }
+    },
   })
 
   const scheduled = sortBy(scheduledRecipes, x => new Date(x.created))
@@ -187,7 +187,7 @@ function CalendarDay({
 
 function mapStateToProps(
   state: IState,
-  props: Pick<ICalendarDayProps, "date">
+  props: Pick<ICalendarDayProps, "date">,
 ) {
   const isShopping =
     state.router.location != null
@@ -197,13 +197,13 @@ function mapStateToProps(
     isSelected:
       isWithinInterval(props.date, {
         start: startOfDay(state.shoppinglist.startDay),
-        end: endOfDay(state.shoppinglist.endDay)
-      }) && isShopping
+        end: endOfDay(state.shoppinglist.endDay),
+      }) && isShopping,
   }
 }
 
 const mapDispatchToProps = (
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ): Pick<
   ICalendarDayProps,
   "create" | "updateCount" | "refetchShoppingList" | "move" | "remove"
@@ -214,7 +214,7 @@ const mapDispatchToProps = (
   refetchShoppingList: fetchingShoppingListAsync(dispatch),
   move: (props: IMoveScheduledRecipeProps) =>
     dispatch(moveOrCreateCalendarRecipe(props)),
-  remove: deletingScheduledRecipeAsync(dispatch)
+  remove: deletingScheduledRecipeAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(CalendarDay)

--- a/frontend/src/components/CalendarDayItem.test.tsx
+++ b/frontend/src/components/CalendarDayItem.test.tsx
@@ -10,8 +10,8 @@ describe("<CalendarDayItem> Snap", () => {
       id: 25,
       recipe: {
         id: 10,
-        name: "Baked Ziti"
-      }
+        name: "Baked Ziti",
+      },
     }
 
     const pastDate = new Date(1776, 1, 1)
@@ -30,7 +30,7 @@ describe("<CalendarDayItem> Snap", () => {
             refetchShoppingList={jest.fn()}
             date={pastDate}
           />
-        </TestProvider>
+        </TestProvider>,
       )
       .toJSON()
 

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -74,7 +74,7 @@ export interface ICalendarItemProps {
   readonly count: ICalRecipe["count"]
   readonly remove: () => void
   readonly updateCount: (
-    count: ICalRecipe["count"]
+    count: ICalRecipe["count"],
   ) => Promise<Result<void, void>>
   readonly refetchShoppingList: () => void
   readonly date: Date
@@ -91,7 +91,7 @@ export function CalendarItem({
   remove,
   recipeName,
   recipeID,
-  id
+  id,
 }: ICalendarItemProps) {
   const [count, setCount] = React.useState(propsCount)
   const ref = React.useRef<HTMLLIElement>(null)
@@ -143,7 +143,7 @@ export function CalendarItem({
     recipeID,
     count,
     id,
-    date
+    date,
   }
 
   const [{ isDragging }, drag] = useDrag({
@@ -157,9 +157,9 @@ export function CalendarItem({
     },
     collect: monitor => {
       return {
-        isDragging: monitor.isDragging()
+        isDragging: monitor.isDragging(),
       }
-    }
+    },
   })
 
   const visibility = isDragging && !isPast(date) ? "hidden" : "visible"

--- a/frontend/src/components/CalendarMoreDropdown.tsx
+++ b/frontend/src/components/CalendarMoreDropdown.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import {
   useDropdown,
   DropdownContainer,
-  DropdownMenu
+  DropdownMenu,
 } from "@/components/Dropdown"
 import { ButtonPlain, ButtonLink, ButtonSecondary } from "@/components/Buttons"
 import { TextInput, selectTarget } from "@/components/Forms"
@@ -15,7 +15,7 @@ function Hr() {
 export function CalendarMoreDropdown({
   settings,
   setSyncEnabled,
-  regenerateCalendarLink
+  regenerateCalendarLink,
 }: {
   readonly settings: WebData<{
     readonly syncEnabled: boolean

--- a/frontend/src/components/DatePickerForm.tsx
+++ b/frontend/src/components/DatePickerForm.tsx
@@ -25,14 +25,14 @@ function mapDispatchToProps(dispatch: Dispatch) {
       recipeID: IRecipe["id"],
       teamID: TeamID,
       on: Date,
-      count: number
-    ) => dispatch(createCalendarRecipe({ recipeID, teamID, on, count }))
+      count: number,
+    ) => dispatch(createCalendarRecipe({ recipeID, teamID, on, count })),
   }
 }
 
 function mapStateToProps(state: IState) {
   return {
-    teamID: state.user.teamID || ("personal" as const)
+    teamID: state.user.teamID || ("personal" as const),
   }
 }
 
@@ -44,7 +44,7 @@ interface IDatePickerProps {
     recipeID: IRecipe["id"],
     teamID: TeamID,
     date: Date,
-    count: number
+    count: number,
   ) => void
   readonly close: () => void
   readonly scheduling?: boolean
@@ -63,7 +63,7 @@ class DatePickerForm extends React.Component<
   state = {
     count: 1,
     date: new Date(),
-    month: new Date()
+    month: new Date(),
   }
 
   handleDateChange = (val: Date) => {
@@ -84,7 +84,7 @@ class DatePickerForm extends React.Component<
       this.props.recipeID,
       this.props.teamID,
       this.state.date,
-      this.state.count
+      this.state.count,
     )
     this.props.close()
   }
@@ -113,7 +113,7 @@ class DatePickerForm extends React.Component<
           "cursor-default",
           "z-index-100",
           "bg-whitesmoke",
-          "p-2"
+          "p-2",
         )}>
         <Month
           showLeft

--- a/frontend/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker/DateRangePicker.tsx
@@ -49,7 +49,7 @@ export default class DateRangePicker extends React.Component<
           "bg-whitesmoke",
           "z-index-100",
           "grid-2-months",
-          this.props.selecting !== Selecting.None ? "d-grid" : "d-none"
+          this.props.selecting !== Selecting.None ? "d-grid" : "d-none",
         )}>
         <Month
           showLeft

--- a/frontend/src/components/DateRangePicker/Day.tsx
+++ b/frontend/src/components/DateRangePicker/Day.tsx
@@ -28,7 +28,7 @@ class Day extends React.Component<IDayProps> {
           { "color-white": this.props.highlight || this.props.endDate },
           { "cal-in-past": this.props.inPast },
           this.props.inPast ? "cursor-default" : "cursor-pointer",
-          { "text-muted": this.props.inPast }
+          { "text-muted": this.props.inPast },
         )}
         onClick={() => this.props.handleClick(this.props.date)}>
         {this.props.date.getDate()}

--- a/frontend/src/components/DateRangePicker/Month.tsx
+++ b/frontend/src/components/DateRangePicker/Month.tsx
@@ -38,7 +38,7 @@ interface IMonthProps {
 class Month extends React.Component<IMonthProps> {
   static defaultProps = {
     showRight: false,
-    showLeft: false
+    showLeft: false,
   }
   render() {
     return (
@@ -81,7 +81,7 @@ class Month extends React.Component<IMonthProps> {
               inPast={isPast(endOfDay(date))}
               highlight={isWithinInterval(date, {
                 start: startOfDay(this.props.startDay),
-                end: endOfDay(this.props.endDay)
+                end: endOfDay(this.props.endDay),
               })}
               endDate={
                 isSameDay(date, this.props.startDay) ||

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -10,7 +10,7 @@ describe("<ListItem/>", () => {
     // tslint:disable-next-line:no-any
     ;((global.console.error as any) as jest.SpyInstance).mockImplementation(
       /* eslint-enable @typescript-eslint/consistent-type-assertions */
-      jest.fn()
+      jest.fn(),
     )
   })
   afterEach(() => {
@@ -24,7 +24,7 @@ describe("<ListItem/>", () => {
     mount(
       <ErrorBoundary>
         <div />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     )
   })
 
@@ -38,7 +38,7 @@ describe("<ListItem/>", () => {
     mount(
       <ErrorBoundary>
         <BadComponent />
-      </ErrorBoundary>
+      </ErrorBoundary>,
     )
   })
 })

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -21,7 +21,7 @@ export default class ErrorBoundary extends React.Component<
   IErrorBoundaryState
 > {
   state = {
-    error: null
+    error: null,
   }
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     this.setState({ error })

--- a/frontend/src/components/Forms.tsx
+++ b/frontend/src/components/Forms.tsx
@@ -66,15 +66,15 @@ const BaseInput = ({
     inputSize,
     {
       "is-danger": error,
-      "is-focused": isFocused
+      "is-focused": isFocused,
     },
-    className
+    className,
   )
   return <input className={cls} {...props} />
 }
 
 const createInput = (
-  type: React.InputHTMLAttributes<HTMLInputElement>["type"]
+  type: React.InputHTMLAttributes<HTMLInputElement>["type"],
 ) => (props: Omit<IBaseInputProps, "type">) => (
   <BaseInput {...props} type={type} />
 )

--- a/frontend/src/components/HelpMenuModal.tsx
+++ b/frontend/src/components/HelpMenuModal.tsx
@@ -5,20 +5,20 @@ import GlobalEvent from "@/components/GlobalEvent"
 const keybinds = [
   {
     key: ["Delete", "#"],
-    description: "delete scheduled recipe"
+    description: "delete scheduled recipe",
   },
   {
     key: "?",
-    description: "toggle help menu"
+    description: "toggle help menu",
   },
   {
     key: ["+", "A"],
-    description: "increment scheduled recipe amount"
+    description: "increment scheduled recipe amount",
   },
   {
     key: ["-", "X"],
-    description: "decrement scheduled recipe amount"
-  }
+    description: "decrement scheduled recipe amount",
+  },
 ]
 
 interface IKeyBindProps {

--- a/frontend/src/components/Home.test.tsx
+++ b/frontend/src/components/Home.test.tsx
@@ -8,20 +8,20 @@ describe("<Home/>", () => {
     mount(
       <TestProvider>
         <Home loggedIn={false} />
-      </TestProvider>
+      </TestProvider>,
     )
   })
   it("Has some text in footer", () => {
     const home = mount(
       <TestProvider>
         <Home loggedIn={false} />
-      </TestProvider>
+      </TestProvider>,
     )
     expect(
       home
         .find("a")
         .first()
-        .text()
+        .text(),
     ).toContain("Create Account")
   })
 })

--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -10,7 +10,7 @@ import { DragDrop, handleDndHover } from "@/dragDrop"
 
 const emptyField = ({
   quantity,
-  name
+  name,
 }: {
   readonly quantity: string | undefined
   readonly name: string | undefined
@@ -19,7 +19,7 @@ const emptyField = ({
 const allEmptyFields = ({
   quantity,
   name,
-  description
+  description,
 }: {
   readonly quantity?: string
   readonly name?: string
@@ -51,7 +51,7 @@ export function Ingredient(props: {
     quantity,
     name,
     description,
-    optional
+    optional,
   }: {
     readonly ingredientId: number
     readonly quantity: string
@@ -61,7 +61,7 @@ export function Ingredient(props: {
   }) => void
   readonly move?: ({
     from,
-    to
+    to,
   }: {
     readonly from: number
     readonly to: number
@@ -69,7 +69,7 @@ export function Ingredient(props: {
   readonly completeMove?: ({
     kind,
     id,
-    to
+    to,
   }: {
     readonly kind: "ingredient"
     readonly id: number
@@ -82,7 +82,7 @@ export function Ingredient(props: {
     description: props.description,
     optional: props.optional,
     editing: false,
-    unsavedChanges: false
+    unsavedChanges: false,
   })
 
   const ref = React.useRef<HTMLLIElement>(null)
@@ -107,7 +107,7 @@ export function Ingredient(props: {
         ...prevState,
         editing: false,
         unsavedChanges:
-          (prevState.editing && contentChanged) || prevState.unsavedChanges
+          (prevState.editing && contentChanged) || prevState.unsavedChanges,
       }
     })
   }
@@ -123,7 +123,7 @@ export function Ingredient(props: {
     const value = e.target.value
     setState(s => ({
       ...s,
-      [name]: value
+      [name]: value,
     }))
   }
 
@@ -138,7 +138,7 @@ export function Ingredient(props: {
     setState(s => ({
       ...s,
       editing: true,
-      unsavedChanges: false
+      unsavedChanges: false,
     }))
   }
 
@@ -149,7 +149,7 @@ export function Ingredient(props: {
       unsavedChanges: false,
       quantity: props.quantity,
       name: props.quantity,
-      description: props.description
+      description: props.description,
     }))
 
   const cancel = () =>
@@ -159,7 +159,7 @@ export function Ingredient(props: {
       editing: false,
       quantity: props.quantity,
       name: props.name,
-      description: props.description
+      description: props.description,
     }))
 
   const handleCancelButton = (e: React.MouseEvent) => {
@@ -184,13 +184,13 @@ export function Ingredient(props: {
       quantity: state.quantity,
       name: state.name,
       description: state.description,
-      optional: state.optional
+      optional: state.optional,
     })
 
     setState(s => ({
       ...s,
       editing: false,
-      unsavedChanges: false
+      unsavedChanges: false,
     }))
   }
 
@@ -201,31 +201,31 @@ export function Ingredient(props: {
     hover: handleDndHover({
       ref,
       index: props.index,
-      move: props.move
-    })
+      move: props.move,
+    }),
   })
 
   const [{ isDragging }, drag, preview] = useDrag({
     item: {
       type: DragDrop.INGREDIENT,
-      index: props.index
+      index: props.index,
     },
     end: () => {
       props.completeMove?.({
         kind: "ingredient",
         id: props.id,
-        to: props.index
+        to: props.index,
       })
     },
     collect: monitor => ({
-      isDragging: monitor.isDragging()
-    })
+      isDragging: monitor.isDragging(),
+    }),
   })
 
   const dragAndDropEnabled = props.completeMove != null && props.move != null
 
   const style = {
-    opacity: isDragging ? 0 : 1
+    opacity: isDragging ? 0 : 1,
   }
 
   if (dragAndDropEnabled) {

--- a/frontend/src/components/IngredientView.test.tsx
+++ b/frontend/src/components/IngredientView.test.tsx
@@ -9,7 +9,7 @@ describe("<IngredientView/>", () => {
       "3 tablespoons",
       "1 teaspoon",
       "1 tablespoon + 2 teaspoons",
-      "1 Teaspoon"
+      "1 Teaspoon",
     ]
 
     testCases.forEach(quantity => {
@@ -23,7 +23,7 @@ describe("<IngredientView/>", () => {
               optional={false}
               description=""
             />
-          </TestProvider>
+          </TestProvider>,
         )
         .toJSON()
 

--- a/frontend/src/components/IngredientView.tsx
+++ b/frontend/src/components/IngredientView.tsx
@@ -16,7 +16,7 @@ export default function IngredientView({
   name,
   description,
   optional,
-  dragRef
+  dragRef,
 }: IIngredientVIewProps) {
   const fmtDescription = description ? ", " + description : ""
 

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -92,18 +92,18 @@ const features = [
   {
     text:
       "Full text recipe search. Easily find recipes by ingredient, author, and name.",
-    imgURL: searchImg
+    imgURL: searchImg,
   },
   {
     text:
       "Collaborate using Recipe Yak Teams to create a shared recipe schedule and shopping list.",
-    imgURL: teamImg
+    imgURL: teamImg,
   },
   {
     text:
       "Automatically generate a condensed shopping list when selecting days to shop.",
-    imgURL: copyShoppingList
-  }
+    imgURL: copyShoppingList,
+  },
 ]
 
 const howToSteps = [
@@ -117,7 +117,7 @@ const howToSteps = [
         form.
       </span>
     ),
-    imgURL: addRecipeImg
+    imgURL: addRecipeImg,
   },
   {
     text: (
@@ -129,7 +129,7 @@ const howToSteps = [
         and add drag recipes onto your calendar.
       </span>
     ),
-    imgURL: landingImg
+    imgURL: landingImg,
   },
   {
     text: (
@@ -141,7 +141,7 @@ const howToSteps = [
         and adjust the days you are shopping for.
       </span>
     ),
-    imgURL: shopImg
+    imgURL: shopImg,
   },
   {
     text: (
@@ -149,8 +149,8 @@ const howToSteps = [
         Copy the automatically generated shopping list with one click.
       </span>
     ),
-    imgURL: copyShoppingList
-  }
+    imgURL: copyShoppingList,
+  },
 ]
 
 const LandingPage = () => (

--- a/frontend/src/components/ListItem.test.tsx
+++ b/frontend/src/components/ListItem.test.tsx
@@ -10,7 +10,7 @@ describe("<ListItem/>", () => {
     mount(
       <MemoryRouter>
         <ListItem id={0} delete={jest.fn()} update={jest.fn()} />
-      </MemoryRouter>
+      </MemoryRouter>,
     )
   })
 
@@ -19,7 +19,7 @@ describe("<ListItem/>", () => {
       "Add 3 tablespoons of tomato paste. Cook 1 minute.",
       "Measure 1 teaspoon of rice vinegar.",
       "Add 1 tablespoon + 2 teaspoons of soy sauce.",
-      "Stir in 1 Teaspoon salt"
+      "Stir in 1 Teaspoon salt",
     ]
 
     testCases.forEach(text => {
@@ -32,7 +32,7 @@ describe("<ListItem/>", () => {
               update={jest.fn()}
               text={text}
             />
-          </TestProvider>
+          </TestProvider>,
         )
         .toJSON()
 

--- a/frontend/src/components/ListItem.tsx
+++ b/frontend/src/components/ListItem.tsx
@@ -15,7 +15,7 @@ interface IListItemProps {
   readonly update: (
     recipeID: IRecipe["id"],
     id: number,
-    data: { text: string }
+    data: { text: string },
   ) => void
   readonly removing?: boolean
   readonly updating?: boolean
@@ -36,7 +36,7 @@ export default class ListItem extends React.Component<
     this.state = {
       text: props.text || "",
       editing: false,
-      unsavedChanges: false
+      unsavedChanges: false,
     }
   }
 
@@ -44,7 +44,7 @@ export default class ListItem extends React.Component<
 
   static defaultProps = {
     recipeID: -1,
-    removing: false
+    removing: false,
   }
 
   handleKeyDown = (e: KeyboardEvent) => {
@@ -71,14 +71,14 @@ export default class ListItem extends React.Component<
       editing: false,
       unsavedChanges:
         (prevState.editing && prevState.text !== text) ||
-        prevState.unsavedChanges
+        prevState.unsavedChanges,
     }))
   }
 
   handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as IListItemState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
@@ -90,7 +90,7 @@ export default class ListItem extends React.Component<
 
     this.setState({
       editing: true,
-      unsavedChanges: false
+      unsavedChanges: false,
     })
   }
 
@@ -98,7 +98,7 @@ export default class ListItem extends React.Component<
     this.setState((_, props) => ({
       editing: false,
       text: props.text || "",
-      unsavedChanges: false
+      unsavedChanges: false,
     }))
   }
 
@@ -114,7 +114,7 @@ export default class ListItem extends React.Component<
   cancel = () => {
     this.setState((_, props) => ({
       editing: false,
-      text: props.text || ""
+      text: props.text || "",
     }))
   }
 
@@ -125,16 +125,16 @@ export default class ListItem extends React.Component<
       this.delete()
     } else if (this.props.recipeID) {
       this.props.update(this.props.recipeID, this.props.id, {
-        text: this.state.text
+        text: this.state.text,
       })
     } else {
       this.props.update(-1, this.props.id, {
-        text: this.state.text
+        text: this.state.text,
       })
     }
     this.setState({
       editing: false,
-      unsavedChanges: false
+      unsavedChanges: false,
     })
   }
 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -32,7 +32,7 @@ interface ILoginState {
 class Login extends React.Component<ILoginProps, ILoginState> {
   state = {
     email: "",
-    password: ""
+    password: "",
   }
 
   componentWillMount = () => {
@@ -45,7 +45,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as ILoginState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -23,7 +23,7 @@ const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "list",
   "linkReference",
   "link",
-  "listItem"
+  "listItem",
 ]
 
 interface IMarkdownProps {
@@ -37,7 +37,7 @@ export function Markdown({
   children: text,
   className,
   title,
-  onClick
+  onClick,
 }: IMarkdownProps) {
   return (
     <MarkdownWrapper className={className} title={title} onClick={onClick}>

--- a/frontend/src/components/MemberRow.tsx
+++ b/frontend/src/components/MemberRow.tsx
@@ -7,7 +7,7 @@ import { ButtonPlain, ButtonDanger } from "@/components/Buttons"
 import {
   settingUserTeamLevelAsync,
   deletingMembershipAsync,
-  Dispatch
+  Dispatch,
 } from "@/store/thunks"
 import { ITeam, IMember } from "@/store/reducers/teams"
 import { IState } from "@/store/store"
@@ -27,12 +27,12 @@ interface IMemberRowProps {
   readonly handleUserLevelChange: (
     teamID: ITeam["id"],
     membershipID: IMember["id"],
-    level: IMember["level"]
+    level: IMember["level"],
   ) => void
   readonly deleteMembership: (
     teamID: ITeam["id"],
     membershipID: IMember["id"],
-    leaving?: boolean
+    leaving?: boolean,
   ) => void
   readonly isUser?: boolean
   readonly isActive?: IMember["is_active"]
@@ -50,7 +50,7 @@ const MemberRow = ({
   deleteMembership,
   isUser,
   isActive,
-  deleting
+  deleting,
 }: IMemberRowProps) => (
   <tr key={membershipID}>
     <td className="d-flex align-items-center pr-4">
@@ -77,7 +77,7 @@ const MemberRow = ({
               teamID,
               membershipID,
               /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
-              e.target.value as "admin" | "contributor" | "read"
+              e.target.value as "admin" | "contributor" | "read",
             )
           }>
           <option value="admin">Admin</option>
@@ -108,8 +108,8 @@ const mapStateToProps = (
   {
     userID,
     teamID,
-    membershipID
-  }: Pick<IMemberRowProps, "userID" | "teamID" | "membershipID">
+    membershipID,
+  }: Pick<IMemberRowProps, "userID" | "teamID" | "membershipID">,
 ) => {
   const team = state.teams.byId[teamID]
   const members = team?.members ?? {}
@@ -121,13 +121,13 @@ const mapStateToProps = (
     userIsTeamAdmin: Object.values(members)
       .filter(notUndefined)
       .filter(x => x.level === "admin")
-      .some(({ user }) => user.id === state.user.id)
+      .some(({ user }) => user.id === state.user.id),
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   handleUserLevelChange: settingUserTeamLevelAsync(dispatch),
-  deleteMembership: deletingMembershipAsync(dispatch)
+  deleteMembership: deletingMembershipAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(MemberRow)

--- a/frontend/src/components/MetaData.tsx
+++ b/frontend/src/components/MetaData.tsx
@@ -61,7 +61,7 @@ const MetaData = ({
   time = "",
   owner,
   onClick,
-  recipeId
+  recipeId,
 }: IMetaDataProps) => {
   const _author = isValid(author) ? (
     <MetaPiece>

--- a/frontend/src/components/Nav.test.tsx
+++ b/frontend/src/components/Nav.test.tsx
@@ -9,7 +9,7 @@ describe("<Nav/>", () => {
     const tree = renderer.create(
       <TestProvider>
         <Navbar />
-      </TestProvider>
+      </TestProvider>,
     )
     expect(tree).toMatchSnapshot()
   })
@@ -20,13 +20,13 @@ describe("<Nav/>", () => {
       ...emptyState,
       user: {
         ...emptyState.user,
-        loggedIn: true
-      }
+        loggedIn: true,
+      },
     })
     const tree = renderer.create(
       <TestProvider store={store}>
         <Navbar />
-      </TestProvider>
+      </TestProvider>,
     )
     expect(tree).toMatchSnapshot()
   })

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -11,7 +11,7 @@ import { styled } from "@/theme"
 import {
   DropdownContainer,
   useDropdown,
-  DropdownMenu
+  DropdownMenu,
 } from "@/components/Dropdown"
 import { Chevron } from "@/components/icons"
 import { lighten } from "polished"
@@ -37,7 +37,7 @@ function useTeams() {
     fetchingTeamsAsync(dispatch)()
   }, [dispatch])
   const loading = useSelector(
-    s => s.teams.status === "loading" || s.teams.status === "initial"
+    s => s.teams.status === "loading" || s.teams.status === "initial",
   )
   const teams = useSelector(teamsFrom)
   if (loading) {

--- a/frontend/src/components/NoMatch.test.tsx
+++ b/frontend/src/components/NoMatch.test.tsx
@@ -8,7 +8,7 @@ describe("<NoMatch/>", () => {
     mount(
       <MemoryRouter>
         <NoMatch />
-      </MemoryRouter>
+      </MemoryRouter>,
     )
   })
 })

--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -9,7 +9,7 @@ import {
   updateNote,
   toggleEditingNoteById,
   deleteNote,
-  INote
+  INote,
 } from "@/store/reducers/recipes"
 import { ButtonPrimary, ButtonSecondary } from "@/components/Buttons"
 import { classNames } from "@/classnames"
@@ -87,7 +87,7 @@ function useNoteEditHandlers({ note, recipeId }: IUseNoteEditHandlers) {
     onEditorChange,
     onEditorKeyDown,
     onNoteClick,
-    onSave
+    onSave,
   }
 }
 
@@ -118,7 +118,7 @@ export function Note({ recipeId, note, className }: INoteProps) {
     onEditorChange,
     onEditorKeyDown,
     onNoteClick,
-    onSave
+    onSave,
   } = useNoteEditHandlers({ note, recipeId })
 
   const ref = React.useRef<HTMLDivElement>(null)
@@ -137,9 +137,9 @@ export function Note({ recipeId, note, className }: INoteProps) {
       className={classNames(
         "d-flex align-items-start",
         {
-          "bg-highlight": isSharedNote
+          "bg-highlight": isSharedNote,
         },
-        className
+        className,
       )}
       id={noteId}>
       <Avatar avatarURL={note.created_by.avatar_url} className="mr-2" />
@@ -235,7 +235,7 @@ function useNoteCreatorHandlers({ recipeId }: IUseNoteCreatorHandlers) {
   const editorMinRowCount = isEditing ? 5 : 0
   const editorClassNames = classNames({
     "my-textarea mb-2": isEditing,
-    textarea: !isEditing
+    textarea: !isEditing,
   })
 
   return {
@@ -249,7 +249,7 @@ function useNoteCreatorHandlers({ recipeId }: IUseNoteCreatorHandlers) {
     onEditorFocus,
     onCreate,
     isLoading,
-    onCancel
+    onCancel,
   }
 }
 
@@ -268,9 +268,9 @@ function NoteCreator({ recipeId }: INoteCreatorProps) {
     onEditorFocus,
     onCreate,
     isLoading,
-    onCancel
+    onCancel,
   } = useNoteCreatorHandlers({
-    recipeId
+    recipeId,
   })
   return (
     <div>

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -10,7 +10,7 @@ const notification = ({
   level = "info",
   show = true,
   closeable = true,
-  close
+  close,
 }: INotificationProps) => {
   if (show) {
     return (

--- a/frontend/src/components/NotificationsDropdown.tsx
+++ b/frontend/src/components/NotificationsDropdown.tsx
@@ -5,7 +5,7 @@ import { ButtonPrimary } from "@/components/Buttons"
 import {
   acceptingInviteAsync,
   fetchingInvitesAsync,
-  decliningInviteAsync
+  decliningInviteAsync,
 } from "@/store/thunks"
 
 import { teamURL } from "@/urls"
@@ -13,7 +13,7 @@ import { getInvites, IInvite } from "@/store/reducers/invites"
 import {
   DropdownContainer,
   useDropdown,
-  DropdownMenu
+  DropdownMenu,
 } from "@/components/Dropdown"
 import { Chevron } from "@/components/icons"
 import { useDispatch, useSelector } from "@/hooks"

--- a/frontend/src/components/OAuth.test.tsx
+++ b/frontend/src/components/OAuth.test.tsx
@@ -8,7 +8,7 @@ describe("<OAuth/>", () => {
     mount(
       <TestProvider>
         <OAuth service="gitlab" token="12345" login={jest.fn()} />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/Owner.tsx
+++ b/frontend/src/components/Owner.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom"
 import {
   ButtonLink,
   ButtonSecondary,
-  ButtonPrimary
+  ButtonPrimary,
 } from "@/components/Buttons"
 
 import {
@@ -14,7 +14,7 @@ import {
   showNotificationWithTimeoutAsync,
   Dispatch,
   INotificationWithTimeout,
-  fetchingTeamsAsync
+  fetchingTeamsAsync,
 } from "@/store/thunks"
 import { IState } from "@/store/store"
 import { IRecipe } from "@/store/reducers/recipes"
@@ -28,7 +28,7 @@ import { notUndefined } from "@/utils/general"
 
 function getTeamUserKeys(
   teams: ITeamsState,
-  userId: IUser["id"] | null
+  userId: IUser["id"] | null,
 ): ReadonlyArray<{ id: string; name: string }> {
   return teams.allIds
     .map(id => {
@@ -38,7 +38,7 @@ function getTeamUserKeys(
       }
       return {
         id: id + "-team",
-        name: team.name
+        name: team.name,
       }
     })
     .filter(notUndefined)
@@ -47,14 +47,14 @@ function getTeamUserKeys(
 
 const mapStateToProps = (state: IState) => ({
   teams: state.teams,
-  userId: state.user.id
+  userId: state.user.id,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   fetchData: fetchingTeamsAsync(dispatch),
   showNotificationWithTimeout: showNotificationWithTimeoutAsync(dispatch),
   moveRecipeTo: moveRecipeToAsync(dispatch),
-  copyRecipeTo: copyRecipeToAsync(dispatch)
+  copyRecipeTo: copyRecipeToAsync(dispatch),
 })
 
 interface IOwnerProps {
@@ -62,15 +62,15 @@ interface IOwnerProps {
   readonly copyRecipeTo: (
     recipeId: IRecipe["id"],
     id: IRecipe["owner"]["id"],
-    type: IRecipe["owner"]["type"]
+    type: IRecipe["owner"]["type"],
   ) => Promise<void>
   readonly moveRecipeTo: (
     recipeId: IRecipe["id"],
     id: IRecipe["owner"]["id"],
-    type: IRecipe["owner"]["type"]
+    type: IRecipe["owner"]["type"],
   ) => Promise<Result<void, void>>
   readonly showNotificationWithTimeout: (
-    props: INotificationWithTimeout
+    props: INotificationWithTimeout,
   ) => void
   readonly recipeId: IRecipe["id"]
   readonly id: IRecipe["owner"]["id"]
@@ -87,7 +87,7 @@ interface IOwnerState {
 class Owner extends React.Component<IOwnerProps, IOwnerState> {
   state: IOwnerState = {
     show: false,
-    values: []
+    values: [],
   }
 
   dropdown = React.createRef<HTMLSpanElement>()
@@ -163,7 +163,7 @@ class Owner extends React.Component<IOwnerProps, IOwnerState> {
           this.props.showNotificationWithTimeout({
             message: `Problem moving recipe: ${res.error}`,
             level: "danger",
-            sticky: true
+            sticky: true,
           })
         }
       })

--- a/frontend/src/components/PasswordChange.tsx
+++ b/frontend/src/components/PasswordChange.tsx
@@ -38,11 +38,11 @@ class PasswordChange extends React.Component<
     password: "",
     oldPassword: "",
     newPassword: "",
-    newPasswordAgain: ""
+    newPasswordAgain: "",
   }
 
   static defaultProps = {
-    setPassword: false
+    setPassword: false,
   }
 
   componentWillMount = () => {
@@ -52,7 +52,7 @@ class PasswordChange extends React.Component<
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as IPasswordChangestate)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
@@ -63,7 +63,7 @@ class PasswordChange extends React.Component<
     this.props.update({
       password1: newPassword,
       password2: newPasswordAgain,
-      oldPassword
+      oldPassword,
     })
   }
 

--- a/frontend/src/components/PasswordReset.test.tsx
+++ b/frontend/src/components/PasswordReset.test.tsx
@@ -8,12 +8,12 @@ describe("<PasswordReset/>", () => {
     const props = {
       error: {},
       loading: false,
-      reset: () => Promise.resolve()
+      reset: () => Promise.resolve(),
     }
     mount(
       <TestProvider>
         <PasswordReset loggedIn={false} {...props} />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/PasswordReset.tsx
+++ b/frontend/src/components/PasswordReset.tsx
@@ -23,13 +23,13 @@ class PasswordReset extends React.Component<
   IPasswordResetState
 > {
   state: IPasswordResetState = {
-    email: ""
+    email: "",
   }
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as IPasswordResetState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }

--- a/frontend/src/components/PasswordResetConfirmation.tsx
+++ b/frontend/src/components/PasswordResetConfirmation.tsx
@@ -19,12 +19,12 @@ const mapStateToProps = (state: IState, props: RouteProps) => {
     uid,
     token,
     loading: state.auth.loadingResetConfirmation,
-    error: state.auth.errorResetConfirmation
+    error: state.auth.errorResetConfirmation,
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  reset: reset(dispatch)
+  reset: reset(dispatch),
 })
 
 interface IPasswordResetConfirmationProps {
@@ -32,7 +32,7 @@ interface IPasswordResetConfirmationProps {
     uid: string,
     token: string,
     newPassword1: string,
-    newPassword2: string
+    newPassword2: string,
   ) => Promise<void>
   readonly uid: string
   readonly token: string
@@ -51,13 +51,13 @@ class PasswordResetConfirmation extends React.Component<
 > {
   state = {
     newPassword1: "",
-    newPassword2: ""
+    newPassword2: "",
   }
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as IPasswordResetConfirmationState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
@@ -68,11 +68,11 @@ class PasswordResetConfirmation extends React.Component<
       this.props.uid,
       this.props.token,
       this.state.newPassword1,
-      this.state.newPassword2
+      this.state.newPassword2,
     )
     this.setState({
       newPassword1: "",
-      newPassword2: ""
+      newPassword2: "",
     })
   }
 
@@ -139,5 +139,5 @@ class PasswordResetConfirmation extends React.Component<
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(PasswordResetConfirmation)

--- a/frontend/src/components/Recipe.test.tsx
+++ b/frontend/src/components/Recipe.test.tsx
@@ -9,12 +9,12 @@ import {
   IRecipe,
   fetchRecipe,
   IRecipesState,
-  initialState
+  initialState,
 } from "@/store/reducers/recipes"
 import {
   baseRecipe,
   baseIngredient,
-  baseStep
+  baseStep,
 } from "@/store/reducers/recipes.test"
 import { TestProvider } from "@/testUtils"
 import { RecipeTimeline } from "@/components/RecipeTimeline"
@@ -36,7 +36,7 @@ function testHook<T>(func: () => T, store: Store): T {
   const root = mount(
     <TestProvider store={store}>
       <TestComponent />
-    </TestProvider>
+    </TestProvider>,
   )
 
   return root.find<ISpanProps<T>>(Span).props().output
@@ -44,7 +44,7 @@ function testHook<T>(func: () => T, store: Store): T {
 
 function rendererCreate<T>(x: ReactElement<T>) {
   return renderer.create(x, {
-    createNodeMock: () => document.createElement("textarea")
+    createNodeMock: () => document.createElement("textarea"),
   })
 }
 
@@ -54,22 +54,22 @@ describe("<Recipe/>", () => {
     url: "/recipes/98-apple-crisp",
     isExact: true,
     params: {
-      id: "98"
-    }
+      id: "98",
+    },
   }
   const location: Location = {
     pathname: "/recipes/98-apple-crisp",
     search: "?timeline=1",
     hash: "",
     key: "u3gfv7",
-    state: null
+    state: null,
   }
 
   it("renders without failure", () => {
     mount(
       <TestProvider>
         <Recipe history={history} match={match} location={location} />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 
@@ -80,13 +80,13 @@ describe("<Recipe/>", () => {
         id: 98,
         name: "Apple Crisp",
         ingredients: [baseIngredient],
-        steps: [baseStep]
+        steps: [baseStep],
       }
       const store = createEmptyStore()
 
       const actions = [
         fetchRecipe.failure({ id: recipe.id, error404: true }),
-        fetchRecipe.success(recipe)
+        fetchRecipe.success(recipe),
       ]
 
       actions.forEach(action => {
@@ -101,7 +101,7 @@ describe("<Recipe/>", () => {
               match={match}
               location={{ ...location, search: "?timeline=1" }}
             />
-          </TestProvider>
+          </TestProvider>,
         ).toJSON()
         expect(tree).toMatchSnapshot()
       })
@@ -114,7 +114,7 @@ describe("<Recipe/>", () => {
         id: 98,
         name: "Apple Crisp",
         ingredients: [baseIngredient],
-        steps: [baseStep]
+        steps: [baseStep],
       }
 
       store.dispatch(fetchRecipe.success(recipe))
@@ -126,7 +126,7 @@ describe("<Recipe/>", () => {
             match={match}
             location={{ ...location, search: "?timeline=1" }}
           />
-        </TestProvider>
+        </TestProvider>,
       )
       expect(root.toJSON()).toMatchSnapshot()
 
@@ -137,7 +137,7 @@ describe("<Recipe/>", () => {
             match={match}
             location={{ ...location, search: "" }}
           />
-        </TestProvider>
+        </TestProvider>,
       )
       expect(root.toJSON()).toMatchSnapshot()
     })
@@ -148,19 +148,19 @@ describe("<Recipe/>", () => {
         id: 98,
         name: "Apple Crisp",
         ingredients: [baseIngredient],
-        steps: [baseStep]
+        steps: [baseStep],
       }
 
       const recipes: IRecipesState = {
         ...initialState,
         byId: {
-          98: Success(recipe)
-        }
+          98: Success(recipe),
+        },
       }
       const emptyState = createEmptyStore().getState()
       const store = createEmptyStore({
         ...emptyState,
-        recipes
+        recipes,
       })
 
       const res = testHook(() => useRecipe(recipe.id), store)
@@ -172,7 +172,7 @@ describe("<Recipe/>", () => {
         .create(
           <TestProvider>
             <RecipeTimeline createdAt="1776-1-1" recipeId={10} />
-          </TestProvider>
+          </TestProvider>,
         )
         .toJSON()
       expect(timelineTree).toMatchSnapshot()

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -15,7 +15,7 @@ import {
   deleteIngredient,
   updateIngredient,
   IIngredient,
-  updateSectionForRecipe
+  updateSectionForRecipe,
 } from "@/store/reducers/recipes"
 import { isInitial, isLoading, isFailure } from "@/webdata"
 import { SectionTitle } from "@/components/RecipeHelpers"
@@ -48,19 +48,19 @@ type SectionsAndIngredients = ReadonlyArray<
 
 function getInitialIngredients({
   sections,
-  ingredients
+  ingredients,
 }: Pick<IRecipe, "sections" | "ingredients">): SectionsAndIngredients {
   const out: Mutable<SectionsAndIngredients> = []
   for (const s of sections) {
     out.push({
       kind: "section" as const,
-      item: s
+      item: s,
     })
   }
   for (const i of ingredients) {
     out.push({
       kind: "ingredient" as const,
-      item: i
+      item: i,
     })
   }
   return sortBy(out, x => x.item.position)
@@ -77,14 +77,14 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
     setSectionsAndIngredients(
       getInitialIngredients({
         sections: recipe.sections,
-        ingredients: recipe.ingredients
-      })
+        ingredients: recipe.ingredients,
+      }),
     )
   }, [recipe.ingredients, recipe.sections])
 
   const handleMove = ({
     from,
-    to
+    to,
   }: {
     readonly from: number
     readonly to: number
@@ -117,16 +117,16 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
               ...item,
               item: {
                 ...item.item,
-                position: newPosition
-              }
+                position: newPosition,
+              },
             })
           } else {
             out.push({
               ...item,
               item: {
                 ...item.item,
-                position: newPosition
-              }
+                position: newPosition,
+              },
             })
           }
         } else {
@@ -140,8 +140,8 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
         updateIngredient.request({
           recipeID: recipe.id,
           ingredientID: args.id,
-          content: { position: newPosition }
-        })
+          content: { position: newPosition },
+        }),
       )
     } else {
       api
@@ -152,8 +152,8 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
               updateSectionForRecipe({
                 recipeId: recipe.id,
                 sectionId: args.id,
-                position: newPosition
-              })
+                position: newPosition,
+              }),
             )
           }
         })
@@ -167,8 +167,8 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
     dispatch(
       deleteIngredient.request({
         recipeID: recipe.id,
-        ingredientID: ingredientId
-      })
+        ingredientID: ingredientId,
+      }),
     )
 
   const handleUpdate = ({
@@ -185,8 +185,8 @@ function RecipeDetails({ recipe }: { readonly recipe: IRecipe }) {
       updateIngredient.request({
         recipeID: recipe.id,
         ingredientID: ingredientId,
-        content: ingredient
-      })
+        content: ingredient,
+      }),
     )
 
   return (

--- a/frontend/src/components/RecipeItem.test.tsx
+++ b/frontend/src/components/RecipeItem.test.tsx
@@ -15,7 +15,7 @@ describe("RecipeItem", () => {
           name="foo"
           drag
         />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/RecipeItem.tsx
+++ b/frontend/src/components/RecipeItem.tsx
@@ -56,16 +56,16 @@ export function RecipeItem({ name, author, id, ...props }: IRecipeItemProps) {
     },
     collect: monitor => {
       return {
-        isDragging: monitor.isDragging()
+        isDragging: monitor.isDragging(),
       }
-    }
+    },
   })
 
   return (
     <section
       ref={props.drag ? drag : undefined}
       className={classNames("card", {
-        "cursor-move": props.drag
+        "cursor-move": props.drag,
       })}
       style={{ opacity: isDragging ? 0.5 : 1 }}>
       <div className="card-content h-100 d-flex flex-column">

--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -70,7 +70,7 @@ function RecipesListSearch({
   recipes,
   drag,
   scroll,
-  teamID
+  teamID,
 }: IRecipesProps) {
   const [query, setQuery] = useState(getInitialQuery)
 
@@ -97,17 +97,17 @@ function RecipesListSearch({
 
 function mapStateToProps(
   state: IState,
-  ownProps: Pick<IRecipesProps, "teamID">
+  ownProps: Pick<IRecipesProps, "teamID">,
 ): Pick<IRecipesProps, "recipes"> {
   return {
-    recipes: getTeamRecipes(state, ownProps.teamID || "personal")
+    recipes: getTeamRecipes(state, ownProps.teamID || "personal"),
   }
 }
 
 const mapDispatchToProps = (
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ): Pick<IRecipesProps, "fetchData"> => ({
-  fetchData: fetchingRecipeListAsync(dispatch)
+  fetchData: fetchingRecipeListAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(RecipesListSearch)

--- a/frontend/src/components/RecipeTimeline.tsx
+++ b/frontend/src/components/RecipeTimeline.tsx
@@ -7,7 +7,7 @@ import {
   isSuccessLike,
   isLoading,
   isFailure,
-  isInitial
+  isInitial,
 } from "@/webdata"
 import { IRecipe } from "@/store/reducers/recipes"
 import { getRecipeTimeline, IRecipeTimelineEvent } from "@/api"
@@ -90,7 +90,7 @@ function toTimelineEvent(event: IRecipeTimelineEvent): ITimelineEvent {
   return {
     type: "scheduled",
     id: event.id,
-    date: new Date(event.on)
+    date: new Date(event.on),
   }
 }
 
@@ -99,7 +99,7 @@ function useRecipeTimeline(recipeId: IRecipe["id"]): IRecipeTimelineState {
   React.useEffect(() => {
     getRecipeTimeline(recipeId).then(res => {
       setState(
-        mapSuccessLike(resultToWebdata(res), d => d.map(toTimelineEvent))
+        mapSuccessLike(resultToWebdata(res), d => d.map(toTimelineEvent)),
       )
     })
   }, [recipeId])

--- a/frontend/src/components/RecipeTitle.tsx
+++ b/frontend/src/components/RecipeTitle.tsx
@@ -5,7 +5,7 @@ import {
   IRecipe,
   updateRecipe,
   deleteRecipe,
-  toggleEditingRecipe
+  toggleEditingRecipe,
 } from "@/store/reducers/recipes"
 import GlobalEvent from "@/components/GlobalEvent"
 import { TextInput } from "@/components/Forms"
@@ -48,7 +48,7 @@ class RecipeTitle extends React.Component<
 > {
   state: IRecipeTitleState = {
     show: false,
-    recipe: {}
+    recipe: {},
   }
 
   toggleEdit = () => this.props.toggleEditing(this.props.id)
@@ -66,15 +66,15 @@ class RecipeTitle extends React.Component<
     this.setState(prevState => ({
       recipe: {
         ...prevState.recipe,
-        [e.target.name]: e.target.value
-      }
+        [e.target.name]: e.target.value,
+      },
     }))
   }
 
   handleDelete = () => {
     if (
       confirm(
-        `Are you sure you want to delete this recipe "${this.props.name}"?`
+        `Are you sure you want to delete this recipe "${this.props.name}"?`,
       )
     ) {
       this.props.remove(this.props.id)
@@ -108,7 +108,7 @@ class RecipeTitle extends React.Component<
       time,
       owner,
       updating,
-      deleting
+      deleting,
     } = this.props
     return (
       <div>
@@ -232,7 +232,7 @@ class RecipeTitle extends React.Component<
 const mapDispatchToProps = {
   update: updateRecipe.request,
   remove: deleteRecipe.request,
-  toggleEditing: toggleEditingRecipe
+  toggleEditing: toggleEditingRecipe,
 }
 
 export default connect(null, mapDispatchToProps)(RecipeTitle)

--- a/frontend/src/components/RecipeTitleDropdown.tsx
+++ b/frontend/src/components/RecipeTitleDropdown.tsx
@@ -12,7 +12,7 @@ import {
   DropdownItemLink,
   DropdownItemButton,
   DropdownMenu,
-  useDropdown
+  useDropdown,
 } from "@/components/Dropdown"
 
 function useScheduleUrl(recipeId: number) {
@@ -44,7 +44,7 @@ interface IUseDuplicateRecipe {
 
 function useDuplicateRecipe({
   recipeId,
-  onComplete
+  onComplete,
 }: IUseDuplicateRecipe): [boolean, () => void] {
   const dispatch = useDispatch()
 
@@ -68,14 +68,14 @@ export function Dropdown({ recipeId }: IDropdownProps) {
 
   const [creatingDuplicate, onDuplicate] = useDuplicateRecipe({
     recipeId,
-    onComplete: close
+    onComplete: close,
   })
 
   const handleCopyIngredients = React.useCallback(() => {
     copyToClipboard(ingredients)
     showNotificationWithTimeoutAsync(dispatch)({
       message: "Copied ingredients to clipboard!",
-      level: "info"
+      level: "info",
     })
     close()
   }, [close, dispatch, ingredients])

--- a/frontend/src/components/Schedule.tsx
+++ b/frontend/src/components/Schedule.tsx
@@ -22,7 +22,7 @@ function Sidebar({ teamID, isRecipes }: ISidebarProps) {
   const arrow = closed ? "→" : "←"
 
   const sideBarStyle = {
-    display: closed ? "none" : ""
+    display: closed ? "none" : "",
   }
 
   const recipesURL =
@@ -115,7 +115,7 @@ export default connect(
     return {
       updateTeamID: updatingTeamIDAsync(dispatch),
       teamID,
-      type: ownProps.match.params["type"]
+      type: ownProps.match.params["type"],
     }
-  }
+  },
 )(Schedule)

--- a/frontend/src/components/Section.tsx
+++ b/frontend/src/components/Section.tsx
@@ -8,7 +8,7 @@ import { isOk } from "@/result"
 import { useDispatch } from "@/hooks"
 import {
   removeSectionFromRecipe,
-  updateSectionForRecipe
+  updateSectionForRecipe,
 } from "@/store/reducers/recipes"
 
 type State = {
@@ -23,7 +23,7 @@ function getInitialState(title: string) {
     updating: "initial",
     removing: "initial",
     editing: false,
-    localTitle: title
+    localTitle: title,
   } as const
 }
 
@@ -33,7 +33,7 @@ export function Section({
   recipeId,
   title,
   move,
-  completeMove
+  completeMove,
 }: {
   readonly index: number
   readonly recipeId: number
@@ -41,7 +41,7 @@ export function Section({
   readonly title: string
   readonly move: ({
     from,
-    to
+    to,
   }: {
     readonly from: number
     readonly to: number
@@ -49,7 +49,7 @@ export function Section({
   readonly completeMove: ({
     kind,
     id,
-    to
+    to,
   }: {
     readonly kind: "section"
     readonly id: number
@@ -86,8 +86,8 @@ export function Section({
             recipeId,
             sectionId,
             title: res.data.title,
-            position: res.data.position
-          })
+            position: res.data.position,
+          }),
         )
         setState(prev => ({ ...prev, updating: "success", editing: false }))
       } else {
@@ -104,25 +104,25 @@ export function Section({
     hover: handleDndHover({
       ref,
       index,
-      move
-    })
+      move,
+    }),
   })
 
   const [{ isDragging }, drag, preview] = useDrag({
     item: {
       type: DragDrop.SECTION,
-      index
+      index,
     },
     end: () => {
       completeMove({ kind: "section", id: sectionId, to: index })
     },
     collect: monitor => ({
-      isDragging: monitor.isDragging()
-    })
+      isDragging: monitor.isDragging(),
+    }),
   })
 
   const style: React.CSSProperties = {
-    opacity: isDragging ? 0 : 1
+    opacity: isDragging ? 0 : 1,
   }
 
   preview(drag(drop(ref)))

--- a/frontend/src/components/Sessions.tsx
+++ b/frontend/src/components/Sessions.tsx
@@ -10,7 +10,7 @@ import {
   Dispatch,
   fetchingSessionsAsync,
   loggingOutSessionByIdAsync,
-  loggingOutAllSessionsAsync
+  loggingOutAllSessionsAsync,
 } from "@/store/thunks"
 
 function getDeviceEmoji(kind: ISession["device"]["kind"]): string | null {
@@ -70,7 +70,7 @@ interface ISessionProps extends ISession {
 
 function Session(props: ISessionProps) {
   const lastActivity = formatDistanceToNow(new Date(props.last_activity), {
-    addSuffix: true
+    addSuffix: true,
   })
   return (
     <li className="mb-2">
@@ -103,7 +103,7 @@ function SessionListBasic({
   logoutAll,
   logoutById,
   loggingOutAll,
-  fetchData
+  fetchData,
 }: ISessionListProps) {
   useEffect(() => {
     fetchData()
@@ -136,18 +136,18 @@ function SessionListBasic({
 
 const mapStateToProps = (state: IState) => ({
   sessions: state.user.sessions,
-  loggingOutAll: state.user.loggingOutAllSessionsStatus
+  loggingOutAll: state.user.loggingOutAllSessionsStatus,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   fetchData: fetchingSessionsAsync(dispatch),
   logoutById: loggingOutSessionByIdAsync(dispatch),
-  logoutAll: loggingOutAllSessionsAsync(dispatch)
+  logoutAll: loggingOutAllSessionsAsync(dispatch),
 })
 
 const SessionList = connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(SessionListBasic)
 
 export default function Sessions() {

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -156,7 +156,7 @@ export default class Settings extends React.Component<
 > {
   state: ISettingsState = {
     email: this.props.email,
-    editing: false
+    editing: false,
   }
 
   componentWillReceiveProps = (nextProps: ISettingsProps) => {
@@ -170,7 +170,7 @@ export default class Settings extends React.Component<
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as ISettingsState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }

--- a/frontend/src/components/ShoppingList.test.ts
+++ b/frontend/src/components/ShoppingList.test.ts
@@ -8,7 +8,7 @@ describe("shoppinglist", () => {
       [{ quantity: "1", unit: Unit.SOME }, "some"],
       [{ quantity: "1", unit: Unit.UNKNOWN }, "1"],
       [{ quantity: "1", unit: Unit.UNKNOWN, unknown_unit: "bag" }, "1 bag"],
-      [{ quantity: "1", unit: Unit.NONE }, "1"]
+      [{ quantity: "1", unit: Unit.NONE }, "1"],
     ]
 
     testCases.forEach(([quantity, expected]) => {

--- a/frontend/src/components/ShoppingList.tsx
+++ b/frontend/src/components/ShoppingList.tsx
@@ -13,7 +13,7 @@ import {
   reportBadMergeAsync,
   showNotificationWithTimeoutAsync,
   Dispatch,
-  fetchingShoppingListAsync
+  fetchingShoppingListAsync,
 } from "@/store/thunks"
 
 import { ingredientByNameAlphabetical } from "@/sorters"
@@ -22,7 +22,7 @@ import DateRangePicker from "@/components/DateRangePicker/DateRangePicker"
 import { IState } from "@/store/store"
 import {
   setSelectingStart,
-  setSelectingEnd
+  setSelectingEnd,
 } from "@/store/reducers/shoppinglist"
 import GlobalEvent from "@/components/GlobalEvent"
 import { Button } from "@/components/Buttons"
@@ -32,14 +32,14 @@ import {
   isFailure,
   isLoading,
   isSuccessOrRefetching,
-  isRefetching
+  isRefetching,
 } from "@/webdata"
 import { classNames } from "@/classnames"
 import {
   IGetShoppingListResponse,
   IIngredientItem,
   IQuantity,
-  Unit
+  Unit,
 } from "@/api"
 
 const selectElementText = (el: Element) => {
@@ -96,7 +96,7 @@ function quantitiesToString(quantities: ReadonlyArray<IQuantity>): string {
 
 function ShoppingListItem({
   item: [name, { quantities }],
-  isFirst
+  isFirst,
 }: IShoppingListItemProps) {
   // padding serves to prevent the button from appearing in front of text
   // we also use <section>s instead of <p>s to avoid extra new lines in Chrome
@@ -187,7 +187,7 @@ interface IShoppingListProps {
 export const enum Selecting {
   End,
   Start,
-  None
+  None,
 }
 
 function ShoppingList({
@@ -199,7 +199,7 @@ function ShoppingList({
   setEndDay: propsSetEndDay,
   shoppinglist,
   sendToast,
-  reportBadMerge
+  reportBadMerge,
 }: IShoppingListProps) {
   const element = useRef<HTMLDivElement>(null)
   const [month, setMonth] = useState(new Date())
@@ -299,7 +299,7 @@ function mapStateToProps(state: IState) {
   return {
     startDay: state.shoppinglist.startDay,
     endDay: state.shoppinglist.endDay,
-    shoppinglist: state.shoppinglist.shoppinglist
+    shoppinglist: state.shoppinglist.shoppinglist,
   }
 }
 
@@ -309,7 +309,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   setEndDay: (date: Date) => dispatch(setSelectingEnd(date)),
   reportBadMerge: reportBadMergeAsync(dispatch),
   sendToast: (message: string) =>
-    showNotificationWithTimeoutAsync(dispatch)({ message, level: "info" })
+    showNotificationWithTimeoutAsync(dispatch)({ message, level: "info" }),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ShoppingList)

--- a/frontend/src/components/Signup.tsx
+++ b/frontend/src/components/Signup.tsx
@@ -25,7 +25,7 @@ class Signup extends React.Component<ISignupProps, ISignupState> {
   state = {
     email: "",
     password1: "",
-    password2: ""
+    password2: "",
   }
 
   componentWillMount = () => {
@@ -35,7 +35,7 @@ class Signup extends React.Component<ISignupProps, ISignupState> {
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as ISignupState)
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
   }
@@ -45,7 +45,7 @@ class Signup extends React.Component<ISignupProps, ISignupState> {
     this.props.signup(
       this.state.email,
       this.state.password1,
-      this.state.password2
+      this.state.password2,
     )
   }
 

--- a/frontend/src/components/SocialAccountSettings.tsx
+++ b/frontend/src/components/SocialAccountSettings.tsx
@@ -6,7 +6,7 @@ import { GithubImg, GitlabImg, GoogleImg } from "@/components/SocialButtons"
 import {
   GITHUB_OAUTH_URL,
   GITLAB_OAUTH_URL,
-  GOOGLE_OAUTH_URL
+  GOOGLE_OAUTH_URL,
 } from "@/settings"
 import { SocialProvider, ISocialAccountsState } from "@/store/reducers/user"
 
@@ -16,7 +16,7 @@ import { connect } from "react-redux"
 import {
   Dispatch,
   fetchSocialConnectionsAsync,
-  disconnectSocialAccountAsync
+  disconnectSocialAccountAsync,
 } from "@/store/thunks"
 import {
   WebData,
@@ -25,7 +25,7 @@ import {
   Loading,
   Failure,
   isFailure,
-  isLoading
+  isLoading,
 } from "@/webdata"
 
 function createRedirectURI(uri: string) {
@@ -55,7 +55,7 @@ interface IOAuthButtonProps {
   readonly Logo: () => JSX.Element
   readonly connection: number | null
   readonly disconnect: (
-    providerName: SocialProvider
+    providerName: SocialProvider,
   ) => Promise<Result<void, string>>
   readonly OAUTH_URL: string
 }
@@ -65,7 +65,7 @@ const OAuthButton = ({
   Logo,
   OAUTH_URL,
   disconnect,
-  connection
+  connection,
 }: IOAuthButtonProps) => {
   const [state, setState] = useState<WebData<void, string>>(undefined)
   const handleDisconnect = async () => {
@@ -110,12 +110,12 @@ const OAuthButton = ({
 }
 
 const mapDispatchToPropsOAuthButton = (dispatch: Dispatch) => ({
-  disconnect: disconnectSocialAccountAsync(dispatch)
+  disconnect: disconnectSocialAccountAsync(dispatch),
 })
 
 const ConnectedOAuthButton = connect(
   null,
-  mapDispatchToPropsOAuthButton
+  mapDispatchToPropsOAuthButton,
 )(OAuthButton)
 
 interface IProvider {
@@ -127,7 +127,7 @@ interface IProvider {
 const providers: ReadonlyArray<IProvider> = [
   { name: "Github", id: "github", logo: GithubImg, oauthUrl: GITHUB_OAUTH_URL },
   { name: "Gitlab", id: "gitlab", logo: GitlabImg, oauthUrl: GITLAB_OAUTH_URL },
-  { name: "Google", id: "google", logo: GoogleImg, oauthUrl: GOOGLE_OAUTH_URL }
+  { name: "Google", id: "google", logo: GoogleImg, oauthUrl: GOOGLE_OAUTH_URL },
 ]
 interface IGenerateOAuthButtonsProps {
   readonly state: ISocialAccountsState
@@ -172,12 +172,12 @@ function SocialAccounts({ fetchData, connections }: ISocialAccountsProps) {
 }
 
 const mapStateToProps = (state: IState) => ({
-  connections: state.user.socialAccountConnections
+  connections: state.user.socialAccountConnections,
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   fetchData: () => {
     fetchSocialConnectionsAsync(dispatch)()
-  }
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SocialAccounts)

--- a/frontend/src/components/SocialButtons.tsx
+++ b/frontend/src/components/SocialButtons.tsx
@@ -5,7 +5,7 @@ import {
   GITLAB_OAUTH_URL,
   BITBUCKET_OAUTH_URL,
   GOOGLE_OAUTH_URL,
-  FACEBOOK_OAUTH_URL
+  FACEBOOK_OAUTH_URL,
 } from "@/settings"
 
 import { FormErrorHandler } from "@/components/Forms"
@@ -119,7 +119,7 @@ interface ISocialButtonsProps {
 const SocialButtons = ({
   nonFieldErrors,
   emailError,
-  signup = true
+  signup = true,
 }: ISocialButtonsProps) => {
   if (!enableSocialButtons) {
     return null

--- a/frontend/src/components/Step.tsx
+++ b/frontend/src/components/Step.tsx
@@ -39,7 +39,7 @@ import {
   IStep,
   IRecipe,
   updateStep,
-  deleteStep
+  deleteStep,
 } from "@/store/reducers/recipes"
 
 interface IStepProps {
@@ -58,25 +58,25 @@ function Step({ text, index, ...props }: IStepProps) {
   const ref = useRef<HTMLDivElement>(null)
   const [, drop] = useDrop({
     accept: DragDrop.STEP,
-    hover: handleDndHover({ ref, index, move: props.move })
+    hover: handleDndHover({ ref, index, move: props.move }),
   })
 
   const [{ isDragging }, drag, preview] = useDrag({
     item: {
       type: DragDrop.STEP,
-      index
+      index,
     },
     end: () => {
       props.completeMove(props.id, index)
     },
     collect: monitor => ({
-      isDragging: monitor.isDragging()
-    })
+      isDragging: monitor.isDragging(),
+    }),
   })
 
   const style = {
     backgroundColor: "white",
-    opacity: isDragging ? 0 : 1
+    opacity: isDragging ? 0 : 1,
   }
 
   preview(drop(ref))
@@ -117,7 +117,7 @@ function StepBodyBasic({
   update,
   remove,
   updating,
-  removing
+  removing,
 }: IStepBodyBasic) {
   const listItemUpdate = (rID: number, sID: number, data: { text: string }) =>
     update({ recipeID: rID, stepID: sID, ...data })
@@ -137,7 +137,7 @@ function StepBodyBasic({
 
 const StepBody = connect(null, {
   update: updateStep.request,
-  remove: deleteStep.request
+  remove: deleteStep.request,
 })(StepBodyBasic)
 
 export default Step

--- a/frontend/src/components/StepContainer.tsx
+++ b/frontend/src/components/StepContainer.tsx
@@ -44,7 +44,7 @@ interface IStepContainerProps {
     recipeID,
     stepID,
     text,
-    position
+    position,
   }: {
     text?: string
     position?: number
@@ -80,16 +80,16 @@ function StepContainer(props: IStepContainerProps) {
         if (index === arrIndex) {
           return {
             ...c,
-            position: newPosition
+            position: newPosition,
           }
         }
         return c
-      })
+      }),
     )
     props.updatingStep({
       recipeID: props.recipeID,
       stepID,
-      position: newPosition
+      position: newPosition,
     })
   }
 
@@ -114,7 +114,7 @@ function StepContainer(props: IStepContainerProps) {
 }
 
 const mapDispatchToProps = {
-  updatingStep: updateStep.request
+  updatingStep: updateStep.request,
 }
 
 export default connect(null, mapDispatchToProps)(StepContainer)

--- a/frontend/src/components/Team.test.tsx
+++ b/frontend/src/components/Team.test.tsx
@@ -21,7 +21,7 @@ describe("<Team/>", () => {
           loadingMembers={false}
           loadingRecipes={false}
         />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/Team.tsx
+++ b/frontend/src/components/Team.tsx
@@ -82,7 +82,7 @@ interface ITeamSettingsProps {
   readonly name: ITeam["name"]
   readonly updatingTeam: (
     id: ITeam["id"],
-    team: { name: string }
+    team: { name: string },
   ) => Promise<void>
   readonly deleteTeam: (id: ITeam["id"]) => Promise<void>
   readonly loading: boolean
@@ -101,12 +101,12 @@ class TeamSettings extends React.Component<
   state: ITeamSettingsState = {
     name: "loading...",
     loadingDeleteTeam: false,
-    loadingSaveChanges: false
+    loadingSaveChanges: false,
   }
 
   static defaultProps = {
     name: "loading",
-    id: 0
+    id: 0,
   }
 
   componentWillMount() {
@@ -189,7 +189,7 @@ interface ITeamProps {
   readonly deleteTeam: (id: ITeam["id"]) => Promise<void>
   readonly updatingTeam: (
     id: ITeam["id"],
-    team: { name: string }
+    team: { name: string },
   ) => Promise<void>
   readonly members: IMember[]
   readonly error404: boolean

--- a/frontend/src/components/TeamCreate.tsx
+++ b/frontend/src/components/TeamCreate.tsx
@@ -11,11 +11,11 @@ import { IState } from "@/store/store"
 import { TextInput, RadioButton } from "@/components/Forms"
 
 const mapStateToProps = (state: IState) => ({
-  loading: !!state.teams.creating
+  loading: !!state.teams.creating,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  createTeam: creatingTeamAsync(dispatch)
+  createTeam: creatingTeamAsync(dispatch),
 })
 
 interface ITeamCreateProps {
@@ -23,7 +23,7 @@ interface ITeamCreateProps {
   readonly createTeam: (
     name: string,
     emails: string[],
-    level: IMember["level"]
+    level: IMember["level"],
   ) => void
 }
 interface ITeamCreateState {
@@ -36,13 +36,13 @@ class TeamCreate extends React.Component<ITeamCreateProps, ITeamCreateState> {
   state: ITeamCreateState = {
     level: "contributor",
     emails: "",
-    name: ""
+    name: "",
   }
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as ITeamCreateState)
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 

--- a/frontend/src/components/TeamInvite.test.tsx
+++ b/frontend/src/components/TeamInvite.test.tsx
@@ -9,11 +9,11 @@ describe("<TeamInvite/>", () => {
     // fake react router props
     const fakeMatch: match<{ id: string }> = {
       params: {
-        id: "1"
+        id: "1",
       },
       isExact: false,
       path: "",
-      url: ""
+      url: "",
     }
     mount(
       <TestProvider>
@@ -31,7 +31,7 @@ describe("<TeamInvite/>", () => {
           // tslint:enable:no-any no-unsafe-any
           /* eslint-enable @typescript-eslint/consistent-type-assertions */
         />
-      </TestProvider>
+      </TestProvider>,
     )
   })
 })

--- a/frontend/src/components/TeamInvite.tsx
+++ b/frontend/src/components/TeamInvite.tsx
@@ -13,7 +13,7 @@ import { teamURL } from "@/urls"
 import {
   fetchingTeamAsync,
   sendingTeamInvitesAsync,
-  Dispatch
+  Dispatch,
 } from "@/store/thunks"
 import { IState } from "@/store/store"
 import { IMember, ITeam } from "@/store/reducers/teams"
@@ -26,31 +26,31 @@ const mapStateToProps = (state: IState, props: ITeamInviteProps) => {
 
   return {
     ...team,
-    id
+    id,
   }
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   fetchData: fetchingTeamAsync(dispatch),
-  sendInvites: sendingTeamInvitesAsync(dispatch)
+  sendInvites: sendingTeamInvitesAsync(dispatch),
 })
 
 export const roles = [
   {
     name: "Admin",
     value: "admin",
-    description: "Add and remove recipes, members."
+    description: "Add and remove recipes, members.",
   },
   {
     name: "Contributor",
     value: "contributor",
-    description: "Add and remove recipes and view all members."
+    description: "Add and remove recipes and view all members.",
   },
   {
     name: "Viewer",
     value: "viewer",
-    description: "View all team recipes and members."
-  }
+    description: "View all team recipes and members.",
+  },
 ]
 
 interface ITeamInviteProps extends RouteComponentProps<{ id: string }> {
@@ -59,7 +59,7 @@ interface ITeamInviteProps extends RouteComponentProps<{ id: string }> {
   readonly sendInvites: (
     id: ITeam["id"],
     emails: string[],
-    level: IMember["level"]
+    level: IMember["level"],
   ) => Promise<Result<void, void>>
   readonly loadingTeam: boolean
   readonly name: string
@@ -74,12 +74,12 @@ interface ITeamInviteState {
 class TeamInvite extends React.Component<ITeamInviteProps, ITeamInviteState> {
   state: ITeamInviteState = {
     level: "contributor",
-    emails: ""
+    emails: "",
   }
 
   static defaultProps = {
     loadingTeam: true,
-    sendingTeamInvites: false
+    sendingTeamInvites: false,
   }
 
   componentWillMount() {
@@ -89,7 +89,7 @@ class TeamInvite extends React.Component<ITeamInviteProps, ITeamInviteState> {
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     this.setState(({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     } as unknown) as ITeamInviteState)
   /* eslint-enable @typescript-eslint/consistent-type-assertions */
 
@@ -123,7 +123,7 @@ class TeamInvite extends React.Component<ITeamInviteProps, ITeamInviteState> {
             const result = await this.props.sendInvites(
               id,
               emails,
-              this.state.level
+              this.state.level,
             )
             if (isErr(result)) {
               // On failure, we should leave our email state unchanged.

--- a/frontend/src/components/TeamRecipes.tsx
+++ b/frontend/src/components/TeamRecipes.tsx
@@ -24,7 +24,7 @@ export default class TeamRecipes extends React.Component<
   ENABLE_SEARCH_THRESHOLD = 8
 
   state: ITeamRecipesState = {
-    query: ""
+    query: "",
   }
 
   render() {

--- a/frontend/src/components/UserDropdown.tsx
+++ b/frontend/src/components/UserDropdown.tsx
@@ -10,7 +10,7 @@ import { loggingOutAsync } from "@/store/thunks"
 import {
   DropdownContainer,
   DropdownMenu,
-  useDropdown
+  useDropdown,
 } from "@/components/Dropdown"
 
 function useDarkMode(): [boolean, () => void] {

--- a/frontend/src/components/UserHome.tsx
+++ b/frontend/src/components/UserHome.tsx
@@ -147,7 +147,7 @@ const UserStatistics = (props: IUserStatisticsProps) => {
         total_user_recipes: 0,
         date_joined: "",
         recipes_added_by_month: [],
-        total_recipes_added_last_month_by_all_users: 0
+        total_recipes_added_last_month_by_all_users: 0,
       }
     : props.stats.data
 

--- a/frontend/src/containers/AddRecipe.ts
+++ b/frontend/src/containers/AddRecipe.ts
@@ -3,7 +3,7 @@ import { connect } from "react-redux"
 import {
   postNewRecipeAsync,
   Dispatch,
-  fetchingTeamsAsync
+  fetchingTeamsAsync,
 } from "@/store/thunks"
 
 import AddRecipe from "@/components/AddRecipe"
@@ -22,13 +22,13 @@ import {
   addAddRecipeFormStep,
   removeAddRecipeFormStep,
   updateAddRecipeFormStep,
-  clearAddRecipeForm
+  clearAddRecipeForm,
 } from "@/store/reducers/addrecipe"
 import { ITeam } from "@/store/reducers/teams"
 import {
   IIngredientBasic,
   IStepBasic,
-  resetAddRecipeErrors
+  resetAddRecipeErrors,
 } from "@/store/reducers/recipes"
 import { updateTeamID } from "@/store/reducers/user"
 
@@ -46,7 +46,7 @@ const mapStateToProps = (state: IState) => ({
   teams: teamsFrom(state),
   loadingTeams:
     state.teams.status === "loading" || state.teams.status === "initial",
-  teamID: state.user.teamID
+  teamID: state.user.teamID,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -77,7 +77,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   clearErrors: () => dispatch(resetAddRecipeErrors()),
   clearForm: () => dispatch(clearAddRecipeForm()),
 
-  fetchData: fetchingTeamsAsync(dispatch)
+  fetchData: fetchingTeamsAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddRecipe)

--- a/frontend/src/containers/Home.ts
+++ b/frontend/src/containers/Home.ts
@@ -6,11 +6,11 @@ import { Dispatch, fetchingUserAsync } from "@/store/thunks"
 import { IState } from "@/store/store"
 
 const mapStateToProps = (state: IState) => ({
-  loggedIn: state.user.loggedIn
+  loggedIn: state.user.loggedIn,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  fetchData: fetchingUserAsync(dispatch)
+  fetchData: fetchingUserAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Home)

--- a/frontend/src/containers/Login.test.tsx
+++ b/frontend/src/containers/Login.test.tsx
@@ -11,12 +11,12 @@ describe("<Login/>", () => {
       search: "",
       hash: "",
       key: "",
-      state: null
+      state: null,
     }
     const element = mount(
       <TestProvider>
         <Login location={location} />
-      </TestProvider>
+      </TestProvider>,
     )
     expect(element.text()).toContain("Email")
     expect(element.text()).toContain("Password")

--- a/frontend/src/containers/Login.ts
+++ b/frontend/src/containers/Login.ts
@@ -9,7 +9,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
     login: logUserInAsync(dispatch),
     clearErrors: () => dispatch(cleareLoginErrors()),
-    setFromUrl: (url: string) => dispatch(setFromUrl(url))
+    setFromUrl: (url: string) => dispatch(setFromUrl(url)),
   }
 }
 
@@ -18,7 +18,7 @@ const mapStateToProps = (state: IState) => {
     loading: state.auth.loadingLogin,
     error: state.auth.errorLogin,
     errorSocial: state.auth.errorSocialLogin,
-    fromUrl: state.auth.fromUrl
+    fromUrl: state.auth.fromUrl,
   }
 }
 

--- a/frontend/src/containers/NavLink.ts
+++ b/frontend/src/containers/NavLink.ts
@@ -4,7 +4,7 @@ import { NavLink } from "@/components/NavLink"
 import { IState } from "@/store/store"
 
 const mapStateToProps = (state: IState) => ({
-  pathname: state.router.location?.pathname ?? ""
+  pathname: state.router.location?.pathname ?? "",
 })
 
 // pass {} to prevent passing `dispatch` to component

--- a/frontend/src/containers/Notification.ts
+++ b/frontend/src/containers/Notification.ts
@@ -7,7 +7,7 @@ import { clearNotification } from "@/store/reducers/notification"
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    close: () => dispatch(clearNotification())
+    close: () => dispatch(clearNotification()),
   }
 }
 
@@ -16,7 +16,7 @@ const mapStateToProps = (state: IState) => {
     message: state.notification.message,
     closeable: state.notification.closeable,
     show: state.notification.show,
-    level: state.notification.level
+    level: state.notification.level,
   }
 }
 

--- a/frontend/src/containers/OAuth.ts
+++ b/frontend/src/containers/OAuth.ts
@@ -9,7 +9,7 @@ import { SocialProvider } from "@/store/reducers/user"
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    login: login(dispatch)
+    login: login(dispatch),
   }
 }
 
@@ -26,21 +26,21 @@ const mapStateToProps = (state: IState, props: RouteProps) => {
   return {
     service,
     token: String(token),
-    redirectUrl
+    redirectUrl,
   }
 }
 
 const mergeProps = (
   stateProps: ReturnType<typeof mapStateToProps>,
-  dispatchProps: ReturnType<typeof mapDispatchToProps>
+  dispatchProps: ReturnType<typeof mapDispatchToProps>,
 ) => ({
   ...stateProps,
   login: () =>
     dispatchProps.login(
       stateProps.service,
       stateProps.token,
-      stateProps.redirectUrl
-    )
+      stateProps.redirectUrl,
+    ),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(OAuth)

--- a/frontend/src/containers/OAuthConnect.ts
+++ b/frontend/src/containers/OAuthConnect.ts
@@ -9,7 +9,7 @@ import { RouteComponentProps } from "react-router"
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    login: socialConnectAsync(dispatch)
+    login: socialConnectAsync(dispatch),
   }
 }
 type RouteProps = RouteComponentProps<{ service: SocialProvider }>
@@ -21,16 +21,16 @@ const mapStateToProps = (_: IState, props: RouteProps) => {
 
   return {
     service,
-    token: String(token)
+    token: String(token),
   }
 }
 
 const mergeProps = (
   stateProps: ReturnType<typeof mapStateToProps>,
-  dispatchProps: ReturnType<typeof mapDispatchToProps>
+  dispatchProps: ReturnType<typeof mapDispatchToProps>,
 ) => ({
   ...stateProps,
-  login: () => dispatchProps.login(stateProps.service, stateProps.token)
+  login: () => dispatchProps.login(stateProps.service, stateProps.token),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(OAuth)

--- a/frontend/src/containers/PasswordChange.ts
+++ b/frontend/src/containers/PasswordChange.ts
@@ -8,12 +8,12 @@ import { clearPasswordUpdateError } from "@/store/reducers/passwordChange"
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   update: updatingPasswordAsync(dispatch),
-  clearErrors: () => dispatch(clearPasswordUpdateError())
+  clearErrors: () => dispatch(clearPasswordUpdateError()),
 })
 
 const mapStateToProps = (state: IState) => ({
   loading: state.passwordChange.loadingPasswordUpdate,
-  error: state.passwordChange.errorPasswordUpdate
+  error: state.passwordChange.errorPasswordUpdate,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordChange)

--- a/frontend/src/containers/PasswordReset.ts
+++ b/frontend/src/containers/PasswordReset.ts
@@ -5,13 +5,13 @@ import PasswordReset from "@/components/PasswordReset"
 import { IState } from "@/store/store"
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  reset: resetAsync(dispatch)
+  reset: resetAsync(dispatch),
 })
 
 const mapStateToProps = (state: IState) => ({
   loading: state.auth.loadingReset,
   error: state.auth.errorReset,
-  loggedIn: state.user.loggedIn
+  loggedIn: state.user.loggedIn,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordReset)

--- a/frontend/src/containers/PasswordSet.ts
+++ b/frontend/src/containers/PasswordSet.ts
@@ -9,12 +9,12 @@ import { clearPasswordUpdateError } from "@/store/reducers/passwordChange"
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   update: updatingPasswordAsync(dispatch),
   setPassword: true,
-  clearErrors: () => dispatch(clearPasswordUpdateError())
+  clearErrors: () => dispatch(clearPasswordUpdateError()),
 })
 
 const mapStateToProps = (state: IState) => ({
   loading: state.passwordChange.loadingPasswordUpdate,
-  error: state.passwordChange.errorPasswordUpdate
+  error: state.passwordChange.errorPasswordUpdate,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordChange)

--- a/frontend/src/containers/Settings.ts
+++ b/frontend/src/containers/Settings.ts
@@ -4,7 +4,7 @@ import {
   updatingEmailAsync,
   deleteUserAccountAsync,
   Dispatch,
-  fetchingUserAsync
+  fetchingUserAsync,
 } from "@/store/thunks"
 
 import Settings from "@/components/Settings"
@@ -19,7 +19,7 @@ const mapStateToProps = (state: IState) => ({
   email: state.user.email,
   updatingEmail: state.user.updatingEmail,
   hasPassword: state.user.hasUsablePassword,
-  loading: state.user.loading
+  loading: state.user.loading,
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -32,7 +32,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       deleteUserAccountAsync(dispatch)()
     }
   },
-  updateEmail: updatingEmailAsync(dispatch)
+  updateEmail: updatingEmailAsync(dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Settings)

--- a/frontend/src/containers/Signup.test.tsx
+++ b/frontend/src/containers/Signup.test.tsx
@@ -8,7 +8,7 @@ describe("<Signup/>", () => {
     const element = mount(
       <TestProvider>
         <Signup />
-      </TestProvider>
+      </TestProvider>,
     )
     expect(element.text()).toContain("Email")
     expect(element.text()).toContain("Password")

--- a/frontend/src/containers/Signup.ts
+++ b/frontend/src/containers/Signup.ts
@@ -8,14 +8,14 @@ import { setErrorSignup } from "@/store/reducers/auth"
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
     signup: signupAsync(dispatch),
-    clearErrors: () => dispatch(setErrorSignup({}))
+    clearErrors: () => dispatch(setErrorSignup({})),
   }
 }
 
 const mapStateToProps = (state: IState) => {
   return {
     loading: state.auth.loadingSignup,
-    error: state.auth.errorSignup
+    error: state.auth.errorSignup,
   }
 }
 

--- a/frontend/src/containers/Team.ts
+++ b/frontend/src/containers/Team.ts
@@ -6,7 +6,7 @@ import {
   fetchingTeamRecipesAsync,
   deletingTeamAsync,
   updatingTeamAsync,
-  Dispatch
+  Dispatch,
 } from "@/store/thunks"
 import Team from "@/components/Team"
 import { IState } from "@/store/store"
@@ -54,7 +54,7 @@ const mapStateToProps = (state: IState, props: RouteProps) => {
     name: team ? team.name : "",
     loadingMembers,
     loadingRecipes,
-    recipes: successfulRecipes
+    recipes: successfulRecipes,
   }
 }
 const mapDispatchToProps = (dispatch: Dispatch) => {
@@ -63,10 +63,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       Promise.all([
         fetchingTeamAsync(dispatch)(id),
         fetchingTeamMembersAsync(dispatch)(id),
-        fetchingTeamRecipesAsync(dispatch)(id)
+        fetchingTeamRecipesAsync(dispatch)(id),
       ]),
     deleteTeam: deletingTeamAsync(dispatch),
-    updatingTeam: updatingTeamAsync(dispatch)
+    updatingTeam: updatingTeamAsync(dispatch),
   }
 }
 

--- a/frontend/src/containers/UserHome.ts
+++ b/frontend/src/containers/UserHome.ts
@@ -6,14 +6,14 @@ import {
   fetchingUserStatsAsync,
   Dispatch,
   fetchingRecentRecipesAsync,
-  fetchingUserAsync
+  fetchingUserAsync,
 } from "@/store/thunks"
 import { IState } from "@/store/store"
 import { getRecentRecipes } from "@/store/reducers/recipes"
 
 const mapStateToProps = (state: IState) => ({
   userStats: state.user.stats,
-  recipes: getRecentRecipes(state)
+  recipes: getRecentRecipes(state),
 })
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -21,7 +21,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     fetchingRecentRecipesAsync(dispatch)()
     fetchingUserAsync(dispatch)()
     fetchingUserStatsAsync(dispatch)()
-  }
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserHome)

--- a/frontend/src/date.test.ts
+++ b/frontend/src/date.test.ts
@@ -11,7 +11,7 @@ test("toISODateString", () => {
   mockTimezone("US/Pacific", () => {
     expect(new Date().getTimezoneOffset()).not.toBe(0)
     expect(toISODateString(new Date())).toEqual(
-      toISODateString(toISODateString(toISODateString(new Date())))
+      toISODateString(toISODateString(toISODateString(new Date()))),
     )
   })
   expect(new Date().getTimezoneOffset()).toBe(0)

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -15,7 +15,7 @@ export function toISODateString(date: Date | string): string {
 export function daysOfMonth(date: Date) {
   return eachDayOfInterval({
     start: startOfMonth(date),
-    end: lastDayOfMonth(date)
+    end: lastDayOfMonth(date),
   })
 }
 

--- a/frontend/src/dragDrop.ts
+++ b/frontend/src/dragDrop.ts
@@ -5,19 +5,19 @@ export const enum DragDrop {
   CAL_RECIPE = "CAL_RECIPE",
   STEP = "STEP",
   INGREDIENT = "INGREDIENT",
-  SECTION = "SECTION"
+  SECTION = "SECTION",
 }
 
 export const handleDndHover = ({
   ref,
   index,
-  move
+  move,
 }: {
   readonly ref: React.RefObject<HTMLElement>
   readonly index: number
   readonly move?: ({
     from,
-    to
+    to,
   }: {
     readonly from: number
     readonly to: number

--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -6,7 +6,7 @@ import { Dispatch } from "@/store/thunks"
 import {
   TypedUseSelectorHook,
   useDispatch as useDispatchRedux,
-  useSelector as useSelectorRedux
+  useSelector as useSelectorRedux,
 } from "react-redux"
 import debounce from "lodash/debounce"
 
@@ -39,7 +39,7 @@ export function useGlobalEvent({
   mouseUp,
   mouseDown,
   keyDown,
-  keyUp
+  keyUp,
 }: IGlobalEventProps) {
   React.useEffect(() => {
     if (keyUp) {
@@ -89,7 +89,7 @@ export const useDispatch = () => useDispatchRedux<Dispatch>()
 export const useSelector: TypedUseSelectorHook<IState> = useSelectorRedux
 
 export function useOnClickOutside<T extends HTMLElement>(
-  handler: (e: MouseEvent | TouchEvent) => void
+  handler: (e: MouseEvent | TouchEvent) => void,
 ): React.MutableRefObject<T | null> {
   const ref = React.useRef<T | null>(null)
 
@@ -124,7 +124,7 @@ export function useOnWindowFocusChange(cb: () => void) {
     // webkit bug: https://bugs.webkit.org/show_bug.cgi?id=179990
     const handleEvent = debounce(cb, 400, {
       leading: true,
-      trailing: false
+      trailing: false,
     })
     window.addEventListener("focus", handleEvent)
     return () => {

--- a/frontend/src/http.ts
+++ b/frontend/src/http.ts
@@ -2,7 +2,7 @@ import axios, {
   AxiosError,
   CancelToken,
   AxiosRequestConfig,
-  AxiosResponse
+  AxiosResponse,
 } from "axios"
 import { uuid4 } from "@/uuid"
 import { store } from "@/store/store"
@@ -39,7 +39,7 @@ async function http3<T, A, O>({
   params,
   cancelToken,
   shape,
-  data
+  data,
 }: {
   readonly url: string
   readonly method: Method
@@ -55,7 +55,7 @@ async function http3<T, A, O>({
       method,
       params,
       cancelToken,
-      data
+      data,
     })
     return shape.decode(r.data)
   } catch (e) {
@@ -98,7 +98,7 @@ const handleResponseError = (error: AxiosError) => {
 baseHttp.interceptors.response.use(
   response => response,
   // tslint:disable-next-line:no-unsafe-any
-  error => handleResponseError(error)
+  error => handleResponseError(error),
 )
 
 baseHttp.interceptors.request.use(
@@ -109,7 +109,7 @@ baseHttp.interceptors.request.use(
     return cfg
   },
   // tslint:disable-next-line:no-throw
-  error => Promise.reject(error)
+  error => Promise.reject(error),
 )
 
 type HttpResult<T> = Promise<Result<T, AxiosError>>
@@ -140,7 +140,7 @@ export const http = {
   patch: <T>(
     url: string,
     data?: {} | unknown,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): HttpResult<T> =>
     baseHttp
       .patch<T>(url, data, config)
@@ -149,7 +149,7 @@ export const http = {
   put: <T>(
     url: string,
     data?: {} | unknown,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): HttpResult<T> =>
     baseHttp
       .put<T>(url, data, config)
@@ -158,7 +158,7 @@ export const http = {
   post: <T>(
     url: string,
     data?: {} | unknown,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): HttpResult<T> =>
     baseHttp
       .post<T>(url, data, config)
@@ -172,7 +172,7 @@ export const http = {
     readonly data?: T
   }): Promise<Either<t.Errors | AxiosError | Error, A>> => {
     return http3(options)
-  }
+  },
 }
 // tslint:enable:no-promise-catch
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,7 +12,7 @@ import { ThemeProvider, theme } from "@/theme"
 
 if (process.env.NODE_ENV === "production" && SENTRY_DSN) {
   Raven.config(SENTRY_DSN, {
-    release: GIT_SHA || ""
+    release: GIT_SHA || "",
   }).install()
   // tslint:disable-next-line:no-console
   console.log("version:", GIT_SHA, "\nsentry:", SENTRY_DSN)
@@ -32,5 +32,5 @@ render(
       <App />
     </Provider>
   </ThemeProvider>,
-  rootElement
+  rootElement,
 )

--- a/frontend/src/position.ts
+++ b/frontend/src/position.ts
@@ -1,6 +1,6 @@
 export function getNewPos(
   list: ReadonlyArray<{ readonly position: number }>,
-  index: number
+  index: number,
 ): number | null {
   const nextCard = list[index + 1]
   const prevCard = list[index - 1]
@@ -22,7 +22,7 @@ export function getNewPos(
 
 export function getNewPosIngredients(
   list: ReadonlyArray<{ readonly item: { readonly position: number } }>,
-  index: number
+  index: number,
 ): number | null {
   const nextCard = list[index + 1]
   const prevCard = list[index - 1]

--- a/frontend/src/result.ts
+++ b/frontend/src/result.ts
@@ -2,7 +2,7 @@ import { WebData, Success, Failure } from "@/webdata"
 
 const enum IResultKind {
   Ok,
-  Err
+  Err,
 }
 
 export interface IOk<T> {
@@ -18,14 +18,14 @@ export interface IErr<E> {
 export function Ok<T>(data: T): IOk<T> {
   return {
     kind: IResultKind.Ok,
-    data
+    data,
   }
 }
 
 export function Err<T>(error: T): IErr<T> {
   return {
     kind: IResultKind.Err,
-    error
+    error,
   }
 }
 
@@ -37,7 +37,7 @@ export const isErr = <T, E>(x: Result<T, E>): x is IErr<E> =>
   x.kind === IResultKind.Err
 
 export function resultToWebdata<T, E>(
-  result: Result<T, E>
+  result: Result<T, E>,
 ): WebData<T, undefined> {
   if (isOk(result)) {
     return Success(result.data)

--- a/frontend/src/search.test.ts
+++ b/frontend/src/search.test.ts
@@ -19,7 +19,7 @@ describe("search", () => {
       ingredients: [],
       sections: [],
       notes: [],
-      created: ""
+      created: "",
     }
 
     const testCases = [
@@ -27,7 +27,7 @@ describe("search", () => {
       ["id:150", false],
       ["recipeId:75", false],
       ["recipeId:", false],
-      ["recipeId:150", true]
+      ["recipeId:150", true],
     ] as const
 
     testCases.forEach(([query, expected]) => {

--- a/frontend/src/sorters.test.ts
+++ b/frontend/src/sorters.test.ts
@@ -5,112 +5,112 @@ describe("byNameAlphabetical", () => {
     const ingredients = [
       {
         unit: "12",
-        name: "barley rusks"
+        name: "barley rusks",
       },
       {
         unit: "0.5 cup",
-        name: "celery"
+        name: "celery",
       },
       {
         unit: "2",
-        name: "cinnamon sticks"
+        name: "cinnamon sticks",
       },
       {
         unit: "1 teaspoon",
-        name: "cumin seeds"
+        name: "cumin seeds",
       },
       {
         unit: "2 ounce",
-        name: "feta"
+        name: "feta",
       },
       {
         unit: "2 tablespoon",
-        name: "fresh mint"
+        name: "fresh mint",
       },
       {
         unit: "1 teaspoon",
-        name: "garam masala"
+        name: "garam masala",
       },
       {
         unit: "1",
-        name: "garlic clove"
+        name: "garlic clove",
       },
       {
         unit: "12",
-        name: "garlic cloves"
+        name: "garlic cloves",
       },
       {
         unit: "1",
-        name: "ginger piece"
+        name: "ginger piece",
       },
       {
         unit: "2",
-        name: "green jalapeno peppers"
+        name: "green jalapeno peppers",
       },
       {
         unit: "1.5 teaspoon",
-        name: "ground cumin"
+        name: "ground cumin",
       },
       {
         unit: "0.5 teaspoon",
-        name: "ground turmeric"
+        name: "ground turmeric",
       },
       {
         unit: "1 teaspoon",
-        name: "kosher salt"
+        name: "kosher salt",
       },
       {
         unit: "2",
-        name: "lemons"
+        name: "lemons",
       },
       {
         unit: "1 tablespoon",
-        name: "neutral oil"
+        name: "neutral oil",
       },
       {
         unit: "0.5625 cup",
-        name: "olive oil"
+        name: "olive oil",
       },
       {
         unit: "0.75 cup",
-        name: "pureed tomatoes"
+        name: "pureed tomatoes",
       },
       {
         unit: "1.5 cup",
-        name: "red beans"
+        name: "red beans",
       },
       {
         unit: "2 tablespoon",
-        name: "sherry vinegar"
+        name: "sherry vinegar",
       },
       {
         unit: "2 pound",
-        name: "skinless, bonless chicken thighs"
+        name: "skinless, bonless chicken thighs",
       },
       {
         unit: "3 tablespoon",
-        name: "slivered almonds"
+        name: "slivered almonds",
       },
       {
         unit: "2 tablespoon",
-        name: "tomato paste"
+        name: "tomato paste",
       },
       {
         unit: "2 pound",
-        name: "tomatoes"
+        name: "tomatoes",
       },
       {
         unit: "2 tablespoon",
-        name: "unsalted butter"
+        name: "unsalted butter",
       },
       {
         unit: "2",
-        name: "white onions"
+        name: "white onions",
       },
       {
         unit: "3 tablespoon",
-        name: "whole-milk yogurt"
-      }
+        name: "whole-milk yogurt",
+      },
     ]
 
     expect(ingredients).toEqual(ingredients.sort(byNameAlphabetical))
@@ -120,223 +120,223 @@ describe("byNameAlphabetical", () => {
     const ingredients = [
       {
         unit: "2",
-        name: "lemons"
+        name: "lemons",
       },
       {
         unit: "0.5625 cup",
-        name: "olive oil"
+        name: "olive oil",
       },
       {
         unit: "12",
-        name: "garlic cloves"
+        name: "garlic cloves",
       },
       {
         unit: "1 teaspoon",
-        name: "kosher salt"
+        name: "kosher salt",
       },
       {
         unit: "2 pound",
-        name: "tomatoes"
+        name: "tomatoes",
       },
       {
         unit: "1.5 cup",
-        name: "red beans"
+        name: "red beans",
       },
       {
         unit: "0.5 cup",
-        name: "celery"
+        name: "celery",
       },
       {
         unit: "1",
-        name: "garlic clove"
+        name: "garlic clove",
       },
       {
         unit: "2 ounce",
-        name: "feta"
+        name: "feta",
       },
       {
         unit: "2 tablespoon",
-        name: "fresh mint"
+        name: "fresh mint",
       },
       {
         unit: "2 tablespoon",
-        name: "sherry vinegar"
+        name: "sherry vinegar",
       },
       {
         unit: "12",
-        name: "barley rusks"
+        name: "barley rusks",
       },
       {
         unit: "2 tablespoon",
-        name: "unsalted butter"
+        name: "unsalted butter",
       },
       {
         unit: "1 tablespoon",
-        name: "neutral oil"
+        name: "neutral oil",
       },
       {
         unit: "1 teaspoon",
-        name: "cumin seeds"
+        name: "cumin seeds",
       },
       {
         unit: "2",
-        name: "cinnamon sticks"
+        name: "cinnamon sticks",
       },
       {
         unit: "2",
-        name: "white onions"
+        name: "white onions",
       },
       {
         unit: "1",
-        name: "ginger piece"
+        name: "ginger piece",
       },
       {
         unit: "2",
-        name: "green jalapeno peppers"
+        name: "green jalapeno peppers",
       },
       {
         unit: "0.75 cup",
-        name: "pureed tomatoes"
+        name: "pureed tomatoes",
       },
       {
         unit: "2 tablespoon",
-        name: "tomato paste"
+        name: "tomato paste",
       },
       {
         unit: "1.5 teaspoon",
-        name: "ground cumin"
+        name: "ground cumin",
       },
       {
         unit: "0.5 teaspoon",
-        name: "ground turmeric"
+        name: "ground turmeric",
       },
       {
         unit: "3 tablespoon",
-        name: "whole-milk yogurt"
+        name: "whole-milk yogurt",
       },
       {
         unit: "2 pound",
-        name: "skinless, bonless chicken thighs"
+        name: "skinless, bonless chicken thighs",
       },
       {
         unit: "3 tablespoon",
-        name: "slivered almonds"
+        name: "slivered almonds",
       },
       {
         unit: "1 teaspoon",
-        name: "garam masala"
-      }
+        name: "garam masala",
+      },
     ]
 
     const expected = [
       {
         unit: "12",
-        name: "barley rusks"
+        name: "barley rusks",
       },
       {
         unit: "0.5 cup",
-        name: "celery"
+        name: "celery",
       },
       {
         unit: "2",
-        name: "cinnamon sticks"
+        name: "cinnamon sticks",
       },
       {
         unit: "1 teaspoon",
-        name: "cumin seeds"
+        name: "cumin seeds",
       },
       {
         unit: "2 ounce",
-        name: "feta"
+        name: "feta",
       },
       {
         unit: "2 tablespoon",
-        name: "fresh mint"
+        name: "fresh mint",
       },
       {
         unit: "1 teaspoon",
-        name: "garam masala"
+        name: "garam masala",
       },
       {
         unit: "1",
-        name: "garlic clove"
+        name: "garlic clove",
       },
       {
         unit: "12",
-        name: "garlic cloves"
+        name: "garlic cloves",
       },
       {
         unit: "1",
-        name: "ginger piece"
+        name: "ginger piece",
       },
       {
         unit: "2",
-        name: "green jalapeno peppers"
+        name: "green jalapeno peppers",
       },
       {
         unit: "1.5 teaspoon",
-        name: "ground cumin"
+        name: "ground cumin",
       },
       {
         unit: "0.5 teaspoon",
-        name: "ground turmeric"
+        name: "ground turmeric",
       },
       {
         unit: "1 teaspoon",
-        name: "kosher salt"
+        name: "kosher salt",
       },
       {
         unit: "2",
-        name: "lemons"
+        name: "lemons",
       },
       {
         unit: "1 tablespoon",
-        name: "neutral oil"
+        name: "neutral oil",
       },
       {
         unit: "0.5625 cup",
-        name: "olive oil"
+        name: "olive oil",
       },
       {
         unit: "0.75 cup",
-        name: "pureed tomatoes"
+        name: "pureed tomatoes",
       },
       {
         unit: "1.5 cup",
-        name: "red beans"
+        name: "red beans",
       },
       {
         unit: "2 tablespoon",
-        name: "sherry vinegar"
+        name: "sherry vinegar",
       },
       {
         unit: "2 pound",
-        name: "skinless, bonless chicken thighs"
+        name: "skinless, bonless chicken thighs",
       },
       {
         unit: "3 tablespoon",
-        name: "slivered almonds"
+        name: "slivered almonds",
       },
       {
         unit: "2 tablespoon",
-        name: "tomato paste"
+        name: "tomato paste",
       },
       {
         unit: "2 pound",
-        name: "tomatoes"
+        name: "tomatoes",
       },
       {
         unit: "2 tablespoon",
-        name: "unsalted butter"
+        name: "unsalted butter",
       },
       {
         unit: "2",
-        name: "white onions"
+        name: "white onions",
       },
       {
         unit: "3 tablespoon",
-        name: "whole-milk yogurt"
-      }
+        name: "whole-milk yogurt",
+      },
     ]
 
     expect(ingredients.sort(byNameAlphabetical)).toEqual(expected)

--- a/frontend/src/store/reducers/addrecipe.test.ts
+++ b/frontend/src/store/reducers/addrecipe.test.ts
@@ -12,7 +12,7 @@ import addrecipe, {
   addAddRecipeFormStep,
   removeAddRecipeFormStep,
   updateAddRecipeFormStep,
-  clearAddRecipeForm
+  clearAddRecipeForm,
 } from "@/store/reducers/addrecipe"
 import { baseIngredient, baseStep } from "@/store/reducers/recipes.test"
 import { IIngredientBasic } from "@/store/reducers/recipes"
@@ -21,113 +21,113 @@ describe("addrecipe", () => {
   it("sets addrecipe form name", () => {
     const beforeState = {
       ...initialState,
-      name: ""
+      name: "",
     }
 
     const name = "example name"
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      name
+      name,
     }
 
     expect(addrecipe(beforeState, setAddRecipeFormName(name))).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("set add recipe form author", () => {
     const beforeState = {
       ...initialState,
-      author: ""
+      author: "",
     }
 
     const author = "author"
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      author
+      author,
     }
 
     expect(addrecipe(beforeState, setAddRecipeFormAuthor(author))).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("set add recipe form time", () => {
     const beforeState = {
       ...initialState,
-      time: ""
+      time: "",
     }
 
     const time = "time"
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      time
+      time,
     }
 
     expect(addrecipe(beforeState, setAddRecipeFormTime(time))).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("set add recipe form source", () => {
     const beforeState = {
       ...initialState,
-      source: ""
+      source: "",
     }
 
     const source = "source"
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      source
+      source,
     }
 
     expect(addrecipe(beforeState, setAddRecipeFormSource(source))).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("set add recipe form servings", () => {
     const beforeState = {
       ...initialState,
-      servings: ""
+      servings: "",
     }
 
     const servings = "servings"
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      servings
+      servings,
     }
 
     expect(addrecipe(beforeState, setAddRecipeFormServings(servings))).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("add add recipe form ingredient", () => {
     const beforeState = {
       ...initialState,
-      ingredients: []
+      ingredients: [],
     }
 
     const ingredient = {
       ...baseIngredient,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      ingredients: [ingredient]
+      ingredients: [ingredient],
     }
 
     expect(
-      addrecipe(beforeState, addAddRecipeFormIngredient(ingredient))
+      addrecipe(beforeState, addAddRecipeFormIngredient(ingredient)),
     ).toEqual(afterState)
   })
 
@@ -136,23 +136,23 @@ describe("addrecipe", () => {
       ...baseIngredient,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const beforeState = {
       ...initialState,
-      ingredients: [ingredient]
+      ingredients: [ingredient],
     }
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      ingredients: []
+      ingredients: [],
     }
 
     const index = 0
 
     expect(
-      addrecipe(beforeState, removeAddRecipeFormIngredient(index))
+      addrecipe(beforeState, removeAddRecipeFormIngredient(index)),
     ).toEqual(afterState)
   })
 
@@ -161,24 +161,24 @@ describe("addrecipe", () => {
       ...baseIngredient,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const beforeState = {
       ...initialState,
-      ingredients: [ingredient]
+      ingredients: [ingredient],
     }
 
     const newIngredient: IIngredientBasic = {
       quantity: "12 lbs",
       name: "tomato",
       description: "sliced",
-      optional: false
+      optional: false,
     }
 
     const afterState: IAddRecipeState = {
       ...initialState,
-      ingredients: [newIngredient]
+      ingredients: [newIngredient],
     }
 
     const index = 0
@@ -186,28 +186,28 @@ describe("addrecipe", () => {
     expect(
       addrecipe(
         beforeState,
-        updateAddRecipeFormIngredient({ index, ingredient: newIngredient })
-      )
+        updateAddRecipeFormIngredient({ index, ingredient: newIngredient }),
+      ),
     ).toEqual(afterState)
   })
 
   it("add add recipe form step", () => {
     const beforeState = {
       ...initialState,
-      steps: []
+      steps: [],
     }
 
     const step = {
-      text: "cook the food"
+      text: "cook the food",
     }
 
     const afterState = {
       ...initialState,
-      steps: [step]
+      steps: [step],
     }
 
     expect(addrecipe(beforeState, addAddRecipeFormStep(step))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -216,23 +216,23 @@ describe("addrecipe", () => {
       ...baseStep,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const beforeState = {
       ...initialState,
-      steps: [step]
+      steps: [step],
     }
 
     const afterState = {
       ...initialState,
-      steps: []
+      steps: [],
     }
 
     const index = 0
 
     expect(addrecipe(beforeState, removeAddRecipeFormStep(index))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -241,30 +241,30 @@ describe("addrecipe", () => {
       ...baseStep,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const beforeState = {
       ...initialState,
-      steps: [step]
+      steps: [step],
     }
 
     const newStep = {
       ...baseStep,
       quantity: "12 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const afterState = {
       ...initialState,
-      steps: [newStep]
+      steps: [newStep],
     }
 
     const index = 0
 
     expect(
-      addrecipe(beforeState, updateAddRecipeFormStep({ index, step: newStep }))
+      addrecipe(beforeState, updateAddRecipeFormStep({ index, step: newStep })),
     ).toEqual(afterState)
   })
 
@@ -273,13 +273,13 @@ describe("addrecipe", () => {
       ...baseStep,
       quantity: "1 lbs",
       name: "tomato",
-      description: "sliced"
+      description: "sliced",
     }
 
     const beforeState = {
       ...initialState,
       steps: [step],
-      name: "tesitng"
+      name: "tesitng",
     }
 
     const afterState = initialState

--- a/frontend/src/store/reducers/addrecipe.ts
+++ b/frontend/src/store/reducers/addrecipe.ts
@@ -2,46 +2,46 @@ import { createStandardAction, ActionType, getType } from "typesafe-actions"
 import { IStepBasic, IIngredientBasic } from "@/store/reducers/recipes"
 
 export const setAddRecipeFormName = createStandardAction(
-  "SET_ADD_RECIPE_FORM_NAME"
+  "SET_ADD_RECIPE_FORM_NAME",
 )<string>()
 export const setAddRecipeFormAuthor = createStandardAction(
-  "SET_ADD_RECIPE_FORM_AUTHOR"
+  "SET_ADD_RECIPE_FORM_AUTHOR",
 )<string>()
 export const setAddRecipeFormSource = createStandardAction(
-  "SET_ADD_RECIPE_FORM_SOURCE"
+  "SET_ADD_RECIPE_FORM_SOURCE",
 )<string>()
 export const setAddRecipeFormTime = createStandardAction(
-  "SET_ADD_RECIPE_FORM_TIME"
+  "SET_ADD_RECIPE_FORM_TIME",
 )<IAddRecipeState["time"]>()
 export const setAddRecipeFormServings = createStandardAction(
-  "SET_ADD_RECIPE_FORM_SERVINGS"
+  "SET_ADD_RECIPE_FORM_SERVINGS",
 )<IAddRecipeState["servings"]>()
 export const addAddRecipeFormIngredient = createStandardAction(
-  "ADD_ADD_RECIPE_FORM_INGREDIENT"
+  "ADD_ADD_RECIPE_FORM_INGREDIENT",
 )<IIngredientBasic>()
 export const removeAddRecipeFormIngredient = createStandardAction(
-  "REMOVE_ADD_RECIPE_FORM_INGREDIENT"
+  "REMOVE_ADD_RECIPE_FORM_INGREDIENT",
 )<number>()
 export const addAddRecipeFormStep = createStandardAction(
-  "ADD_ADD_RECIPE_FORM_STEP"
+  "ADD_ADD_RECIPE_FORM_STEP",
 )<IStepBasic>()
 export const removeAddRecipeFormStep = createStandardAction(
-  "REMOVE_ADD_RECIPE_FORM_STEP"
+  "REMOVE_ADD_RECIPE_FORM_STEP",
 )<number>()
 export const updateAddRecipeFormIngredient = createStandardAction(
-  "UPDATE_ADD_RECIPE_FORM_INGREDIENT"
+  "UPDATE_ADD_RECIPE_FORM_INGREDIENT",
 )<{
   index: number
   ingredient: IIngredientBasic
 }>()
 export const updateAddRecipeFormStep = createStandardAction(
-  "UPDATE_ADD_RECIPE_FORM_STEP"
+  "UPDATE_ADD_RECIPE_FORM_STEP",
 )<{
   index: number
   step: IStepBasic
 }>()
 export const clearAddRecipeForm = createStandardAction(
-  "CLEAR_ADD_RECIPE_FORM"
+  "CLEAR_ADD_RECIPE_FORM",
 )()
 
 export type AddRecipeActions =
@@ -75,12 +75,12 @@ export const initialState: IAddRecipeState = {
   time: "",
   servings: "",
   ingredients: [],
-  steps: []
+  steps: [],
 }
 
 const addrecipe = (
   state: IAddRecipeState = initialState,
-  action: AddRecipeActions
+  action: AddRecipeActions,
 ): IAddRecipeState => {
   switch (action.type) {
     case getType(setAddRecipeFormName):
@@ -96,12 +96,12 @@ const addrecipe = (
     case getType(addAddRecipeFormIngredient):
       return {
         ...state,
-        ingredients: [...state.ingredients, action.payload]
+        ingredients: [...state.ingredients, action.payload],
       }
     case getType(removeAddRecipeFormIngredient):
       return {
         ...state,
-        ingredients: state.ingredients.filter((_, i) => i !== action.payload)
+        ingredients: state.ingredients.filter((_, i) => i !== action.payload),
       }
     case getType(updateAddRecipeFormIngredient):
       return {
@@ -111,17 +111,17 @@ const addrecipe = (
             return action.payload.ingredient
           }
           return x
-        })
+        }),
       }
     case getType(addAddRecipeFormStep):
       return {
         ...state,
-        steps: [...state.steps, action.payload]
+        steps: [...state.steps, action.payload],
       }
     case getType(removeAddRecipeFormStep):
       return {
         ...state,
-        steps: state.steps.filter((_, i) => i !== action.payload)
+        steps: state.steps.filter((_, i) => i !== action.payload),
       }
     case getType(updateAddRecipeFormStep):
       return {
@@ -131,7 +131,7 @@ const addrecipe = (
             return action.payload.step
           }
           return x
-        })
+        }),
       }
     case getType(clearAddRecipeForm):
       return initialState

--- a/frontend/src/store/reducers/auth.test.ts
+++ b/frontend/src/store/reducers/auth.test.ts
@@ -1,21 +1,21 @@
 import auth, {
   IAuthState,
   initialState,
-  setFromUrl
+  setFromUrl,
 } from "@/store/reducers/auth"
 
 describe("auth", () => {
   it("sets redirect url", () => {
     const beforeState = {
       ...initialState,
-      fromUrl: ""
+      fromUrl: "",
     }
 
     const fromUrl = "/recipes/15?test#1234"
 
     const afterState: IAuthState = {
       ...initialState,
-      fromUrl
+      fromUrl,
     }
 
     expect(auth(beforeState, setFromUrl(fromUrl))).toEqual(afterState)

--- a/frontend/src/store/reducers/auth.ts
+++ b/frontend/src/store/reducers/auth.ts
@@ -2,7 +2,7 @@ import {
   createStandardAction,
   getType,
   createAsyncAction,
-  ActionType
+  ActionType,
 } from "typesafe-actions"
 import { IUser } from "@/store/reducers/user"
 
@@ -11,7 +11,7 @@ export const setFromUrl = createStandardAction("SET_FROM_URL")<
 >()
 
 export const setErrorSocialLogin = createStandardAction(
-  "SET_ERROR_SOCIAL_LOGIN"
+  "SET_ERROR_SOCIAL_LOGIN",
 )<ISocialError>()
 export const setErrorSignup = createStandardAction("SET_ERROR_SIGNUP")<
   ISignupErrors
@@ -20,13 +20,13 @@ export const setErrorReset = createStandardAction("SET_ERROR_RESET")<
   IPasswordResetError
 >()
 export const setErrorResetConfirmation = createStandardAction(
-  "SET_ERROR_RESET_CONFIRMATION"
+  "SET_ERROR_RESET_CONFIRMATION",
 )<IPasswordResetConfirmError>()
 
 export const login = createAsyncAction(
   "LOGIN_REQUEST",
   "LOGIN_SUCCESS",
-  "LOGIN_FAILURE"
+  "LOGIN_FAILURE",
 )<void, IUser, ILoginError | void>()
 
 export const cleareLoginErrors = createStandardAction("CLEAR_LOGIN_ERRORS")()
@@ -38,7 +38,7 @@ export const setLoadingReset = createStandardAction("SET_LOADING_RESET")<
   IAuthState["loadingReset"]
 >()
 export const setLoadingResetConfirmation = createStandardAction(
-  "SET_LOADING_RESET_CONFIRMATION"
+  "SET_LOADING_RESET_CONFIRMATION",
 )<IAuthState["loadingResetConfirmation"]>()
 
 export type AuthActions =
@@ -105,12 +105,12 @@ export const initialState: IAuthState = {
   loadingLogin: false,
   loadingSignup: false,
   loadingReset: false,
-  loadingResetConfirmation: false
+  loadingResetConfirmation: false,
 }
 
 const auth = (
   state: IAuthState = initialState,
-  action: AuthActions
+  action: AuthActions,
 ): IAuthState => {
   switch (action.type) {
     case getType(setFromUrl):

--- a/frontend/src/store/reducers/calendar.test.ts
+++ b/frontend/src/store/reducers/calendar.test.ts
@@ -8,7 +8,7 @@ import {
   deleteCalendarRecipe,
   moveCalendarRecipe,
   replaceCalendarRecipe,
-  getExistingRecipe
+  getExistingRecipe,
 } from "@/store/reducers/calendar"
 import { baseRecipe } from "@/store/reducers/recipes.test"
 import { getModel } from "redux-loop"
@@ -31,8 +31,8 @@ describe("Calendar", () => {
         user: 1,
         recipe: {
           ...baseRecipe,
-          id: 9
-        }
+          id: 9,
+        },
       },
       {
         id: 2,
@@ -43,21 +43,21 @@ describe("Calendar", () => {
         user: 1,
         recipe: {
           ...baseRecipe,
-          id: 3
-        }
-      }
+          id: 3,
+        },
+      },
     ]
 
     const afterState: ICalendarState = {
       status: "success",
       byId: {
         [recipes[0].id]: recipes[0],
-        [recipes[1].id]: recipes[1]
+        [recipes[1].id]: recipes[1],
       },
       settings: Success({
         syncEnabled: false,
-        calendarLink: ""
-      })
+        calendarLink: "",
+      }),
     }
 
     const start = "2019-02-01T00:00:00.000Z"
@@ -72,16 +72,16 @@ describe("Calendar", () => {
           end,
           settings: {
             syncEnabled: false,
-            calendarLink: ""
-          }
-        })
-      )
+            calendarLink: "",
+          },
+        }),
+      ),
     ).toEqual(afterState)
   })
 
   it("sets individual calendar recipe", () => {
     const beforeState: ICalendarState = {
-      ...initialState
+      ...initialState,
     }
 
     const recipe: ICalRecipe = {
@@ -93,15 +93,15 @@ describe("Calendar", () => {
       user: 1,
       recipe: {
         id: 9,
-        name: "1231"
-      }
+        name: "1231",
+      },
     }
 
     const afterState: ICalendarState = {
       ...initialState,
       byId: {
-        [recipe.id]: recipe
-      }
+        [recipe.id]: recipe,
+      },
     }
 
     expect(calendar(beforeState, setCalendarRecipe(recipe))).toEqual(afterState)
@@ -119,45 +119,45 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
-        }
-      }
+            name: "1231",
+          },
+        },
+      },
     }
 
     const afterState: ICalendarState = {
-      ...initialState
+      ...initialState,
     }
 
     expect(calendar(beforeState, deleteCalendarRecipe(1))).toEqual(afterState)
   })
   it("sets calendar loading", () => {
     const beforeState: ICalendarState = {
-      ...initialState
+      ...initialState,
     }
 
     const afterState: ICalendarState = {
       ...initialState,
-      status: "loading"
+      status: "loading",
     }
 
     expect(calendar(beforeState, fetchCalendarRecipes.request())).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("sets calendar error", () => {
     const beforeState: ICalendarState = {
-      ...initialState
+      ...initialState,
     }
 
     const afterState: ICalendarState = {
       ...initialState,
-      status: "failure"
+      status: "failure",
     }
 
     expect(calendar(beforeState, fetchCalendarRecipes.failure())).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -176,10 +176,10 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
-        }
-      }
+            name: "1231",
+          },
+        },
+      },
     }
 
     const newOn = "2018-05-20"
@@ -196,14 +196,14 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
-        }
-      }
+            name: "1231",
+          },
+        },
+      },
     }
 
     expect(
-      calendar(beforeState, moveCalendarRecipe({ id, to: newOn }))
+      calendar(beforeState, moveCalendarRecipe({ id, to: newOn })),
     ).toEqual(afterState)
   })
 
@@ -223,8 +223,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
+            name: "1231",
+          },
         },
         2: {
           id: 2,
@@ -235,8 +235,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 7,
-            name: "1231"
-          }
+            name: "1231",
+          },
         },
         3: {
           id: 3,
@@ -247,10 +247,10 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
-        }
-      }
+            name: "1231",
+          },
+        },
+      },
     }
 
     const afterState: ICalendarState = {
@@ -265,8 +265,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 9,
-            name: "1231"
-          }
+            name: "1231",
+          },
         },
         2: {
           id: 2,
@@ -277,8 +277,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             id: 7,
-            name: "1231"
-          }
+            name: "1231",
+          },
         },
         3: {
           id: 3,
@@ -289,14 +289,14 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             id: 9,
-            name: "1231"
-          }
-        }
-      }
+            name: "1231",
+          },
+        },
+      },
     }
 
     expect(
-      calendar(beforeState, moveCalendarRecipe({ id, to: newOn }))
+      calendar(beforeState, moveCalendarRecipe({ id, to: newOn })),
     ).toEqual(afterState)
   })
 
@@ -316,8 +316,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         2: {
           id: 2,
@@ -328,8 +328,8 @@ describe("Calendar", () => {
           on: newOn,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         3: {
           id: 3,
@@ -340,10 +340,10 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
-        }
-      }
+            id: 9,
+          },
+        },
+      },
     }
 
     const afterState: ICalendarState = {
@@ -358,8 +358,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         3: {
           id: 3,
@@ -370,14 +370,14 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
-        }
-      }
+            id: 9,
+          },
+        },
+      },
     }
 
     expect(
-      calendar(beforeState, moveCalendarRecipe({ id, to: newOn }))
+      calendar(beforeState, moveCalendarRecipe({ id, to: newOn })),
     ).toEqual(afterState)
   })
 
@@ -396,8 +396,8 @@ describe("Calendar", () => {
           team: 2,
           user: 1,
           recipe: {
-            ...baseRecipe
-          }
+            ...baseRecipe,
+          },
         },
         2: {
           id: 2,
@@ -407,8 +407,8 @@ describe("Calendar", () => {
           team: 2,
           user: 1,
           recipe: {
-            ...baseRecipe
-          }
+            ...baseRecipe,
+          },
         },
         3: {
           id: 3,
@@ -418,10 +418,10 @@ describe("Calendar", () => {
           user: 1,
           on: "2018-06-07",
           recipe: {
-            ...baseRecipe
-          }
-        }
-      }
+            ...baseRecipe,
+          },
+        },
+      },
     }
 
     const recipe: ICalRecipe = {
@@ -432,7 +432,7 @@ describe("Calendar", () => {
       team: 2,
       user: 1,
 
-      recipe: { id: 19, name: "foo" }
+      recipe: { id: 19, name: "foo" },
     }
 
     const afterState: ICalendarState = {
@@ -447,8 +447,8 @@ describe("Calendar", () => {
           team: 2,
           user: 1,
           recipe: {
-            ...baseRecipe
-          }
+            ...baseRecipe,
+          },
         },
         3: {
           id: 3,
@@ -458,14 +458,14 @@ describe("Calendar", () => {
           user: 1,
           on: "2018-06-07",
           recipe: {
-            ...baseRecipe
-          }
-        }
-      }
+            ...baseRecipe,
+          },
+        },
+      },
     }
 
     expect(
-      calendar(beforeState, replaceCalendarRecipe({ id, recipe }))
+      calendar(beforeState, replaceCalendarRecipe({ id, recipe })),
     ).toEqual(afterState)
   })
 
@@ -484,8 +484,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         3: {
           id: 3,
@@ -496,10 +496,10 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
-        }
-      }
+            id: 9,
+          },
+        },
+      },
     }
 
     const recipe: ICalRecipe = {
@@ -509,7 +509,7 @@ describe("Calendar", () => {
       on,
       team: 2,
       user: 1,
-      recipe: { ...baseRecipe, id: 9 }
+      recipe: { ...baseRecipe, id: 9 },
     }
 
     const afterState: ICalendarState = {
@@ -524,8 +524,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         3: {
           id: 3,
@@ -536,10 +536,10 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
-        }
-      }
+            id: 9,
+          },
+        },
+      },
     }
 
     expect(calendar(beforeState, setCalendarRecipe(recipe))).toEqual(afterState)
@@ -557,8 +557,8 @@ describe("Calendar", () => {
       on: "2018-07-07",
       recipe: {
         ...baseRecipe,
-        id: 9
-      }
+        id: 9,
+      },
     }
 
     const beforeState: ICalendarState = {
@@ -573,8 +573,8 @@ describe("Calendar", () => {
           user: 1,
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
         3: {
           id: 3,
@@ -585,11 +585,11 @@ describe("Calendar", () => {
           on: "2018-06-07",
           recipe: {
             ...baseRecipe,
-            id: 9
-          }
+            id: 9,
+          },
         },
-        4: recipe4
-      }
+        4: recipe4,
+      },
     }
 
     const start = toISODateString(startOfWeek(subWeeks(parseISO(on), 1)))
@@ -603,10 +603,10 @@ describe("Calendar", () => {
           end,
           settings: {
             syncEnabled: false,
-            calendarLink: ""
-          }
-        })
-      )
+            calendarLink: "",
+          },
+        }),
+      ),
     )
 
     expect(nextState.byId).toEqual({ 4: recipe4 })
@@ -617,7 +617,7 @@ describe("calendar selectors", () => {
   test("#getExistingRecipe", () => {
     // initialize state
     const emptyState = getModel(
-      calendar(undefined, fetchCalendarRecipes.failure())
+      calendar(undefined, fetchCalendarRecipes.failure()),
     )
 
     const teamID = 5
@@ -634,8 +634,8 @@ describe("calendar selectors", () => {
       user: userID,
       recipe: {
         id: recipeID,
-        name: "foo recipe"
-      }
+        name: "foo recipe",
+      },
     }
     const toDate = addWeeks(fromDate, 1)
 
@@ -647,8 +647,8 @@ describe("calendar selectors", () => {
       getExistingRecipe({
         state: emptyState,
         on: toDate,
-        from
-      })
+        from,
+      }),
     ).toEqual(undefined)
 
     // existing recipe scheduled at the toDate
@@ -661,8 +661,8 @@ describe("calendar selectors", () => {
       user: userID,
       recipe: {
         id: recipeID,
-        name: "foo recipe"
-      }
+        name: "foo recipe",
+      },
     }
     expect(calRecipeOnSameDay.id).not.toEqual(from.id)
     expect(isSameDay(new Date(calRecipeOnSameDay.on), toDate)).toEqual(true)
@@ -677,20 +677,20 @@ describe("calendar selectors", () => {
           scheduledRecipes: [calRecipeOnSameDay],
           settings: {
             syncEnabled: false,
-            calendarLink: ""
+            calendarLink: "",
           },
           start,
-          end
-        })
-      )
+          end,
+        }),
+      ),
     )
 
     expect(
       getExistingRecipe({
         state: nextState,
         on: toDate,
-        from
-      })
+        from,
+      }),
     ).not.toBeUndefined()
 
     // moving recipe from its location and back to its location in one
@@ -698,7 +698,7 @@ describe("calendar selectors", () => {
     const calRecipe = getExistingRecipe({
       state: nextState,
       on: toDate,
-      from: calRecipeOnSameDay
+      from: calRecipeOnSameDay,
     })
     expect(calRecipe).toBeUndefined()
   })

--- a/frontend/src/store/reducers/calendar.ts
+++ b/frontend/src/store/reducers/calendar.ts
@@ -4,7 +4,7 @@ import {
   createAsyncAction,
   ActionType,
   getType,
-  createStandardAction
+  createStandardAction,
 } from "typesafe-actions"
 import { isUndefined } from "util"
 import { notUndefined } from "@/utils/general"
@@ -16,7 +16,7 @@ import {
   IAddingScheduledRecipeProps,
   IMoveScheduledRecipeProps,
   addingScheduledRecipeAsync,
-  Dispatch
+  Dispatch,
 } from "@/store/thunks"
 import { isAfter, isBefore, parseISO } from "date-fns"
 import { WebData, Success, mapSuccessLike } from "@/webdata"
@@ -26,7 +26,7 @@ import { isRight } from "fp-ts/lib/Either"
 export const fetchCalendarRecipes = createAsyncAction(
   "FETCH_CALENDAR_RECIPES_START",
   "FETCH_CALENDAR_RECIPES_SUCCESS",
-  "FETCH_CALENDAR_RECIPES_FAILURE"
+  "FETCH_CALENDAR_RECIPES_FAILURE",
 )<
   void,
   {
@@ -44,28 +44,28 @@ export const setCalendarRecipe = createStandardAction("SET_CALENDAR_RECIPE")<
   ICalRecipe
 >()
 export const deleteCalendarRecipe = createStandardAction(
-  "DELETE_CALENDAR_RECIPE"
+  "DELETE_CALENDAR_RECIPE",
 )<number>()
 export const moveCalendarRecipe = createStandardAction("MOVE_CALENDAR_RECIPE")<{
   id: ICalRecipe["id"]
   to: string
 }>()
 export const replaceCalendarRecipe = createStandardAction(
-  "REPLACE_CALENDAR_RECIPE"
+  "REPLACE_CALENDAR_RECIPE",
 )<{ id: ICalRecipe["id"]; recipe: ICalRecipe }>()
 
 export const moveOrCreateCalendarRecipe = createStandardAction(
-  "MOVE_OR_CREATE_CALENDAR_RECIPE"
+  "MOVE_OR_CREATE_CALENDAR_RECIPE",
 )<IMoveScheduledRecipeProps>()
 
 export const createCalendarRecipe = createStandardAction(
-  "CREATE_CALENDAR_RECIPE"
+  "CREATE_CALENDAR_RECIPE",
 )<IAddingScheduledRecipeProps>()
 
 export const updateCalendarSettings = createAsyncAction(
   "UPDATE_CALENDAR_SETTINGS_START",
   "UPDATE_CALENDAR_SETTINGS_SUCCESS",
-  "UPDATE_CALENDAR_SETTINGS_FAILURE"
+  "UPDATE_CALENDAR_SETTINGS_FAILURE",
 )<
   { readonly teamID: TeamID; readonly syncEnabled: boolean },
   {
@@ -80,16 +80,16 @@ export const updateCalendarSettings = createAsyncAction(
 export async function updateCalendarSettingsAsync(
   {
     teamID,
-    syncEnabled
+    syncEnabled,
   }: {
     readonly teamID: TeamID
     readonly syncEnabled: boolean
   },
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.updateCalendarSettings({
     teamID,
-    data: { syncEnabled }
+    data: { syncEnabled },
   })
   if (isRight(res)) {
     dispatch(updateCalendarSettings.success(res.right))
@@ -101,7 +101,7 @@ export async function updateCalendarSettingsAsync(
 export const regenerateCalendarLink = createAsyncAction(
   "REGENERATE_CALENDAR_LINK_START",
   "REGENERATE_CALENDAR_LINK_SUCCESS",
-  "REGENERATE_CALENDAR_LINK_FAILURE"
+  "REGENERATE_CALENDAR_LINK_FAILURE",
 )<
   { readonly teamID: TeamID },
   {
@@ -112,10 +112,10 @@ export const regenerateCalendarLink = createAsyncAction(
 
 export async function regenerateCalendarLinkAsync(
   teamID: TeamID,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.generateCalendarLink({
-    teamID
+    teamID,
   })
   if (isRight(res)) {
     dispatch(regenerateCalendarLink.success(res.right))
@@ -163,7 +163,7 @@ export interface ICalendarState {
 export const initialState: ICalendarState = {
   byId: {},
   status: "initial",
-  settings: undefined
+  settings: undefined,
 }
 
 // tslint:disable-next-line object-index-must-return-possibly-undefined
@@ -173,7 +173,7 @@ function byId<T extends { id: number }>(a: { [_: number]: T }, b: T) {
 
 export const calendar = (
   state: ICalendarState = initialState,
-  action: CalendarActions
+  action: CalendarActions,
 ): ICalendarState | Loop<ICalendarState, CalendarActions> => {
   switch (action.type) {
     case getType(fetchCalendarRecipes.success):
@@ -182,7 +182,7 @@ export const calendar = (
         .filter(
           value =>
             isAfter(parseISO(value.on), parseISO(action.payload.end)) ||
-            isBefore(parseISO(value.on), parseISO(action.payload.start))
+            isBefore(parseISO(value.on), parseISO(action.payload.start)),
         )
         .reduce(byId, {})
 
@@ -190,16 +190,16 @@ export const calendar = (
         ...state,
         byId: {
           ...byIdState,
-          ...action.payload.scheduledRecipes.reduce(byId, {})
+          ...action.payload.scheduledRecipes.reduce(byId, {}),
         },
         settings: Success(action.payload.settings),
-        status: "success"
+        status: "success",
       }
     case getType(setCalendarRecipe): {
       const existing = getExistingRecipe({
         state,
         on: action.payload.on,
-        from: action.payload
+        from: action.payload,
       })
 
       if (existing) {
@@ -210,9 +210,9 @@ export const calendar = (
             ...omit(state.byId, existing.id),
             [action.payload.id]: {
               ...action.payload,
-              count: existing.count + action.payload.count
-            }
-          }
+              count: existing.count + action.payload.count,
+            },
+          },
         }
       }
 
@@ -220,26 +220,26 @@ export const calendar = (
         ...state,
         byId: {
           ...state.byId,
-          [action.payload.id]: action.payload
-        }
+          [action.payload.id]: action.payload,
+        },
       }
     }
     case getType(deleteCalendarRecipe):
       return {
         ...state,
-        byId: omit(state.byId, action.payload)
+        byId: omit(state.byId, action.payload),
       }
     case getType(fetchCalendarRecipes.request): {
       if (state.status === "initial") {
         return {
           ...state,
-          status: "loading"
+          status: "loading",
         }
       }
       if (state.status === "success") {
         return {
           ...state,
-          status: "refetching"
+          status: "refetching",
         }
       }
       return state
@@ -247,7 +247,7 @@ export const calendar = (
     case getType(fetchCalendarRecipes.failure):
       return {
         ...state,
-        status: "failure"
+        status: "failure",
       }
     case getType(moveCalendarRecipe): {
       // if the same recipe already exists at the date:
@@ -282,9 +282,9 @@ export const calendar = (
             ...omit(state.byId, action.payload.id),
             [existing.id]: {
               ...existing,
-              count: existing.count + moving.count
-            }
-          }
+              count: existing.count + moving.count,
+            },
+          },
         }
       }
 
@@ -298,9 +298,9 @@ export const calendar = (
           ...state.byId,
           [action.payload.id]: {
             ...cal,
-            on: action.payload.to
-          }
-        }
+            on: action.payload.to,
+          },
+        },
       }
     }
     case getType(updateCalendarSettings.request):
@@ -309,40 +309,40 @@ export const calendar = (
           ...state,
           settings: mapSuccessLike(state.settings, s => ({
             ...s,
-            ...action.payload
-          }))
+            ...action.payload,
+          })),
         },
         Cmd.run(updateCalendarSettingsAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(updateCalendarSettings.success):
       return {
         ...state,
-        settings: Success(action.payload)
+        settings: Success(action.payload),
       }
     case getType(updateCalendarSettings.failure):
       return {
         ...state,
         settings: mapSuccessLike(state.settings, s => ({
           ...s,
-          ...action.payload
-        }))
+          ...action.payload,
+        })),
       }
     case getType(regenerateCalendarLink.request):
       return loop(
         state,
         Cmd.run(regenerateCalendarLinkAsync, {
-          args: [action.payload.teamID, Cmd.dispatch]
-        })
+          args: [action.payload.teamID, Cmd.dispatch],
+        }),
       )
     case getType(regenerateCalendarLink.success):
       return {
         ...state,
         settings: mapSuccessLike(state.settings, s => ({
           ...s,
-          ...action.payload
-        }))
+          ...action.payload,
+        })),
       }
     case getType(regenerateCalendarLink.failure):
       return state
@@ -350,23 +350,23 @@ export const calendar = (
       return loop(
         state,
         Cmd.run(moveScheduledRecipe, {
-          args: [Cmd.dispatch, Cmd.getState, action.payload]
-        })
+          args: [Cmd.dispatch, Cmd.getState, action.payload],
+        }),
       )
     case getType(createCalendarRecipe):
       return loop(
         state,
         Cmd.run(addingScheduledRecipeAsync, {
-          args: [Cmd.dispatch, Cmd.getState, action.payload]
-        })
+          args: [Cmd.dispatch, Cmd.getState, action.payload],
+        }),
       )
     case getType(replaceCalendarRecipe):
       return {
         ...state,
         byId: {
           ...omit(state.byId, action.payload.id),
-          [action.payload.recipe.id]: action.payload.recipe
-        }
+          [action.payload.recipe.id]: action.payload.recipe,
+        },
       }
     default:
       return state
@@ -398,12 +398,12 @@ interface IGetExistingRecipeProps {
 export const getExistingRecipe = ({
   state,
   on,
-  from
+  from,
 }: IGetExistingRecipeProps) =>
   getAllCalRecipes(state).find(
     x =>
       isSameDay(new Date(x.on), new Date(on)) &&
       haveSameTeam(x, from) &&
       x.id !== from.id &&
-      x.recipe.id === from.recipe.id
+      x.recipe.id === from.recipe.id,
   )

--- a/frontend/src/store/reducers/invites.test.ts
+++ b/frontend/src/store/reducers/invites.test.ts
@@ -4,7 +4,7 @@ import invites, {
   IInvite,
   fetchInvites,
   acceptInvite,
-  declineInvite
+  declineInvite,
 } from "@/store/reducers/invites"
 
 const basicInvite: IInvite = {
@@ -12,14 +12,14 @@ const basicInvite: IInvite = {
   active: false,
   team: {
     id: 1,
-    name: "foo"
+    name: "foo",
   },
   status: "open",
   creator: {
     id: 1,
     email: "foo@foo.com",
-    avatar_url: "foo.com"
-  }
+    avatar_url: "foo.com",
+  },
 }
 
 describe("Invites", () => {
@@ -33,11 +33,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     const afterState: IInvitesState = {
@@ -50,11 +50,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     expect(invites(beforeState, fetchInvites.request())).toEqual(afterState)
@@ -62,7 +62,7 @@ describe("Invites", () => {
   it("sets invites", () => {
     const beforeState: IInvitesState = {
       loading: true,
-      byId: {}
+      byId: {},
     }
 
     const newInvites: IInvite[] = [
@@ -72,9 +72,9 @@ describe("Invites", () => {
         active: false,
         team: {
           id: 1,
-          name: "foo"
+          name: "foo",
         },
-        status: "open"
+        status: "open",
       },
       {
         ...basicInvite,
@@ -82,10 +82,10 @@ describe("Invites", () => {
         active: false,
         team: {
           id: 2,
-          name: "bar"
+          name: "bar",
         },
-        status: "open"
-      }
+        status: "open",
+      },
     ]
 
     const afterState: IInvitesState = {
@@ -97,9 +97,9 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
+          status: "open",
         },
         2: {
           ...basicInvite,
@@ -107,15 +107,15 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 2,
-            name: "bar"
+            name: "bar",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     expect(invites(beforeState, fetchInvites.success(newInvites))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -129,9 +129,9 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
+          status: "open",
         },
         2: {
           ...basicInvite,
@@ -139,11 +139,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 2,
-            name: "bar"
+            name: "bar",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     const afterState: IInvitesState = {
@@ -155,10 +155,10 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
           status: "open",
-          accepting: true
+          accepting: true,
         },
         2: {
           ...basicInvite,
@@ -166,11 +166,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 2,
-            name: "bar"
+            name: "bar",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     expect(invites(beforeState, acceptInvite.request(1))).toEqual(afterState)
@@ -186,11 +186,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     const afterState: IInvitesState = {
@@ -202,12 +202,12 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
           status: "open",
-          declining: true
-        }
-      }
+          declining: true,
+        },
+      },
     }
 
     expect(invites(beforeState, declineInvite.request(1))).toEqual(afterState)
@@ -223,11 +223,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     const afterState: IInvitesState = {
@@ -239,12 +239,12 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
           status: "declined",
-          declining: false
-        }
-      }
+          declining: false,
+        },
+      },
     }
 
     expect(invites(beforeState, declineInvite.success(1))).toEqual(afterState)
@@ -260,11 +260,11 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
-          status: "open"
-        }
-      }
+          status: "open",
+        },
+      },
     }
 
     const afterState: IInvitesState = {
@@ -276,12 +276,12 @@ describe("Invites", () => {
           active: false,
           team: {
             id: 1,
-            name: "foo"
+            name: "foo",
           },
           status: "accepted",
-          accepting: false
-        }
-      }
+          accepting: false,
+        },
+      },
     }
 
     expect(invites(beforeState, acceptInvite.success(1))).toEqual(afterState)

--- a/frontend/src/store/reducers/invites.ts
+++ b/frontend/src/store/reducers/invites.ts
@@ -6,19 +6,19 @@ import { Loading, Success } from "@/webdata"
 export const fetchInvites = createAsyncAction(
   "FETCH_INVITES_START",
   "FETCH_INVITES_SUCCESS",
-  "FETCH_INVITES_FAILURE"
+  "FETCH_INVITES_FAILURE",
 )<void, IInvite[], void>()
 
 export const acceptInvite = createAsyncAction(
   "ACCEPT_INVITE_REQUEST",
   "ACCEPT_INVITE_SUCCESS",
-  "ACCEPT_INVITE_FAILURE"
+  "ACCEPT_INVITE_FAILURE",
 )<IInvite["id"], IInvite["id"], IInvite["id"]>()
 
 export const declineInvite = createAsyncAction(
   "DECLINE_INVITE_REQUEST",
   "DECLINE_INVITE_SUCCESS",
-  "DECLINE_INVITE_FAILURE"
+  "DECLINE_INVITE_FAILURE",
 )<IInvite["id"], IInvite["id"], IInvite["id"]>()
 
 export type InviteActions =
@@ -50,7 +50,7 @@ export interface IInvite {
 function mapById(
   state: IInvitesState,
   id: IInvite["id"],
-  func: (invite: IInvite) => IInvite
+  func: (invite: IInvite) => IInvite,
 ): IInvitesState {
   const invite = state.byId[id]
   if (invite == null) {
@@ -60,8 +60,8 @@ function mapById(
     ...state,
     byId: {
       ...state.byId,
-      [id]: func(invite)
-    }
+      [id]: func(invite),
+    },
   }
 }
 
@@ -74,12 +74,12 @@ export interface IInvitesState {
 
 export const initialState: IInvitesState = {
   loading: false,
-  byId: {}
+  byId: {},
 }
 
 const invites = (
   state: IInvitesState = initialState,
-  action: InviteActions
+  action: InviteActions,
 ): IInvitesState => {
   switch (action.type) {
     case getType(fetchInvites.success):
@@ -91,11 +91,11 @@ const invites = (
           ...action.payload.reduce(
             (a, b) => ({
               ...a,
-              [b.id]: b
+              [b.id]: b,
             }),
-            {}
-          )
-        }
+            {},
+          ),
+        },
       }
     case getType(fetchInvites.request):
       return { ...state, loading: true }
@@ -104,35 +104,35 @@ const invites = (
     case getType(acceptInvite.request):
       return mapById(state, action.payload, invite => ({
         ...invite,
-        accepting: true
+        accepting: true,
       }))
     case getType(acceptInvite.success):
       return mapById(state, action.payload, invite => ({
         ...invite,
         accepting: false,
-        status: "accepted"
+        status: "accepted",
       }))
     case getType(acceptInvite.failure):
       return mapById(state, action.payload, invite => ({
         ...invite,
-        accepting: false
+        accepting: false,
       }))
     case getType(declineInvite.request):
       return mapById(state, action.payload, invite => ({
         ...invite,
-        declining: true
+        declining: true,
       }))
     case getType(declineInvite.success):
       return mapById(state, action.payload, invite => ({
         ...invite,
         status: "declined",
-        declining: false
+        declining: false,
       }))
     case getType(declineInvite.failure):
       return mapById(state, action.payload, invite => ({
         ...invite,
         status: "declined",
-        declining: false
+        declining: false,
       }))
     default:
       return state

--- a/frontend/src/store/reducers/notification.test.ts
+++ b/frontend/src/store/reducers/notification.test.ts
@@ -1,30 +1,30 @@
 import notification, {
   initialState,
   setNotification,
-  clearNotification
+  clearNotification,
 } from "@/store/reducers/notification"
 
 describe("Notification", () => {
   it("Sets notification settings", () => {
     const beforeState = {
       ...initialState,
-      message: ""
+      message: "",
     }
 
     const action = {
       message: "testing",
-      closeable: true
+      closeable: true,
     }
 
     const afterState = {
       ...initialState,
       message: "testing",
       closeable: true,
-      show: true
+      show: true,
     }
 
     expect(notification(beforeState, setNotification(action))).toEqual(
-      afterState
+      afterState,
     )
   })
   it("clears notification", () => {
@@ -32,14 +32,14 @@ describe("Notification", () => {
       ...initialState,
       message: "testing",
       closeable: true,
-      show: true
+      show: true,
     }
 
     const afterState = {
       ...initialState,
       message: "",
       closeable: false,
-      show: false
+      show: false,
     }
 
     expect(notification(beforeState, clearNotification())).toEqual(afterState)

--- a/frontend/src/store/reducers/notification.ts
+++ b/frontend/src/store/reducers/notification.ts
@@ -26,12 +26,12 @@ export const initialState: INotificationState = {
   message: "",
   level: "info",
   closeable: false,
-  show: false
+  show: false,
 }
 
 const notification = (
   state: INotificationState = initialState,
-  action: NotificationsActions
+  action: NotificationsActions,
 ): INotificationState => {
   switch (action.type) {
     case getType(setNotification): {

--- a/frontend/src/store/reducers/passwordChange.test.ts
+++ b/frontend/src/store/reducers/passwordChange.test.ts
@@ -1,6 +1,6 @@
 import passwordChange, {
   initialState,
-  passwordUpdate
+  passwordUpdate,
 } from "@/store/reducers/passwordChange"
 
 describe("passwordChange", () => {
@@ -9,20 +9,20 @@ describe("passwordChange", () => {
 
     const afterState = {
       ...initialState,
-      loadingPasswordUpdate: true
+      loadingPasswordUpdate: true,
     }
 
     expect(passwordChange(beforeState, passwordUpdate.request())).toEqual(
-      afterState
+      afterState,
     )
 
     const anotherAfterState = {
       ...initialState,
-      loadingPasswordUpdate: false
+      loadingPasswordUpdate: false,
     }
 
     expect(passwordChange(beforeState, passwordUpdate.success())).toEqual(
-      anotherAfterState
+      anotherAfterState,
     )
   })
 
@@ -30,15 +30,15 @@ describe("passwordChange", () => {
     const beforeState = initialState
 
     const error = {
-      newPassword: ["The two password fields didn't match."]
+      newPassword: ["The two password fields didn't match."],
     }
 
     const afterState = {
       ...initialState,
-      errorPasswordUpdate: error
+      errorPasswordUpdate: error,
     }
     expect(passwordChange(beforeState, passwordUpdate.failure(error))).toEqual(
-      afterState
+      afterState,
     )
   })
 })

--- a/frontend/src/store/reducers/passwordChange.ts
+++ b/frontend/src/store/reducers/passwordChange.ts
@@ -2,17 +2,17 @@ import {
   getType,
   createAsyncAction,
   ActionType,
-  createStandardAction
+  createStandardAction,
 } from "typesafe-actions"
 
 export const passwordUpdate = createAsyncAction(
   "PASSWORD_UPDATE_START",
   "PASSWORD_UPDATE_SUCCESS",
-  "PASSWORD_UPDATE_FAILURE"
+  "PASSWORD_UPDATE_FAILURE",
 )<void, void, IPasswordUpdateError | void>()
 
 export const clearPasswordUpdateError = createStandardAction(
-  "CLEAR_PASSWORD_UPDATE_ERROR"
+  "CLEAR_PASSWORD_UPDATE_ERROR",
 )()
 
 export type PasswordChangeActions =
@@ -32,12 +32,12 @@ export interface IPasswordChangeState {
 
 export const initialState: IPasswordChangeState = {
   loadingPasswordUpdate: false,
-  errorPasswordUpdate: {}
+  errorPasswordUpdate: {},
 }
 
 export const passwordChange = (
   state: IPasswordChangeState = initialState,
-  action: PasswordChangeActions
+  action: PasswordChangeActions,
 ): IPasswordChangeState => {
   switch (action.type) {
     case getType(passwordUpdate.request):
@@ -48,12 +48,12 @@ export const passwordChange = (
       return {
         ...state,
         loadingPasswordUpdate: false,
-        errorPasswordUpdate: action.payload || {}
+        errorPasswordUpdate: action.payload || {},
       }
     case getType(clearPasswordUpdateError):
       return {
         ...state,
-        errorPasswordUpdate: {}
+        errorPasswordUpdate: {},
       }
     default:
       return state

--- a/frontend/src/store/reducers/recipes.test.ts
+++ b/frontend/src/store/reducers/recipes.test.ts
@@ -19,7 +19,7 @@ import recipes, {
   updatingRecipeAsync,
   setSchedulingRecipe,
   duplicateRecipe,
-  duplicateRecipeAsync
+  duplicateRecipeAsync,
 } from "@/store/reducers/recipes"
 import { HttpErrorKind, Loading, isSuccess, Failure, Success } from "@/webdata"
 import { getModel } from "redux-loop"
@@ -42,12 +42,12 @@ export const baseRecipe: IRecipe = {
   team: 1,
   owner: {
     id: 1,
-    type: "user"
+    type: "user",
   },
   ingredients: [],
   notes: [],
   sections: [],
-  created: "1776-1-1"
+  created: "1776-1-1",
 }
 
 export const baseIngredient: IIngredient = {
@@ -56,13 +56,13 @@ export const baseIngredient: IIngredient = {
   quantity: "1 cup",
   description: "chopped",
   position: 12.3,
-  optional: false
+  optional: false,
 }
 
 export const baseStep: IStep = {
   id: 1,
   text: "foo",
-  position: 10
+  position: 10,
 }
 
 function recipeStoreWith(recipe: IRecipe | IRecipe[]): IRecipesState {
@@ -70,8 +70,8 @@ function recipeStoreWith(recipe: IRecipe | IRecipe[]): IRecipesState {
     return getModel(
       recipes(
         undefined,
-        fetchRecipeList.success({ recipes: recipe, teamID: "personal" })
-      )
+        fetchRecipeList.success({ recipes: recipe, teamID: "personal" }),
+      ),
     )
   }
   return getModel(recipes(undefined, fetchRecipe.success(recipe)))
@@ -82,12 +82,12 @@ describe("Recipes", () => {
     const res = [
       {
         ...baseRecipe,
-        id: 123
+        id: 123,
       },
       {
         ...baseRecipe,
-        id: 2
-      }
+        id: 2,
+      },
     ]
     const [first, second] = res
     const beforeState = recipeStoreWith(res)
@@ -110,7 +110,7 @@ describe("Recipes", () => {
 
   it("Remove non-existent recipe from recipe list", () => {
     expect(recipes(initialState, deleteRecipe.success(123))).toEqual(
-      initialState
+      initialState,
     )
   })
 
@@ -119,21 +119,21 @@ describe("Recipes", () => {
       ...baseRecipe,
       name: "good recipe",
       steps: [],
-      deleting: false
+      deleting: false,
     })
 
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
       name: "good recipe",
       steps: [],
-      deleting: true
+      deleting: true,
     })
 
     expect(getModel(recipes(beforeState, deleteRecipe.request(1)))).toEqual(
-      afterState
+      afterState,
     )
     expect(getModel(recipes(afterState, deleteRecipe.failure(1)))).toEqual(
-      beforeState
+      beforeState,
     )
   })
 
@@ -141,14 +141,14 @@ describe("Recipes", () => {
     const beforeState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
       name: "good recipe",
-      steps: []
+      steps: [],
     })
 
     const newStep = {
       ...baseStep,
       id: 1,
       text: "a new step",
-      position: 10
+      position: 10,
     }
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -156,13 +156,13 @@ describe("Recipes", () => {
       name: "good recipe",
       steps: [newStep],
       addingStepToRecipe: false,
-      draftStep: ""
+      draftStep: "",
     })
 
     expect(
       getModel(
-        recipes(beforeState, addStepToRecipe.success({ id: 1, step: newStep }))
-      )
+        recipes(beforeState, addStepToRecipe.success({ id: 1, step: newStep })),
+      ),
     ).toEqual(afterState)
   })
 
@@ -174,9 +174,9 @@ describe("Recipes", () => {
         {
           id: 1,
           text: "test",
-          position: 10
-        }
-      ]
+          position: 10,
+        },
+      ],
     })
 
     const newIngredient = baseIngredient
@@ -188,19 +188,19 @@ describe("Recipes", () => {
         {
           id: 1,
           text: "test",
-          position: 10
-        }
+          position: 10,
+        },
       ],
-      addingIngredient: false
+      addingIngredient: false,
     })
 
     expect(
       getModel(
         recipes(
           beforeState,
-          addIngredientToRecipe.success({ id: 1, ingredient: newIngredient })
-        )
-      )
+          addIngredientToRecipe.success({ id: 1, ingredient: newIngredient }),
+        ),
+      ),
     ).toEqual(afterState)
 
     const failureAfterState: IRecipesState = recipeStoreWith({
@@ -209,14 +209,14 @@ describe("Recipes", () => {
         {
           id: 1,
           text: "test",
-          position: 10
-        }
+          position: 10,
+        },
       ],
-      addingIngredient: false
+      addingIngredient: false,
     })
 
     expect(recipes(beforeState, addIngredientToRecipe.failure(1))).toEqual(
-      failureAfterState
+      failureAfterState,
     )
   })
 
@@ -228,9 +228,9 @@ describe("Recipes", () => {
         {
           id: 1,
           text: "test",
-          position: 2.54
-        }
-      ]
+          position: 2.54,
+        },
+      ],
     })
 
     const text = "new text"
@@ -244,16 +244,16 @@ describe("Recipes", () => {
           id: 1,
           text,
           position,
-          updating: false
-        }
-      ]
+          updating: false,
+        },
+      ],
     })
 
     expect(
       recipes(
         beforeState,
-        updateStep.success({ recipeID: 1, stepID: 1, text, position })
-      )
+        updateStep.success({ recipeID: 1, stepID: 1, text, position }),
+      ),
     ).toEqual(afterState)
   })
 
@@ -266,10 +266,10 @@ describe("Recipes", () => {
           id: 1,
           quantity: "2 count",
           name: "Tomato",
-          description: "sliced"
-        }
+          description: "sliced",
+        },
       ],
-      steps: [baseStep]
+      steps: [baseStep],
     })
 
     const newIngredient: IIngredient = {
@@ -277,7 +277,7 @@ describe("Recipes", () => {
       id: 1,
       quantity: "4 count",
       name: "Tomato",
-      description: "diced"
+      description: "diced",
     }
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -285,10 +285,10 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...newIngredient,
-          updating: false
-        }
+          updating: false,
+        },
       ],
-      steps: [baseStep]
+      steps: [baseStep],
     })
 
     expect(
@@ -297,9 +297,9 @@ describe("Recipes", () => {
         updateIngredient.success({
           recipeID: 1,
           ingredientID: 1,
-          content: newIngredient
-        })
-      )
+          content: newIngredient,
+        }),
+      ),
     ).toEqual(afterState)
 
     const failureAfterState: IRecipesState = recipeStoreWith({
@@ -311,10 +311,10 @@ describe("Recipes", () => {
           quantity: "2 count",
           name: "Tomato",
           description: "sliced",
-          updating: false
-        }
+          updating: false,
+        },
       ],
-      steps: [baseStep]
+      steps: [baseStep],
     })
 
     expect(
@@ -322,9 +322,9 @@ describe("Recipes", () => {
         beforeState,
         updateIngredient.failure({
           recipeID: 1,
-          ingredientID: 1
-        })
-      )
+          ingredientID: 1,
+        }),
+      ),
     ).toEqual(failureAfterState)
   })
 
@@ -335,13 +335,13 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...baseIngredient,
-          id: 1
+          id: 1,
         },
         {
           ...baseIngredient,
-          id: 2
-        }
-      ]
+          id: 2,
+        },
+      ],
     })
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -350,15 +350,15 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...baseIngredient,
-          id: 2
-        }
-      ]
+          id: 2,
+        },
+      ],
     })
     expect(
       recipes(
         beforeState,
-        deleteIngredient.success({ recipeID: 1, ingredientID: 1 })
-      )
+        deleteIngredient.success({ recipeID: 1, ingredientID: 1 }),
+      ),
     ).toEqual(afterState)
   })
 
@@ -369,14 +369,14 @@ describe("Recipes", () => {
         {
           ...baseStep,
           id: 1,
-          text: "test"
+          text: "test",
         },
         {
           ...baseStep,
           id: 2,
-          text: "target"
-        }
-      ]
+          text: "target",
+        },
+      ],
     })
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -385,45 +385,45 @@ describe("Recipes", () => {
         {
           ...baseStep,
           id: 2,
-          text: "target"
-        }
-      ]
+          text: "target",
+        },
+      ],
     })
 
     expect(
       getModel(
-        recipes(beforeState, deleteStep.success({ recipeID: 1, stepID: 1 }))
-      )
+        recipes(beforeState, deleteStep.success({ recipeID: 1, stepID: 1 })),
+      ),
     ).toEqual(afterState)
   })
 
   it("sets the loading state for adding a step to a recipe", () => {
     const beforeState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
-      addingStepToRecipe: false
+      addingStepToRecipe: false,
     })
 
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
-      addingStepToRecipe: true
+      addingStepToRecipe: true,
     })
 
     expect(
       getModel(
-        recipes(beforeState, addStepToRecipe.request({ id: 1, step: "foo" }))
-      )
+        recipes(beforeState, addStepToRecipe.request({ id: 1, step: "foo" })),
+      ),
     ).toEqual(afterState)
   })
 
   it("sets the recipe to be adding an ingredient", () => {
     const beforeState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
-      addingIngredient: false
+      addingIngredient: false,
     })
 
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
-      addingIngredient: true
+      addingIngredient: true,
     })
 
     expect(
@@ -432,10 +432,10 @@ describe("Recipes", () => {
           beforeState,
           addIngredientToRecipe.request({
             recipeID: 1,
-            ingredient: { name: "foo" }
-          })
-        )
-      )
+            ingredient: { name: "foo" },
+          }),
+        ),
+      ),
     ).toEqual(afterState)
   })
 
@@ -445,18 +445,18 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...baseIngredient,
-          updating: false
-        }
-      ]
+          updating: false,
+        },
+      ],
     })
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
       ingredients: [
         {
           ...baseIngredient,
-          updating: true
-        }
-      ]
+          updating: true,
+        },
+      ],
     })
 
     expect(
@@ -466,10 +466,10 @@ describe("Recipes", () => {
           updateIngredient.request({
             recipeID: 1,
             ingredientID: 1,
-            content: { name: "foo" }
-          })
-        )
-      )
+            content: { name: "foo" },
+          }),
+        ),
+      ),
     ).toEqual(afterState)
   })
 
@@ -479,9 +479,9 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...baseIngredient,
-          removing: false
-        }
-      ]
+          removing: false,
+        },
+      ],
     })
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -489,14 +489,14 @@ describe("Recipes", () => {
       ingredients: [
         {
           ...baseIngredient,
-          removing: true
-        }
-      ]
+          removing: true,
+        },
+      ],
     })
 
     const nextState = recipes(
       beforeState,
-      deleteIngredient.request({ recipeID: 1, ingredientID: 1 })
+      deleteIngredient.request({ recipeID: 1, ingredientID: 1 }),
     )
 
     expect(getModel(nextState)).toEqual(afterState)
@@ -510,24 +510,24 @@ describe("Recipes", () => {
       steps: [
         {
           ...baseStep,
-          updating: false
-        }
-      ]
+          updating: false,
+        },
+      ],
     })
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
       steps: [
         {
           ...baseStep,
-          updating: true
-        }
-      ]
+          updating: true,
+        },
+      ],
     })
 
     expect(
       getModel(
-        recipes(beforeState, updateStep.request({ recipeID: 1, stepID: 1 }))
-      )
+        recipes(beforeState, updateStep.request({ recipeID: 1, stepID: 1 })),
+      ),
     ).toEqual(afterState)
   })
 
@@ -539,9 +539,9 @@ describe("Recipes", () => {
           ...baseStep,
           id: 1,
           text: "a new step",
-          removing: false
-        }
-      ]
+          removing: false,
+        },
+      ],
     })
 
     const afterState: IRecipesState = recipeStoreWith({
@@ -551,14 +551,14 @@ describe("Recipes", () => {
           ...baseStep,
           id: 1,
           text: "a new step",
-          removing: true
-        }
-      ]
+          removing: true,
+        },
+      ],
     })
     expect(
       getModel(
-        recipes(beforeState, deleteStep.request({ recipeID: 1, stepID: 1 }))
-      )
+        recipes(beforeState, deleteStep.request({ recipeID: 1, stepID: 1 })),
+      ),
     ).toEqual(afterState)
   })
 
@@ -568,34 +568,34 @@ describe("Recipes", () => {
       loadingAll: false,
       errorLoadingAll: false,
       byId: {
-        [baseRecipe.id]: Loading()
+        [baseRecipe.id]: Loading(),
       },
-      personalIDs: undefined
+      personalIDs: undefined,
     }
     const fetchingActual = getModel(
-      recipes(beforeState, fetchRecipe.request(baseRecipe.id))
+      recipes(beforeState, fetchRecipe.request(baseRecipe.id)),
     )
     expect(fetchingActual.byId).toEqual(fetchingState.byId)
     expect(fetchingActual.personalIDs).toEqual(fetchingState.personalIDs)
 
     const successState: IRecipesState = recipeStoreWith({
-      ...baseRecipe
+      ...baseRecipe,
     })
     expect(recipes(beforeState, fetchRecipe.success(baseRecipe))).toEqual(
-      successState
+      successState,
     )
 
     const failureState = {
       loadingAll: false,
       errorLoadingAll: false,
       byId: {
-        [baseRecipe.id]: Failure(HttpErrorKind.error404)
+        [baseRecipe.id]: Failure(HttpErrorKind.error404),
       },
-      personalIDs: undefined
+      personalIDs: undefined,
     }
 
     const failActual = getModel(
-      recipes(beforeState, fetchRecipe.failure({ id: 1, error404: true }))
+      recipes(beforeState, fetchRecipe.failure({ id: 1, error404: true })),
     )
     expect(failActual.byId).toEqual(failureState.byId)
     expect(failActual.personalIDs).toEqual(failureState.personalIDs)
@@ -606,12 +606,12 @@ describe("Recipes", () => {
 
     const afterState: IRecipesState = recipeStoreWith({
       ...baseRecipe,
-      updating: true
+      updating: true,
     })
 
     const actual = recipes(
       beforeState,
-      updateRecipe.request({ id: 1, data: { name: "foo" } })
+      updateRecipe.request({ id: 1, data: { name: "foo" } }),
     )
 
     expect(getModel(actual)).toEqual(afterState)
@@ -620,13 +620,13 @@ describe("Recipes", () => {
 
     const newRecipe: IRecipe = {
       ...baseRecipe,
-      name: baseRecipe.name + "foo"
+      name: baseRecipe.name + "foo",
     }
 
     expect(newRecipe.name).not.toEqual(baseRecipe.name)
 
     expect(recipes(beforeState, updateRecipe.success(newRecipe))).toEqual(
-      recipeStoreWith({ ...newRecipe, updating: false, editing: false })
+      recipeStoreWith({ ...newRecipe, updating: false, editing: false }),
     )
   })
 
@@ -635,25 +635,25 @@ describe("Recipes", () => {
       {
         ...baseRecipe,
         name: "Initial recipe name",
-        updating: true
-      }
+        updating: true,
+      },
     ])
 
     const newRecipe = {
       ...baseRecipe,
-      name: "new recipe name"
+      name: "new recipe name",
     }
 
     const afterState: IRecipesState = {
       ...recipeStoreWith({
         ...baseRecipe,
-        name: "new recipe name"
+        name: "new recipe name",
       }),
-      personalIDs: Success([baseRecipe.id])
+      personalIDs: Success([baseRecipe.id]),
     }
 
     expect(recipes(beforeState, fetchRecipe.success(newRecipe))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -662,13 +662,13 @@ describe("Recipes", () => {
       {
         ...baseRecipe,
         id: 1,
-        name: "Initial recipe name 1"
+        name: "Initial recipe name 1",
       },
       {
         ...baseRecipe,
         id: 2,
-        name: "Initial recipe name 2"
-      }
+        name: "Initial recipe name 2",
+      },
     ])
 
     const afterState: IRecipesState = recipeStoreWith([
@@ -679,24 +679,24 @@ describe("Recipes", () => {
         owner: {
           id: 14,
           type: "team",
-          name: "A Cool Name"
-        }
+          name: "A Cool Name",
+        },
       },
       {
         ...baseRecipe,
         id: 2,
-        name: "Initial recipe name 2"
-      }
+        name: "Initial recipe name 2",
+      },
     ])
     const id = 1
     const owner: IRecipe["owner"] = {
       id: 14,
       type: "team",
-      name: "A Cool Name"
+      name: "A Cool Name",
     }
 
     expect(recipes(beforeState, updateRecipeOwner({ id, owner }))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -705,13 +705,13 @@ describe("Recipes", () => {
       {
         ...baseRecipe,
         id: 1,
-        name: "Initial recipe name 1"
+        name: "Initial recipe name 1",
       },
       {
         ...baseRecipe,
         id: 2,
-        name: "Initial recipe name 2"
-      }
+        name: "Initial recipe name 2",
+      },
     ])
 
     const afterState: IRecipesState = recipeStoreWith([
@@ -719,20 +719,20 @@ describe("Recipes", () => {
         ...baseRecipe,
         id: 1,
         name: "Initial recipe name 1",
-        scheduling: true
+        scheduling: true,
       },
       {
         ...baseRecipe,
         id: 2,
-        name: "Initial recipe name 2"
-      }
+        name: "Initial recipe name 2",
+      },
     ])
 
     expect(
       recipes(
         beforeState,
-        setSchedulingRecipe({ recipeID: 1, scheduling: true })
-      )
+        setSchedulingRecipe({ recipeID: 1, scheduling: true }),
+      ),
     ).toEqual(afterState)
   })
 
@@ -741,13 +741,13 @@ describe("Recipes", () => {
       const initialRecipe: IRecipe = {
         ...baseRecipe,
         id: 1,
-        name: "Initial Recipe"
+        name: "Initial Recipe",
       }
 
       const duplicatedRecipe: IRecipe = {
         ...initialRecipe,
         id: 2,
-        name: "Initial Recipe (copy)"
+        name: "Initial Recipe (copy)",
       }
 
       const startState = recipeStoreWith(initialRecipe)
@@ -756,7 +756,7 @@ describe("Recipes", () => {
 
       const requestState = recipes(
         startState,
-        duplicateRecipe.request({ recipeId: initialRecipe.id })
+        duplicateRecipe.request({ recipeId: initialRecipe.id }),
       )
       const requestModel = getModel(requestState)
       expect(requestModel.duplicatingById[initialRecipe.id]).toBe(true)
@@ -766,18 +766,18 @@ describe("Recipes", () => {
         requestModel,
         duplicateRecipe.success({
           recipe: duplicatedRecipe,
-          originalRecipeId: initialRecipe.id
-        })
+          originalRecipeId: initialRecipe.id,
+        }),
       )
       const successModel = getModel(successState)
       expect(successModel.duplicatingById[initialRecipe.id]).toBe(false)
       expect(Object.keys(successModel.byId)).toHaveLength(2)
       expect(successModel.byId[duplicatedRecipe.id]).toEqual(
-        Success(duplicatedRecipe)
+        Success(duplicatedRecipe),
       )
 
       const failureState = getModel(
-        recipes(requestModel, duplicateRecipe.failure(initialRecipe.id))
+        recipes(requestModel, duplicateRecipe.failure(initialRecipe.id)),
       )
       expect(failureState.duplicatingById[initialRecipe.id]).toBe(false)
     })
@@ -799,12 +799,12 @@ describe("Recipes", () => {
       expect(dispatch).toHaveBeenCalledWith(
         duplicateRecipe.success({
           recipe: successResponse,
-          originalRecipeId: recipeId
-        })
+          originalRecipeId: recipeId,
+        }),
       )
       expect(dispatch).toHaveBeenCalledWith(push(recipeURL(successResponse.id)))
       expect(dispatch).not.toHaveBeenCalledWith(
-        duplicateRecipe.failure(recipeId)
+        duplicateRecipe.failure(recipeId),
       )
     })
   })

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -6,7 +6,7 @@ import {
   createAsyncAction,
   ActionType,
   getType,
-  createStandardAction
+  createStandardAction,
 } from "typesafe-actions"
 import { IState } from "@/store/store"
 import {
@@ -16,7 +16,7 @@ import {
   Failure,
   isSuccessOrRefetching,
   mapSuccessLike,
-  toLoading
+  toLoading,
 } from "@/webdata"
 import { isOk } from "@/result"
 import { Loop, loop, Cmd } from "redux-loop"
@@ -24,7 +24,7 @@ import {
   Dispatch,
   updatingStepAsync,
   deletingStepAsync,
-  deletingIngredientAsync
+  deletingIngredientAsync,
 } from "@/store/thunks"
 import { push } from "connected-react-router"
 import { recipeURL } from "@/urls"
@@ -37,12 +37,12 @@ export const updateRecipeOwner = createStandardAction("UPDATE_RECIPE_OWNER")<{
 export const deleteRecipe = createAsyncAction(
   "DELETE_RECIPE_START",
   "DELETE_RECIPE_SUCCESS",
-  "DELETE_RECIPE_FAILURE"
+  "DELETE_RECIPE_FAILURE",
 )<IRecipe["id"], IRecipe["id"], IRecipe["id"]>()
 
 async function deletingRecipeAsync(
   recipeID: IRecipe["id"],
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.deleteRecipe(recipeID)
   if (isOk(res)) {
@@ -56,12 +56,12 @@ async function deletingRecipeAsync(
 export const fetchRecipe = createAsyncAction(
   "FETCH_RECIPE_START",
   "FETCH_RECIPE_SUCCESS",
-  "FETCH_RECIPE_FAILURE"
+  "FETCH_RECIPE_FAILURE",
 )<IRecipe["id"], IRecipe, { id: IRecipe["id"]; error404: boolean }>()
 
 async function fetchingRecipeAsync(
   recipeID: IRecipe["id"],
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.getRecipe(recipeID)
   if (isOk(res)) {
@@ -71,8 +71,8 @@ async function fetchingRecipeAsync(
     dispatch(
       fetchRecipe.failure({
         id: recipeID,
-        error404
-      })
+        error404,
+      }),
     )
   }
 }
@@ -80,7 +80,7 @@ async function fetchingRecipeAsync(
 export const fetchRecipeList = createAsyncAction(
   "FETCH_RECIPE_LIST_START",
   "FETCH_RECIPE_LIST_SUCCESS",
-  "FETCH_RECIPE_LIST_FAILURE"
+  "FETCH_RECIPE_LIST_FAILURE",
 )<
   { teamID: TeamID },
   { recipes: IRecipe[]; teamID: TeamID },
@@ -96,17 +96,17 @@ export interface IAddRecipeError {
 export const createRecipe = createAsyncAction(
   "CREATE_RECIPE_START",
   "CREATE_RECIPE_SUCCESS",
-  "CREATE_RECIPE_FAILURE"
+  "CREATE_RECIPE_FAILURE",
 )<void, IRecipe, IAddRecipeError>()
 
 export const resetAddRecipeErrors = createStandardAction(
-  "RESET_CREATE_RECIPE_ERRORS"
+  "RESET_CREATE_RECIPE_ERRORS",
 )()
 
 export const deleteStep = createAsyncAction(
   "DELETE_STEP_REQUEST",
   "DELETE_STEP_SUCCESS",
-  "DELETE_STEP_FAILURE"
+  "DELETE_STEP_FAILURE",
 )<
   {
     recipeID: IRecipe["id"]
@@ -125,7 +125,7 @@ export const deleteStep = createAsyncAction(
 export const updateStep = createAsyncAction(
   "UPDATING_STEP_REQUEST",
   "UPDATING_STEP_SUCCESS",
-  "UPDATING_STEP_FAILURE"
+  "UPDATING_STEP_FAILURE",
 )<
   {
     recipeID: IRecipe["id"]
@@ -148,7 +148,7 @@ export const updateStep = createAsyncAction(
 export const deleteIngredient = createAsyncAction(
   "DELETE_INGREDIENT_REQUEST",
   "DELETE_INGREDIENT_SUCCESS",
-  "DELETE_INGREDIENT_FAILURE"
+  "DELETE_INGREDIENT_FAILURE",
 )<
   {
     recipeID: IRecipe["id"]
@@ -173,7 +173,7 @@ interface IUpdateIngredientArg {
 export const updateIngredient = createAsyncAction(
   "UPDATE_INGREDIENT_REQUEST",
   "UPDATE_INGREDIENT_SUCCESS",
-  "UPDATE_INGREDIENT_FAILURE"
+  "UPDATE_INGREDIENT_FAILURE",
 )<
   IUpdateIngredientArg,
   {
@@ -186,7 +186,7 @@ export const updateIngredient = createAsyncAction(
 
 async function updatingIngredientAsync(
   payload: IUpdateIngredientArg,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const { recipeID, ingredientID, content } = payload
   const res = await api.updateIngredient(recipeID, ingredientID, content)
@@ -195,8 +195,8 @@ async function updatingIngredientAsync(
       updateIngredient.success({
         recipeID,
         ingredientID,
-        content: res.data
-      })
+        content: res.data,
+      }),
     )
   } else {
     dispatch(updateIngredient.failure({ recipeID, ingredientID }))
@@ -211,12 +211,12 @@ interface IUpdateRecipeRequestArg {
 export const updateRecipe = createAsyncAction(
   "UPDATE_RECIPE_REQUEST",
   "UPDATE_RECIPE_SUCCESS",
-  "UPDATE_RECIPE_FAILIURE"
+  "UPDATE_RECIPE_FAILIURE",
 )<IUpdateRecipeRequestArg, IRecipe, IRecipe["id"]>()
 
 export async function updatingRecipeAsync(
   payload: IUpdateRecipeRequestArg,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.updateRecipe(payload.id, payload.data)
   if (isOk(res)) {
@@ -234,7 +234,7 @@ interface IAddStepToRecipeArg {
 export const addStepToRecipe = createAsyncAction(
   "ADD_STEP_TO_RECIPE_REQUEST",
   "ADD_STEP_TO_RECIPE_SUCCESS",
-  "ADD_STEP_TO_RECIPE_FAILURE"
+  "ADD_STEP_TO_RECIPE_FAILURE",
 )<
   IAddStepToRecipeArg,
   {
@@ -246,15 +246,15 @@ export const addStepToRecipe = createAsyncAction(
 
 async function addingStepToRecipeAsync(
   payload: IAddStepToRecipeArg,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.addStepToRecipe(payload.id, payload.step)
   if (isOk(res)) {
     dispatch(
       addStepToRecipe.success({
         id: payload.id,
-        step: res.data
-      })
+        step: res.data,
+      }),
     )
   } else {
     dispatch(addStepToRecipe.failure(payload.id))
@@ -264,7 +264,7 @@ async function addingStepToRecipeAsync(
 export const addNoteToRecipe = createAsyncAction(
   "ADD_NOTE_TO_RECIPE_REQUEST",
   "ADD_NOTE_TO_RECIPE_SUCCESS",
-  "ADD_NOTE_TO_RECIPE_FAILURE"
+  "ADD_NOTE_TO_RECIPE_FAILURE",
 )<
   { id: IRecipe["id"] },
   {
@@ -275,13 +275,13 @@ export const addNoteToRecipe = createAsyncAction(
 >()
 
 export const toggleCreatingNewNote = createStandardAction(
-  "TOGGLE_EDITING_NOTE"
+  "TOGGLE_EDITING_NOTE",
 )<{
   recipeId: number
   value: boolean
 }>()
 export const toggleEditingNoteById = createStandardAction(
-  "TOGGLE_EDITING_NOTE_BY_ID"
+  "TOGGLE_EDITING_NOTE_BY_ID",
 )<{
   noteId: number
   value: boolean
@@ -297,18 +297,18 @@ interface IAddNoteToRecipeArg {
 
 async function addingNoteToRecipeAsync(
   payload: IAddNoteToRecipeArg,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.addNoteToRecipe({
     recipeId: payload.id,
-    note: payload.note
+    note: payload.note,
   })
   if (isOk(res)) {
     dispatch(
       addNoteToRecipe.success({
         recipeId: payload.id,
-        note: res.data
-      })
+        note: res.data,
+      }),
     )
   } else {
     dispatch(addNoteToRecipe.failure(payload.id))
@@ -318,7 +318,7 @@ async function addingNoteToRecipeAsync(
 export const updateNote = createAsyncAction(
   "UPDATE_NOTE_REQUEST",
   "UPDATE_NOTE_SUCCESS",
-  "UPDATE_NOTE_FAILURE"
+  "UPDATE_NOTE_FAILURE",
 )<
   { recipeId: IRecipe["id"]; noteId: INote["id"]; text: INote["text"] },
   {
@@ -335,17 +335,20 @@ interface IUpdatingNoteAysnc {
 }
 async function updatingNoteAsync(
   payload: IUpdatingNoteAysnc,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.updateNote({
     noteId: payload.noteId,
-    note: payload.text
+    note: payload.text,
   })
   if (isOk(res)) {
     dispatch(updateNote.success({ recipeId: payload.recipeId, note: res.data }))
   } else {
     dispatch(
-      updateNote.failure({ recipeId: payload.recipeId, noteId: payload.noteId })
+      updateNote.failure({
+        recipeId: payload.recipeId,
+        noteId: payload.noteId,
+      }),
     )
   }
 }
@@ -353,7 +356,7 @@ async function updatingNoteAsync(
 export const deleteNote = createAsyncAction(
   "DELETE_NOTE_REQUEST",
   "DELETE_NOTE_SUCCESS",
-  "DELETE_NOTE_FAILURE"
+  "DELETE_NOTE_FAILURE",
 )<
   { recipeId: IRecipe["id"]; noteId: INote["id"] },
   { recipeId: IRecipe["id"]; noteId: INote["id"] },
@@ -366,18 +369,24 @@ interface IDeletingNoteAsync {
 }
 async function deletingNoteAsync(
   payload: IDeletingNoteAsync,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.deleteNote({
-    noteId: payload.noteId
+    noteId: payload.noteId,
   })
   if (isOk(res)) {
     dispatch(
-      deleteNote.success({ recipeId: payload.recipeId, noteId: payload.noteId })
+      deleteNote.success({
+        recipeId: payload.recipeId,
+        noteId: payload.noteId,
+      }),
     )
   } else {
     dispatch(
-      deleteNote.failure({ recipeId: payload.recipeId, noteId: payload.noteId })
+      deleteNote.failure({
+        recipeId: payload.recipeId,
+        noteId: payload.noteId,
+      }),
     )
   }
 }
@@ -398,7 +407,7 @@ interface IAddIngredientToRecipeArg {
 export const addIngredientToRecipe = createAsyncAction(
   "ADD_INGREDIENT_TO_RECIPE_REQUEST",
   "ADD_INGREDIENT_TO_RECIPE_SUCCESS",
-  "ADD_INGREDIENT_TO_RECIPE_FAILURE"
+  "ADD_INGREDIENT_TO_RECIPE_FAILURE",
 )<
   IAddIngredientToRecipeArg,
   {
@@ -410,19 +419,19 @@ export const addIngredientToRecipe = createAsyncAction(
 
 async function addingIngredientToRecipeAsync(
   payload: IAddIngredientToRecipeArg,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.addIngredientToRecipe(
     payload.recipeID,
-    payload.ingredient
+    payload.ingredient,
   )
 
   if (isOk(res)) {
     dispatch(
       addIngredientToRecipe.success({
         id: payload.recipeID,
-        ingredient: res.data
-      })
+        ingredient: res.data,
+      }),
     )
   } else {
     dispatch(addIngredientToRecipe.failure(payload.recipeID))
@@ -430,7 +439,7 @@ async function addingIngredientToRecipeAsync(
 }
 
 export const addSectionToRecipe = createStandardAction(
-  "ADD_SECTION_TO_RECIPE"
+  "ADD_SECTION_TO_RECIPE",
 )<{
   readonly recipeId: number
   readonly section: {
@@ -441,13 +450,13 @@ export const addSectionToRecipe = createStandardAction(
 }>()
 
 export const removeSectionFromRecipe = createStandardAction(
-  "REMOVE_SECTION_FROM_RECIPE"
+  "REMOVE_SECTION_FROM_RECIPE",
 )<{
   readonly recipeId: number
   readonly sectionId: number
 }>()
 export const updateSectionForRecipe = createStandardAction(
-  "UPDATE_SECTION_FOR_RECIPE"
+  "UPDATE_SECTION_FOR_RECIPE",
 )<{
   readonly recipeId: number
   readonly sectionId: number
@@ -456,7 +465,7 @@ export const updateSectionForRecipe = createStandardAction(
 }>()
 
 export const setSchedulingRecipe = createStandardAction(
-  "SET_SCHEDULING_RECIPE"
+  "SET_SCHEDULING_RECIPE",
 )<{
   recipeID: IRecipe["id"]
   scheduling: boolean
@@ -464,21 +473,21 @@ export const setSchedulingRecipe = createStandardAction(
 export const fetchRecentRecipes = createAsyncAction(
   "FETCH_RECENT_RECIPES_START",
   "FETCH_RECENT_RECIPES_SUCCESS",
-  "FETCH_RECENT_RECIPES_FAILURE"
+  "FETCH_RECENT_RECIPES_FAILURE",
 )<void, IRecipe[], void>()
 
 export const toggleEditingRecipe = createStandardAction(
-  "TOGGLE_RECIPE_EDITING"
+  "TOGGLE_RECIPE_EDITING",
 )<IRecipe["id"]>()
 
 export const setRecipeStepDraft = createStandardAction(
-  "SET_RECIPE_STEP_DRAFT"
+  "SET_RECIPE_STEP_DRAFT",
 )<{ id: IRecipe["id"]; draftStep: IRecipe["draftStep"] }>()
 
 export const duplicateRecipe = createAsyncAction(
   "DUPLICATE_RECIPE/REQUEST",
   "DUPLICATE_RECIPE/SUCCESS",
-  "DUPLICATE_RECIPE/FAILURE"
+  "DUPLICATE_RECIPE/FAILURE",
 )<
   { readonly recipeId: IRecipe["id"]; readonly onComplete?: () => void },
   { readonly recipe: IRecipe; readonly originalRecipeId: IRecipe["id"] },
@@ -492,13 +501,13 @@ interface IDuplicateRecipeAsync {
 export async function duplicateRecipeAsync(
   { recipeId }: IDuplicateRecipeAsync,
   dispatch: Dispatch,
-  cb?: () => void
+  cb?: () => void,
 ) {
   const res = await api.duplicateRecipe(recipeId)
 
   if (isOk(res)) {
     dispatch(
-      duplicateRecipe.success({ recipe: res.data, originalRecipeId: recipeId })
+      duplicateRecipe.success({ recipe: res.data, originalRecipeId: recipeId }),
     )
     dispatch(push(recipeURL(res.data.id)))
   } else {
@@ -559,18 +568,18 @@ export type RecipeActions =
 
 const mapSuccessLikeById = <T extends IRecipe["id"][]>(
   arr: WebData<T>,
-  state: IState
+  state: IState,
 ): WebData<IRecipe[]> =>
   mapSuccessLike(arr, a =>
     a
       .map(id => getRecipeById(state, id))
       .filter(isSuccessOrRefetching)
-      .map(d => d.data)
+      .map(d => d.data),
   )
 
 export function getTeamRecipes(
   state: IState,
-  teamID: TeamID
+  teamID: TeamID,
 ): WebData<IRecipe[]> {
   const ids =
     teamID === "personal"
@@ -581,7 +590,7 @@ export function getTeamRecipes(
 
 export const getRecipeById = (
   state: Pick<IState, "recipes">,
-  id: IRecipe["id"]
+  id: IRecipe["id"],
 ): WebData<IRecipe> => state.recipes.byId[id]
 
 export const getRecentRecipes = (state: IState): WebData<IRecipe[]> =>
@@ -670,7 +679,7 @@ export interface IRecipe {
 function mapRecipeSuccessById(
   state: IRecipesState,
   id: IRecipe["id"],
-  func: (recipe: IRecipe) => IRecipe
+  func: (recipe: IRecipe) => IRecipe,
 ): IRecipesState {
   const recipe = state.byId[id]
   if (!isSuccessOrRefetching(recipe)) {
@@ -682,23 +691,23 @@ function mapRecipeSuccessById(
       ...state.byId,
       [id]: {
         ...recipe,
-        data: func(recipe.data)
-      }
-    }
+        data: func(recipe.data),
+      },
+    },
   }
 }
 function mapNoteById(
   state: IRecipesState["notesById"],
   id: INote["id"],
-  func: (note: INoteByIdState) => INoteByIdState
+  func: (note: INoteByIdState) => INoteByIdState,
 ): IRecipesState["notesById"] {
   const note = state[id] || {}
   return {
     ...state,
     [id]: {
       ...note,
-      ...func(note)
-    }
+      ...func(note),
+    },
   }
 }
 
@@ -737,12 +746,12 @@ export const initialState: IRecipesState = {
   personalIDs: undefined,
   teamIDs: {},
   recentIds: undefined,
-  notesById: {}
+  notesById: {},
 }
 
 export const recipes = (
   state: IRecipesState = initialState,
-  action: RecipeActions
+  action: RecipeActions,
 ): IRecipesState | Loop<IRecipesState, RecipeActions> => {
   switch (action.type) {
     case getType(fetchRecipe.request): {
@@ -752,12 +761,12 @@ export const recipes = (
           ...state,
           byId: {
             ...state.byId,
-            [action.payload]: toLoading(r)
-          }
+            [action.payload]: toLoading(r),
+          },
         },
         Cmd.run(fetchingRecipeAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     }
     case getType(fetchRecipe.success):
@@ -765,8 +774,8 @@ export const recipes = (
         ...state,
         byId: {
           ...state.byId,
-          [action.payload.id]: Success(action.payload)
-        }
+          [action.payload.id]: Success(action.payload),
+        },
       }
     case getType(fetchRecipe.failure): {
       const failure = action.payload.error404
@@ -776,27 +785,27 @@ export const recipes = (
         ...state,
         byId: {
           ...state.byId,
-          [action.payload.id]: Failure(failure)
-        }
+          [action.payload.id]: Failure(failure),
+        },
       }
     }
     case getType(toggleEditingRecipe):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        editing: !recipe.editing
+        editing: !recipe.editing,
       }))
 
     case getType(setRecipeStepDraft):
       return mapRecipeSuccessById(state, action.payload.id, recipe => ({
         ...recipe,
-        draftStep: action.payload.draftStep
+        draftStep: action.payload.draftStep,
       }))
 
     case getType(fetchRecipeList.request): {
       if (action.payload.teamID === "personal") {
         return {
           ...state,
-          personalIDs: toLoading(state.personalIDs)
+          personalIDs: toLoading(state.personalIDs),
         }
       }
       const teamIdsState = state.teamIDs[action.payload.teamID]
@@ -804,8 +813,8 @@ export const recipes = (
         ...state,
         teamIDs: {
           ...state.teamIDs,
-          [action.payload.teamID]: toLoading(teamIdsState)
-        }
+          [action.payload.teamID]: toLoading(teamIdsState),
+        },
       }
     }
     case getType(fetchRecipeList.success): {
@@ -816,10 +825,10 @@ export const recipes = (
         byId: action.payload.recipes.reduce(
           (a, b) => ({
             ...a,
-            [b.id]: Success(b)
+            [b.id]: Success(b),
           }),
-          state.byId
-        )
+          state.byId,
+        ),
       }
 
       if (action.payload.teamID === "personal") {
@@ -830,29 +839,29 @@ export const recipes = (
         ...newState,
         teamIDs: {
           ...state.teamIDs,
-          [action.payload.teamID]: Success(newIds)
-        }
+          [action.payload.teamID]: Success(newIds),
+        },
       }
     }
     case getType(fetchRecipeList.failure): {
       if (action.payload.teamID === "personal") {
         return {
           ...state,
-          personalIDs: Failure(HttpErrorKind.other)
+          personalIDs: Failure(HttpErrorKind.other),
         }
       }
       return {
         ...state,
         teamIDs: {
           ...state.teamIDs,
-          [action.payload.teamID]: Failure(HttpErrorKind.other)
-        }
+          [action.payload.teamID]: Failure(HttpErrorKind.other),
+        },
       }
     }
     case getType(fetchRecentRecipes.request): {
       return {
         ...state,
-        recentIds: toLoading(state.recentIds)
+        recentIds: toLoading(state.recentIds),
       }
     }
     case getType(fetchRecentRecipes.success):
@@ -861,22 +870,22 @@ export const recipes = (
         byId: action.payload.reduce(
           (a, b) => ({
             ...a,
-            [b.id]: Success(b)
+            [b.id]: Success(b),
           }),
-          state.byId
+          state.byId,
         ),
-        recentIds: Success(action.payload.map(r => r.id))
+        recentIds: Success(action.payload.map(r => r.id)),
       }
     case getType(fetchRecentRecipes.failure):
       return {
         ...state,
-        recentIds: Failure(HttpErrorKind.other)
+        recentIds: Failure(HttpErrorKind.other),
       }
     case getType(createRecipe.request):
       return {
         ...state,
         creatingRecipe: true,
-        errorCreatingRecipe: {}
+        errorCreatingRecipe: {},
       }
     case getType(createRecipe.success):
       return {
@@ -885,49 +894,49 @@ export const recipes = (
         errorCreatingRecipe: {},
         byId: {
           ...state.byId,
-          [action.payload.id]: Success(action.payload)
-        }
+          [action.payload.id]: Success(action.payload),
+        },
       }
     case getType(createRecipe.failure):
       return {
         ...state,
         creatingRecipe: false,
-        errorCreatingRecipe: action.payload
+        errorCreatingRecipe: action.payload,
       }
     case getType(resetAddRecipeErrors):
       return {
         ...state,
-        errorCreatingRecipe: {}
+        errorCreatingRecipe: {},
       }
     case getType(deleteRecipe.request):
       return loop(
         mapRecipeSuccessById(state, action.payload, recipe => ({
           ...recipe,
-          deleting: true
+          deleting: true,
         })),
-        Cmd.run(deletingRecipeAsync, { args: [action.payload, Cmd.dispatch] })
+        Cmd.run(deletingRecipeAsync, { args: [action.payload, Cmd.dispatch] }),
       )
     case getType(deleteRecipe.success):
       return {
         ...state,
         byId: omit(state.byId, action.payload),
         personalIDs: mapSuccessLike(state.personalIDs, ids =>
-          ids.filter(id => id !== action.payload)
+          ids.filter(id => id !== action.payload),
         ),
         teamIDs: Object.entries(state.teamIDs).reduce(
           (acc, [key, value]) => ({
             ...acc,
             [key]: mapSuccessLike(value, v =>
-              v.filter(id => id !== action.payload)
-            )
+              v.filter(id => id !== action.payload),
+            ),
           }),
-          {}
-        )
+          {},
+        ),
       }
     case getType(deleteRecipe.failure):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        deleting: false
+        deleting: false,
       }))
     case getType(updateNote.request):
       return loop(
@@ -936,19 +945,19 @@ export const recipes = (
           notesById: mapNoteById(
             state.notesById,
             action.payload.noteId,
-            note => ({ ...note, saving: true })
-          )
+            note => ({ ...note, saving: true }),
+          ),
         },
         Cmd.run(updatingNoteAsync, {
           args: [
             {
               recipeId: action.payload.recipeId,
               noteId: action.payload.noteId,
-              text: action.payload.text
+              text: action.payload.text,
             },
-            Cmd.dispatch
-          ]
-        })
+            Cmd.dispatch,
+          ],
+        }),
       )
     case getType(updateNote.success):
       return {
@@ -957,8 +966,8 @@ export const recipes = (
             ...recipe,
             notes: [
               ...recipe.notes.filter(x => x.id !== action.payload.note.id),
-              action.payload.note
-            ]
+              action.payload.note,
+            ],
           }
         }),
         notesById: mapNoteById(
@@ -967,9 +976,9 @@ export const recipes = (
           note => ({
             ...note,
             openForEditing: false,
-            saving: false
-          })
-        )
+            saving: false,
+          }),
+        ),
       }
     case getType(updateNote.failure):
       return {
@@ -977,8 +986,8 @@ export const recipes = (
         notesById: mapNoteById(
           state.notesById,
           action.payload.noteId,
-          note => ({ ...note, saving: false })
-        )
+          note => ({ ...note, saving: false }),
+        ),
       }
     case getType(deleteNote.request):
       return loop(
@@ -987,24 +996,24 @@ export const recipes = (
           notesById: mapNoteById(
             state.notesById,
             action.payload.noteId,
-            note => ({ ...note, deleting: true })
-          )
+            note => ({ ...note, deleting: true }),
+          ),
         },
         Cmd.run(deletingNoteAsync, {
           args: [
             {
               recipeId: action.payload.recipeId,
-              noteId: action.payload.noteId
+              noteId: action.payload.noteId,
             },
-            Cmd.dispatch
-          ]
-        })
+            Cmd.dispatch,
+          ],
+        }),
       )
     case getType(deleteNote.success):
       return mapRecipeSuccessById(state, action.payload.recipeId, recipe => {
         return {
           ...recipe,
-          notes: recipe.notes.filter(x => x.id !== action.payload.noteId)
+          notes: recipe.notes.filter(x => x.id !== action.payload.noteId),
         }
       })
     case getType(deleteNote.failure):
@@ -1013,8 +1022,8 @@ export const recipes = (
         notesById: mapNoteById(
           state.notesById,
           action.payload.noteId,
-          note => ({ ...note, deleting: false })
-        )
+          note => ({ ...note, deleting: false }),
+        ),
       }
     case getType(toggleEditingNoteById):
       return {
@@ -1022,8 +1031,8 @@ export const recipes = (
         notesById: mapNoteById(
           state.notesById,
           action.payload.noteId,
-          note => ({ ...note, openForEditing: action.payload.value })
-        )
+          note => ({ ...note, openForEditing: action.payload.value }),
+        ),
       }
     case getType(toggleCreatingNewNote):
       const nextState = mapRecipeSuccessById(
@@ -1031,8 +1040,8 @@ export const recipes = (
         action.payload.recipeId,
         recipe => ({
           ...recipe,
-          creatingNewNote: action.payload.value
-        })
+          creatingNewNote: action.payload.value,
+        }),
       )
       if (!action.payload.value) {
         return loop(nextState, Cmd.run(blurNoteTextArea))
@@ -1041,7 +1050,7 @@ export const recipes = (
     case getType(setDraftNote):
       return mapRecipeSuccessById(state, action.payload.recipeId, recipe => ({
         ...recipe,
-        draftNote: action.payload.text
+        draftNote: action.payload.text,
       }))
     case getType(addNoteToRecipe.request):
       const maybeRecipe = state.byId[action.payload.id]
@@ -1052,11 +1061,11 @@ export const recipes = (
       return loop(
         mapRecipeSuccessById(state, action.payload.id, recipe => ({
           ...recipe,
-          addingNoteToRecipe: true
+          addingNoteToRecipe: true,
         })),
         Cmd.run(addingNoteToRecipeAsync, {
-          args: [{ id: action.payload.id, note: text }, Cmd.dispatch]
-        })
+          args: [{ id: action.payload.id, note: text }, Cmd.dispatch],
+        }),
       )
     case getType(addNoteToRecipe.success):
       return loop(
@@ -1065,53 +1074,53 @@ export const recipes = (
           notes: recipe.notes.concat(action.payload.note),
           draftNote: "",
           creatingNewNote: false,
-          addingNoteToRecipe: false
+          addingNoteToRecipe: false,
         })),
-        Cmd.run(blurNoteTextArea)
+        Cmd.run(blurNoteTextArea),
       )
     case getType(addNoteToRecipe.failure):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        addingNoteToRecipe: false
+        addingNoteToRecipe: false,
       }))
     case getType(addStepToRecipe.request):
       return loop(
         mapRecipeSuccessById(state, action.payload.id, recipe => ({
           ...recipe,
-          addingStepToRecipe: true
+          addingStepToRecipe: true,
         })),
         Cmd.run(addingStepToRecipeAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(addStepToRecipe.success):
       return mapRecipeSuccessById(state, action.payload.id, recipe => ({
         ...recipe,
         steps: recipe.steps.concat(action.payload.step),
         addingStepToRecipe: false,
-        draftStep: ""
+        draftStep: "",
       }))
     case getType(addStepToRecipe.failure):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        addingStepToRecipe: false
+        addingStepToRecipe: false,
       }))
     case getType(addIngredientToRecipe.request):
       return loop(
         mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
           ...recipe,
-          addingIngredient: true
+          addingIngredient: true,
         })),
         Cmd.run(addingIngredientToRecipeAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(addSectionToRecipe):
       return mapRecipeSuccessById(state, action.payload.recipeId, recipe => {
         const sections = recipe.sections.concat(action.payload.section)
         return {
           ...recipe,
-          sections
+          sections,
         }
       })
     case getType(removeSectionFromRecipe):
@@ -1120,11 +1129,11 @@ export const recipes = (
           return recipe
         }
         const sections = recipe.sections.filter(
-          x => x.id !== action.payload.sectionId
+          x => x.id !== action.payload.sectionId,
         )
         return {
           ...recipe,
-          sections
+          sections,
         }
       })
     case getType(updateSectionForRecipe):
@@ -1140,19 +1149,19 @@ export const recipes = (
         })
         return {
           ...recipe,
-          sections
+          sections,
         }
       })
     case getType(addIngredientToRecipe.success):
       return mapRecipeSuccessById(state, action.payload.id, recipe => ({
         ...recipe,
         ingredients: recipe.ingredients.concat(action.payload.ingredient),
-        addingIngredient: false
+        addingIngredient: false,
       }))
     case getType(addIngredientToRecipe.failure):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        addingIngredient: false
+        addingIngredient: false,
       }))
     case getType(deleteIngredient.request):
       return loop(
@@ -1162,22 +1171,22 @@ export const recipes = (
             if (x.id === action.payload.ingredientID) {
               return {
                 ...x,
-                removing: true
+                removing: true,
               }
             }
             return x
-          })
+          }),
         })),
         Cmd.run(deletingIngredientAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(deleteIngredient.success):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
         ...recipe,
         ingredients: recipe.ingredients.filter(
-          x => x.id !== action.payload.ingredientID
-        )
+          x => x.id !== action.payload.ingredientID,
+        ),
       }))
     case getType(deleteIngredient.failure):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
@@ -1186,11 +1195,11 @@ export const recipes = (
           if (x.id === action.payload.ingredientID) {
             return {
               ...x,
-              removing: false
+              removing: false,
             }
           }
           return x
-        })
+        }),
       }))
     case getType(updateIngredient.request): {
       return loop(
@@ -1201,15 +1210,15 @@ export const recipes = (
               return {
                 ...x,
                 updating: true,
-                position: action.payload.content.position ?? x.position
+                position: action.payload.content.position ?? x.position,
               }
             }
             return x
-          })
+          }),
         })),
         Cmd.run(updatingIngredientAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     }
     case getType(updateIngredient.success):
@@ -1220,7 +1229,7 @@ export const recipes = (
             return { ...ingre, ...action.payload.content, updating: false }
           }
           return ingre
-        })
+        }),
       }))
     case getType(updateIngredient.failure):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
@@ -1229,11 +1238,11 @@ export const recipes = (
           if (x.id === action.payload.ingredientID) {
             return {
               ...x,
-              updating: false
+              updating: false,
             }
           }
           return x
-        })
+        }),
       }))
     case getType(deleteStep.request):
       return loop(
@@ -1243,20 +1252,20 @@ export const recipes = (
             if (x.id === action.payload.stepID) {
               return {
                 ...x,
-                removing: true
+                removing: true,
               }
             }
             return x
-          })
+          }),
         })),
         Cmd.run(deletingStepAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(deleteStep.success):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
         ...recipe,
-        steps: recipe.steps.filter(x => x.id !== action.payload.stepID)
+        steps: recipe.steps.filter(x => x.id !== action.payload.stepID),
       }))
     case getType(deleteStep.failure):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
@@ -1265,11 +1274,11 @@ export const recipes = (
           if (x.id === action.payload.stepID) {
             return {
               ...x,
-              removing: false
+              removing: false,
             }
           }
           return x
-        })
+        }),
       }))
     case getType(updateStep.request): {
       return loop(
@@ -1281,15 +1290,15 @@ export const recipes = (
                 ...x,
                 text: action.payload.text || x.text,
                 position: action.payload.position || x.position,
-                updating: true
+                updating: true,
               }
             }
             return x
-          })
+          }),
         })),
         Cmd.run(updatingStepAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     }
 
@@ -1302,11 +1311,11 @@ export const recipes = (
               ...s,
               text: action.payload.text,
               position: action.payload.position,
-              updating: false
+              updating: false,
             }
           }
           return s
-        })
+        }),
       }))
     case getType(updateStep.failure):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
@@ -1315,45 +1324,45 @@ export const recipes = (
           if (x.id === action.payload.stepID) {
             return {
               ...x,
-              updating: false
+              updating: false,
             }
           }
           return x
-        })
+        }),
       }))
 
     case getType(updateRecipe.request):
       return loop(
         mapRecipeSuccessById(state, action.payload.id, recipe => ({
           ...recipe,
-          updating: true
+          updating: true,
         })),
         Cmd.run(updatingRecipeAsync, {
-          args: [action.payload, Cmd.dispatch]
-        })
+          args: [action.payload, Cmd.dispatch],
+        }),
       )
     case getType(updateRecipe.success):
       return mapRecipeSuccessById(state, action.payload.id, recipe => ({
         ...recipe,
         ...action.payload,
         updating: false,
-        editing: false
+        editing: false,
       }))
     case getType(updateRecipe.failure):
       return mapRecipeSuccessById(state, action.payload, recipe => ({
         ...recipe,
-        updating: false
+        updating: false,
       }))
     case getType(updateRecipeOwner):
       return mapRecipeSuccessById(state, action.payload.id, recipe => ({
         ...recipe,
 
-        owner: action.payload.owner
+        owner: action.payload.owner,
       }))
     case getType(setSchedulingRecipe):
       return mapRecipeSuccessById(state, action.payload.recipeID, recipe => ({
         ...recipe,
-        scheduling: action.payload.scheduling
+        scheduling: action.payload.scheduling,
       }))
     case getType(duplicateRecipe.request): {
       const { recipeId, onComplete } = action.payload
@@ -1362,12 +1371,12 @@ export const recipes = (
           ...state,
           duplicatingById: {
             ...state.duplicatingById,
-            [recipeId]: true
-          }
+            [recipeId]: true,
+          },
         },
         Cmd.run(duplicateRecipeAsync, {
-          args: [{ recipeId }, Cmd.dispatch, onComplete]
-        })
+          args: [{ recipeId }, Cmd.dispatch, onComplete],
+        }),
       )
     }
     case getType(duplicateRecipe.success):
@@ -1375,12 +1384,12 @@ export const recipes = (
         ...state,
         duplicatingById: {
           ...state.duplicatingById,
-          [action.payload.originalRecipeId]: false
+          [action.payload.originalRecipeId]: false,
         },
         byId: {
           ...state.byId,
-          [action.payload.recipe.id]: Success(action.payload.recipe)
-        }
+          [action.payload.recipe.id]: Success(action.payload.recipe),
+        },
       }
 
     case getType(duplicateRecipe.failure):
@@ -1388,8 +1397,8 @@ export const recipes = (
         ...state,
         duplicatingById: {
           ...state.duplicatingById,
-          [action.payload]: false
-        }
+          [action.payload]: false,
+        },
       }
     default:
       return state

--- a/frontend/src/store/reducers/rootReducer.test.ts
+++ b/frontend/src/store/reducers/rootReducer.test.ts
@@ -10,7 +10,7 @@ describe("logout", () => {
       ...emptyStore.getState(),
       user: {
         ...emptyStore.getState().user,
-        loggedIn: true
+        loggedIn: true,
       },
       auth: initialState,
       router: {
@@ -18,18 +18,18 @@ describe("logout", () => {
           state: "",
           pathname: "",
           search: "",
-          hash: ""
-        }
-      }
+          hash: "",
+        },
+      },
     }
 
     const afterState = {
       ...emptyStore.getState(),
-      router: beforeState.router
+      router: beforeState.router,
     }
 
     expect(getModel(rootReducer(beforeState, setUserLoggedIn(false)))).toEqual(
-      afterState
+      afterState,
     )
   })
 })

--- a/frontend/src/store/reducers/shoppinglist.test.ts
+++ b/frontend/src/store/reducers/shoppinglist.test.ts
@@ -2,7 +2,7 @@ import shoppinglist, {
   IShoppingListState,
   fetchShoppingList,
   setSelectingStart,
-  setSelectingEnd
+  setSelectingEnd,
 } from "@/store/reducers/shoppinglist"
 import { Loading, Success, Failure, HttpErrorKind } from "@/webdata"
 import { IGetShoppingListResponse, Unit } from "@/api"
@@ -13,24 +13,24 @@ describe("Shopping List", () => {
       quantities: [
         {
           quantity: "4.204622621848776",
-          unit: Unit.POUND
-        }
-      ]
+          unit: Unit.POUND,
+        },
+      ],
     },
     "soy sauce": {
       quantities: [
         {
           quantity: "2",
-          unit: Unit.TABLESPOON
-        }
-      ]
-    }
+          unit: Unit.TABLESPOON,
+        },
+      ],
+    },
   }
   it("sets list", () => {
     const beforeState: IShoppingListState = {
       shoppinglist: Loading(),
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
     // this should match up to what the server is providing because we
     // normalize the server data in the reducer
@@ -38,11 +38,11 @@ describe("Shopping List", () => {
     const afterState: IShoppingListState = {
       shoppinglist: Success(shopList),
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     expect(
-      shoppinglist(beforeState, fetchShoppingList.success(shopList))
+      shoppinglist(beforeState, fetchShoppingList.success(shopList)),
     ).toEqual(afterState)
   })
 
@@ -50,17 +50,17 @@ describe("Shopping List", () => {
     const beforeState: IShoppingListState = {
       shoppinglist: undefined,
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     const afterState: IShoppingListState = {
       shoppinglist: Loading(),
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     expect(shoppinglist(beforeState, fetchShoppingList.request())).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -68,17 +68,17 @@ describe("Shopping List", () => {
     const beforeState: IShoppingListState = {
       shoppinglist: Loading(),
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     const afterState: IShoppingListState = {
       shoppinglist: Failure(HttpErrorKind.other),
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     expect(shoppinglist(beforeState, fetchShoppingList.failure())).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -88,17 +88,17 @@ describe("Shopping List", () => {
     const beforeState: IShoppingListState = {
       shoppinglist: undefined,
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     const afterState: IShoppingListState = {
       shoppinglist: undefined,
       startDay,
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     expect(shoppinglist(beforeState, setSelectingStart(startDay))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -108,17 +108,17 @@ describe("Shopping List", () => {
     const beforeState: IShoppingListState = {
       shoppinglist: undefined,
       startDay: new Date(1776, 1, 1),
-      endDay: new Date(1776, 1, 2)
+      endDay: new Date(1776, 1, 2),
     }
 
     const afterState: IShoppingListState = {
       shoppinglist: undefined,
       startDay: new Date(1776, 1, 1),
-      endDay
+      endDay,
     }
 
     expect(shoppinglist(beforeState, setSelectingEnd(endDay))).toEqual(
-      afterState
+      afterState,
     )
   })
 })

--- a/frontend/src/store/reducers/shoppinglist.ts
+++ b/frontend/src/store/reducers/shoppinglist.ts
@@ -2,7 +2,7 @@ import {
   createAsyncAction,
   ActionType,
   getType,
-  createStandardAction
+  createStandardAction,
 } from "typesafe-actions"
 import { WebData, Success, Failure, HttpErrorKind, toLoading } from "@/webdata"
 import { startOfToday, addWeeks } from "date-fns"
@@ -11,7 +11,7 @@ import { IGetShoppingListResponse } from "@/api"
 export const fetchShoppingList = createAsyncAction(
   "FETCH_SHOPPING_LIST_START",
   "FETCH_SHOPPING_LIST_SUCCESS",
-  "FETCH_SHOPPING_LIST_FAILURE"
+  "FETCH_SHOPPING_LIST_FAILURE",
 )<void, IGetShoppingListResponse, void>()
 
 export const setSelectingStart = createStandardAction("SET_SELECTING_START")<
@@ -33,12 +33,12 @@ export interface IShoppingListState {
 const initialState: IShoppingListState = {
   shoppinglist: undefined,
   startDay: startOfToday(),
-  endDay: addWeeks(startOfToday(), 1)
+  endDay: addWeeks(startOfToday(), 1),
 }
 
 const shoppinglist = (
   state: IShoppingListState = initialState,
-  action: ShoppingListActions
+  action: ShoppingListActions,
 ): IShoppingListState => {
   switch (action.type) {
     case getType(fetchShoppingList.success):

--- a/frontend/src/store/reducers/teams.test.ts
+++ b/frontend/src/store/reducers/teams.test.ts
@@ -16,7 +16,7 @@ import {
   setUserTeamLevel,
   setUpdatingUserTeamLevel,
   fetchTeamRecipes,
-  fetchTeamMembers
+  fetchTeamMembers,
 } from "@/store/reducers/teams"
 import { baseRecipe } from "@/store/reducers/recipes.test"
 
@@ -34,10 +34,10 @@ const baseMember: IMember = {
     email: "bar",
     avatar_url: "bar.com",
     dark_mode_enabled: false,
-    selected_team: null
+    selected_team: null,
   },
   level: "read",
-  is_active: true
+  is_active: true,
 }
 
 describe("Teams", () => {
@@ -45,12 +45,12 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "team name",
-      members: []
+      members: [],
     })
     const recipe = {
       id: 123,
       name: "other team name",
-      members: []
+      members: [],
     }
     const afterState = {
       ...beforeState,
@@ -58,10 +58,10 @@ describe("Teams", () => {
         ...beforeState.byId,
         [recipe.id]: {
           ...recipe,
-          loadingTeam: false
-        }
+          loadingTeam: false,
+        },
       },
-      allIds: [1, recipe.id]
+      allIds: [1, recipe.id],
     }
 
     expect(teams(beforeState, fetchTeam.success(recipe))).toEqual(afterState)
@@ -71,19 +71,19 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "team name",
-      members: []
+      members: [],
     })
     const recipe = {
       id: 1,
       name: "other team name",
-      members: []
+      members: [],
     }
 
     const afterState = teamStateWith({
       id: 1,
       name: "other team name",
       members: [],
-      loadingTeam: false
+      loadingTeam: false,
     })
 
     expect(teams(beforeState, fetchTeam.success(recipe))).toEqual(afterState)
@@ -94,32 +94,32 @@ describe("Teams", () => {
       {
         id: 1,
         name: "add all teams",
-        members: []
+        members: [],
       },
       {
         id: 4,
         name: "blah",
         loadingTeam: false,
-        members: []
-      }
+        members: [],
+      },
     ])
 
     const data: ITeam[] = [
       {
         id: 2,
         name: "another name",
-        members: []
+        members: [],
       },
       {
         id: 3,
         name: "yet another name",
-        members: []
+        members: [],
       },
       {
         id: 4,
         name: "blah",
-        members: []
-      }
+        members: [],
+      },
     ]
 
     const afterState: ITeamsState = {
@@ -127,27 +127,27 @@ describe("Teams", () => {
         1: {
           id: 1,
           name: "add all teams",
-          members: []
+          members: [],
         },
         2: {
           id: 2,
           name: "another name",
-          members: []
+          members: [],
         },
         3: {
           id: 3,
           name: "yet another name",
-          members: []
+          members: [],
         },
         4: {
           id: 4,
           name: "blah",
           loadingTeam: false,
-          members: []
-        }
+          members: [],
+        },
       },
       allIds: [1, 4, 2, 3],
-      status: "success"
+      status: "success",
     }
 
     expect(teams(beforeState, fetchTeams.success(data))).toEqual(afterState)
@@ -157,14 +157,14 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "team name",
-      members: []
+      members: [],
     })
 
     const afterState = teamStateWith({
       id: 1,
       name: "team name",
       loadingTeam: true,
-      members: []
+      members: [],
     })
 
     expect(teams(beforeState, fetchTeam.request(1))).toEqual(afterState)
@@ -174,14 +174,14 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "team name",
-      members: []
+      members: [],
     })
 
     const afterState = teamStateWith({
       id: 1,
       name: "team name",
       loadingMembers: true,
-      members: []
+      members: [],
     })
 
     expect(teams(beforeState, fetchTeamMembers.request(1))).toEqual(afterState)
@@ -191,14 +191,14 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "team name",
-      members: []
+      members: [],
     })
 
     const afterState = teamStateWith({
       id: 1,
       name: "team name",
       loadingRecipes: true,
-      members: []
+      members: [],
     })
 
     expect(teams(beforeState, fetchTeamRecipes.request(1))).toEqual(afterState)
@@ -209,13 +209,13 @@ describe("Teams", () => {
       {
         id: 1,
         name: "team name",
-        members: []
+        members: [],
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     const afterState = teamStateWith([
@@ -224,17 +224,17 @@ describe("Teams", () => {
         name: "team name",
         error404: true,
         members: [],
-        loadingTeam: false
+        loadingTeam: false,
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     expect(
-      teams(beforeState, fetchTeam.failure({ id: 1, error404: true }))
+      teams(beforeState, fetchTeam.failure({ id: 1, error404: true })),
     ).toEqual(afterState)
   })
 
@@ -243,13 +243,13 @@ describe("Teams", () => {
       {
         id: 1,
         name: "team name",
-        members: []
+        members: [],
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     const members: IMember[] = [
@@ -262,9 +262,9 @@ describe("Teams", () => {
           avatar_url: "http://lksjdflsjdf",
           has_usable_password: false,
           dark_mode_enabled: false,
-          selected_team: null
-        }
-      }
+          selected_team: null,
+        },
+      },
     ]
 
     const afterState = teamStateWith([
@@ -273,18 +273,18 @@ describe("Teams", () => {
         loadingMembers: false,
         name: "team name",
         members: {
-          [members[0].id]: members[0]
-        }
+          [members[0].id]: members[0],
+        },
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     expect(
-      teams(beforeState, fetchTeamMembers.success({ id: 1, members }))
+      teams(beforeState, fetchTeamMembers.success({ id: 1, members })),
     ).toEqual(afterState)
   })
 
@@ -293,13 +293,13 @@ describe("Teams", () => {
       {
         id: 1,
         name: "team name",
-        members: []
+        members: [],
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     const recipes = [
@@ -311,9 +311,9 @@ describe("Teams", () => {
           email: "blah@blah.com",
           avatar_url: "http://lksjdflsjdf",
           dark_mode_enabled: false,
-          selected_team: null
-        }
-      }
+          selected_team: null,
+        },
+      },
     ]
 
     const afterState = teamStateWith([
@@ -322,17 +322,17 @@ describe("Teams", () => {
         name: "team name",
         members: [],
         recipes: [1],
-        loadingRecipes: false
+        loadingRecipes: false,
       },
       {
         id: 2,
         name: "another team name",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     expect(
-      teams(beforeState, fetchTeamRecipes.success({ id: 1, recipes }))
+      teams(beforeState, fetchTeamRecipes.success({ id: 1, recipes })),
     ).toEqual(afterState)
   })
 
@@ -340,18 +340,18 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "foo",
-      members: []
+      members: [],
     })
 
     const afterState = teamStateWith({
       id: 1,
       name: "foo",
       updating: true,
-      members: []
+      members: [],
     })
 
     expect(
-      teams(beforeState, setUpdatingUserTeamLevel({ id: 1, updating: true }))
+      teams(beforeState, setUpdatingUserTeamLevel({ id: 1, updating: true })),
     ).toEqual(afterState)
   })
 
@@ -369,8 +369,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -381,10 +381,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState = teamStateWith({
@@ -400,8 +400,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -412,17 +412,17 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     expect(
       teams(
         beforeState,
-        setUserTeamLevel({ teamID: 1, membershipID: 2, level: "admin" })
-      )
+        setUserTeamLevel({ teamID: 1, membershipID: 2, level: "admin" }),
+      ),
     ).toEqual(afterState)
   })
 
@@ -440,8 +440,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -452,10 +452,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState = teamStateWith({
@@ -471,8 +471,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -484,17 +484,17 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     expect(
       teams(
         beforeState,
-        setDeletingMembership({ teamID: 1, membershipID: 2, val: true })
-      )
+        setDeletingMembership({ teamID: 1, membershipID: 2, val: true }),
+      ),
     ).toEqual(afterState)
   })
 
@@ -512,8 +512,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -525,10 +525,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState = teamStateWith({
@@ -544,14 +544,14 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     expect(
-      teams(beforeState, deleteMembership({ teamID: 1, membershipID: 2 }))
+      teams(beforeState, deleteMembership({ teamID: 1, membershipID: 2 })),
     ).toEqual(afterState)
   })
 
@@ -569,8 +569,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -581,10 +581,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState = teamStateWith({
@@ -601,8 +601,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -613,14 +613,14 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     expect(
-      teams(beforeState, setSendingTeamInvites({ teamID: 1, val: true }))
+      teams(beforeState, setSendingTeamInvites({ teamID: 1, val: true })),
     ).toEqual(afterState)
   })
 
@@ -638,8 +638,8 @@ describe("Teams", () => {
             email: "foo",
             avatar_url: "foo.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -650,10 +650,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState: ITeamsState = {
@@ -670,8 +670,8 @@ describe("Teams", () => {
               email: "foo",
               avatar_url: "foo.com",
               dark_mode_enabled: false,
-              selected_team: null
-            }
+              selected_team: null,
+            },
           },
           2: {
             ...baseMember,
@@ -682,12 +682,12 @@ describe("Teams", () => {
               email: "bar",
               avatar_url: "bar.com",
               dark_mode_enabled: false,
-              selected_team: null
-            }
-          }
-        }
+              selected_team: null,
+            },
+          },
+        },
       }),
-      status: "loading"
+      status: "loading",
     }
 
     expect(teams(beforeState, fetchTeams.request())).toEqual(afterState)
@@ -708,8 +708,8 @@ describe("Teams", () => {
             avatar_url: "foo.com",
 
             dark_mode_enabled: false,
-            selected_team: null
-          }
+            selected_team: null,
+          },
         },
         2: {
           ...baseMember,
@@ -720,10 +720,10 @@ describe("Teams", () => {
             email: "bar",
             avatar_url: "bar.com",
             dark_mode_enabled: false,
-            selected_team: null
-          }
-        }
-      }
+            selected_team: null,
+          },
+        },
+      },
     })
 
     const afterState: ITeamsState = {
@@ -743,8 +743,8 @@ describe("Teams", () => {
                 email: "foo",
                 avatar_url: "foo.com",
                 dark_mode_enabled: false,
-                selected_team: null
-              }
+                selected_team: null,
+              },
             },
             2: {
               ...baseMember,
@@ -755,13 +755,13 @@ describe("Teams", () => {
                 email: "bar",
                 avatar_url: "bar.com",
                 dark_mode_enabled: false,
-                selected_team: null
-              }
-            }
-          }
-        }
+                selected_team: null,
+              },
+            },
+          },
+        },
       },
-      allIds: [1]
+      allIds: [1],
     }
 
     expect(teams(beforeState, setCreatingTeam(true))).toEqual(afterState)
@@ -771,7 +771,7 @@ describe("Teams", () => {
     const team: ITeam = {
       id: 2,
       name: "buzz",
-      members: {}
+      members: {},
     }
 
     const beforeState: ITeamsState = {
@@ -780,10 +780,10 @@ describe("Teams", () => {
         1: {
           id: 1,
           name: "foobar",
-          members: {}
-        }
+          members: {},
+        },
       },
-      allIds: [1]
+      allIds: [1],
     }
 
     const afterState: ITeamsState = {
@@ -792,15 +792,15 @@ describe("Teams", () => {
         1: {
           id: 1,
           name: "foobar",
-          members: {}
+          members: {},
         },
-        [team.id]: team
+        [team.id]: team,
       },
-      allIds: [1, team.id]
+      allIds: [1, team.id],
     }
 
     expect(teams(beforeState, setTeam({ id: team.id, team }))).toEqual(
-      afterState
+      afterState,
     )
   })
 
@@ -809,31 +809,31 @@ describe("Teams", () => {
       {
         id: 1,
         name: "foo",
-        members: []
+        members: [],
       },
       {
         id: 2,
         name: "bar",
-        members: []
+        members: [],
       },
       {
         id: 3,
         name: "buzz",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     const afterState = teamStateWith([
       {
         id: 1,
         name: "foo",
-        members: []
+        members: [],
       },
       {
         id: 3,
         name: "buzz",
-        members: []
-      }
+        members: [],
+      },
     ])
 
     expect(teams(beforeState, deleteTeam(2))).toEqual(afterState)
@@ -843,13 +843,13 @@ describe("Teams", () => {
     const beforeState: ITeamsState = {
       status: "initial",
       byId: {},
-      allIds: []
+      allIds: [],
     }
     const afterState: ITeamsState = {
       status: "initial",
       copying: true,
       byId: {},
-      allIds: []
+      allIds: [],
     }
     expect(teams(beforeState, setCopyingTeam(true))).toEqual(afterState)
   })
@@ -858,21 +858,21 @@ describe("Teams", () => {
     const beforeState = teamStateWith({
       id: 1,
       name: "Acme Inc.",
-      members: []
+      members: [],
     })
     const afterState = teamStateWith({
       id: 1,
       name: "InnoTech",
-      members: []
+      members: [],
     })
     expect(
       teams(
         beforeState,
         updateTeamById({
           id: 1,
-          teamKeys: { id: 1, name: "InnoTech", members: [] }
-        })
-      )
+          teamKeys: { id: 1, name: "InnoTech", members: [] },
+        }),
+      ),
     ).toEqual(afterState)
   })
 })

--- a/frontend/src/store/reducers/teams.ts
+++ b/frontend/src/store/reducers/teams.ts
@@ -4,7 +4,7 @@ import {
   createAsyncAction,
   getType,
   ActionType,
-  createStandardAction
+  createStandardAction,
 } from "typesafe-actions"
 import { IRecipe } from "@/store/reducers/recipes"
 
@@ -13,12 +13,12 @@ export const deleteTeam = createStandardAction("DELETE_TEAM")<ITeam["id"]>()
 export const fetchTeam = createAsyncAction(
   "FETCH_TEAM_REQUEST",
   "FETCH_TEAM_SUCCESS",
-  "FETCH_TEAM_FAILURE"
+  "FETCH_TEAM_FAILURE",
 )<ITeam["id"], ITeam, { id: ITeam["id"]; error404?: boolean }>()
 export const fetchTeamMembers = createAsyncAction(
   "FETCH_TEAM_MEMBERS_REQUEST",
   "FETCH_TEAM_MEMBERS_SUCCESS",
-  "FETCH_TEAM_MEMBERS_FAILURE"
+  "FETCH_TEAM_MEMBERS_FAILURE",
 )<
   ITeam["id"],
   {
@@ -31,7 +31,7 @@ export const fetchTeamMembers = createAsyncAction(
 export const fetchTeamRecipes = createAsyncAction(
   "FETCH_TEAM_RECIPES_REQUEST",
   "FETCH_TEAM_RECIPES_SUCCESS",
-  "FETCH_TEAM_RECIPES_FAILURE"
+  "FETCH_TEAM_RECIPES_FAILURE",
 )<
   ITeam["id"],
   {
@@ -42,10 +42,10 @@ export const fetchTeamRecipes = createAsyncAction(
 >()
 
 export const setUpdatingUserTeamLevel = createStandardAction(
-  "SET_UPDATING_USER_TEAM_LEVEL"
+  "SET_UPDATING_USER_TEAM_LEVEL",
 )<{ id: ITeam["id"]; updating: boolean }>()
 export const setDeletingMembership = createStandardAction(
-  "SET_DELETING_MEMBERSHIP"
+  "SET_DELETING_MEMBERSHIP",
 )<{ teamID: number; membershipID: number; val: boolean }>()
 export const setUserTeamLevel = createStandardAction("SET_USER_TEAM_LEVEL")<{
   teamID: ITeam["id"]
@@ -53,7 +53,7 @@ export const setUserTeamLevel = createStandardAction("SET_USER_TEAM_LEVEL")<{
   level: IMember["level"]
 }>()
 export const setSendingTeamInvites = createStandardAction(
-  "SET_SENDING_TEAM_INVITES"
+  "SET_SENDING_TEAM_INVITES",
 )<{ teamID: ITeam["id"]; val: boolean }>()
 export const deleteMembership = createStandardAction("DELETE_MEMBERSHIP")<{
   teamID: ITeam["id"]
@@ -77,7 +77,7 @@ export const updateTeamById = createStandardAction("UPDATE_TEAM")<{
 export const fetchTeams = createAsyncAction(
   "FETCH_TEAMS_START",
   "FETCH_TEAMS_SUCCESS",
-  "FETCH_TEAMS_FAILURE"
+  "FETCH_TEAMS_FAILURE",
 )<void, ITeam[], void>()
 
 export type TeamsActions =
@@ -134,7 +134,7 @@ export interface ITeamsState {
 function mapById(
   state: ITeamsState,
   id: ITeam["id"],
-  func: (team: ITeam) => ITeam
+  func: (team: ITeam) => ITeam,
 ): ITeamsState {
   const team = state.byId[id]
   if (team == null) {
@@ -144,8 +144,8 @@ function mapById(
     ...state,
     byId: {
       ...state.byId,
-      [id]: func(team)
-    }
+      [id]: func(team),
+    },
   }
 }
 
@@ -153,18 +153,18 @@ function mapById(
 const initialState: ITeamsState = {
   byId: {},
   allIds: [],
-  status: "initial"
+  status: "initial",
 }
 
 export const teams = (
   state: ITeamsState = initialState,
-  action: TeamsActions
+  action: TeamsActions,
 ): ITeamsState => {
   switch (action.type) {
     case getType(fetchTeam.request):
       return mapById(state, action.payload, team => ({
         ...team,
-        loadingTeam: true
+        loadingTeam: true,
       }))
     case getType(fetchTeam.success):
       return {
@@ -174,27 +174,27 @@ export const teams = (
           [action.payload.id]: {
             ...state.byId[action.payload.id],
             ...action.payload,
-            loadingTeam: false
-          }
+            loadingTeam: false,
+          },
         },
-        allIds: uniq([...state.allIds, action.payload.id])
+        allIds: uniq([...state.allIds, action.payload.id]),
       }
     case getType(fetchTeam.failure):
       return mapById(state, action.payload.id, team => ({
         ...team,
         loadingTeam: false,
-        error404: action.payload.error404 || false
+        error404: action.payload.error404 || false,
       }))
     case getType(deleteTeam):
       return {
         ...state,
         byId: omit(state.byId, action.payload),
-        allIds: state.allIds.filter(id => id !== action.payload)
+        allIds: state.allIds.filter(id => id !== action.payload),
       }
     case getType(fetchTeamMembers.request):
       return mapById(state, action.payload, team => ({
         ...team,
-        loadingMembers: true
+        loadingMembers: true,
       }))
     case getType(fetchTeamMembers.success):
       return mapById(state, action.payload.id, team => ({
@@ -202,37 +202,37 @@ export const teams = (
         members: action.payload.members.reduce(
           (a, b) => ({
             ...a,
-            [b.id]: b
+            [b.id]: b,
           }),
-          {}
+          {},
         ),
-        loadingMembers: false
+        loadingMembers: false,
       }))
     case getType(fetchTeamMembers.failure):
       return mapById(state, action.payload, team => ({
         ...team,
-        loadingMembers: false
+        loadingMembers: false,
       }))
     case getType(fetchTeamRecipes.request):
       return mapById(state, action.payload, team => ({
         ...team,
-        loadingRecipes: true
+        loadingRecipes: true,
       }))
     case getType(fetchTeamRecipes.success):
       return mapById(state, action.payload.id, team => ({
         ...team,
         recipes: action.payload.recipes.map(r => r.id),
-        loadingRecipes: false
+        loadingRecipes: false,
       }))
     case getType(fetchTeamRecipes.failure):
       return mapById(state, action.payload, team => ({
         ...team,
-        loadingRecipes: false
+        loadingRecipes: false,
       }))
     case getType(setUpdatingUserTeamLevel):
       return mapById(state, action.payload.id, team => ({
         ...team,
-        updating: action.payload.updating
+        updating: action.payload.updating,
       }))
     case getType(setDeletingMembership):
       return mapById(state, action.payload.teamID, team => {
@@ -248,9 +248,9 @@ export const teams = (
             ...team.members,
             [action.payload.membershipID]: {
               ...member,
-              deleting: action.payload.val
-            }
-          }
+              deleting: action.payload.val,
+            },
+          },
         }
       })
     case getType(setUserTeamLevel):
@@ -266,21 +266,21 @@ export const teams = (
             ...team.members,
             [action.payload.membershipID]: {
               ...member,
-              level: action.payload.level
-            }
-          }
+              level: action.payload.level,
+            },
+          },
         }
       })
     case getType(setSendingTeamInvites):
       return mapById(state, action.payload.teamID, team => ({
         ...team,
-        sendingTeamInvites: action.payload.val
+        sendingTeamInvites: action.payload.val,
       }))
     case getType(deleteMembership):
       return mapById(state, action.payload.teamID, team => ({
         ...team,
         // TODO: refactor membership into it's own reducer
-        members: omit(team.members, action.payload.membershipID)
+        members: omit(team.members, action.payload.membershipID),
       }))
     case getType(fetchTeams.success):
       return {
@@ -291,17 +291,17 @@ export const teams = (
             ...a,
             [b.id]: {
               ...state.byId[b.id],
-              ...b
-            }
+              ...b,
+            },
           }),
-          state.byId
+          state.byId,
         ),
-        allIds: uniq(state.allIds.concat(action.payload.map(x => x.id)))
+        allIds: uniq(state.allIds.concat(action.payload.map(x => x.id))),
       }
     case getType(fetchTeams.request):
       return {
         ...state,
-        status: state.status === "initial" ? "loading" : "refetching"
+        status: state.status === "initial" ? "loading" : "refetching",
       }
     case getType(fetchTeams.failure):
       return { ...state, status: "failure" }
@@ -310,19 +310,19 @@ export const teams = (
         ...state,
         byId: {
           ...state.byId,
-          [action.payload.id]: action.payload.team
+          [action.payload.id]: action.payload.team,
         },
-        allIds: uniq(state.allIds.concat(action.payload.id))
+        allIds: uniq(state.allIds.concat(action.payload.id)),
       }
     case getType(setCreatingTeam):
       return {
         ...state,
-        creating: action.payload
+        creating: action.payload,
       }
     case getType(setCopyingTeam):
       return {
         ...state,
-        copying: action.payload
+        copying: action.payload,
       }
     case getType(updateTeamById):
       return mapById(state, action.payload.id, () => action.payload.teamKeys)

--- a/frontend/src/store/reducers/user.test.ts
+++ b/frontend/src/store/reducers/user.test.ts
@@ -4,7 +4,7 @@ import user, {
   fetchUser,
   logOut,
   toggleDarkMode,
-  setUserLoggedIn
+  setUserLoggedIn,
 } from "@/store/reducers/user"
 import { login } from "@/store/reducers/auth"
 
@@ -13,11 +13,11 @@ describe("fetchingUser", () => {
   it("#request: sets loading, removes failures", () => {
     const beforeState = {
       loading: false,
-      error: true
+      error: true,
     } as IUserState
     const expected = {
       loading: true,
-      error: false
+      error: false,
     } as IUserState
     expect(user(beforeState, fetchUser.request())).toEqual(expected)
   })
@@ -25,7 +25,7 @@ describe("fetchingUser", () => {
     const beforeState = {
       loading: true,
       error: false,
-      updatingEmail: false
+      updatingEmail: false,
     } as IUserState
 
     const userPayload = {
@@ -34,7 +34,7 @@ describe("fetchingUser", () => {
       id: 123,
       has_usable_password: true,
       dark_mode_enabled: true,
-      selected_team: 456
+      selected_team: 456,
     } as IUser
 
     const expected = {
@@ -47,7 +47,7 @@ describe("fetchingUser", () => {
       error: false,
       darkMode: true,
       hasUsablePassword: true,
-      teamID: userPayload.selected_team
+      teamID: userPayload.selected_team,
     }
     expect(user(beforeState, fetchUser.success(userPayload))).toEqual(expected)
     expect(user(beforeState, login.success(userPayload))).toEqual(expected)
@@ -55,11 +55,11 @@ describe("fetchingUser", () => {
   it("#failure: sets loading, sets error", () => {
     const beforeState = {
       loading: true,
-      error: false
+      error: false,
     } as IUserState
     const expected = {
       loading: false,
-      error: true
+      error: true,
     } as IUserState
     expect(user(beforeState, fetchUser.failure())).toEqual(expected)
   })
@@ -68,41 +68,41 @@ describe("fetchingUser", () => {
 describe("User", () => {
   it("sets user to logging out", () => {
     const beforeState = {
-      loggingOut: false
+      loggingOut: false,
     }
 
     const afterState = {
-      loggingOut: true
+      loggingOut: true,
     }
 
     expect(user(beforeState as IUserState, logOut.request())).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("toggles darkmode", () => {
     const beforeState = {
-      darkMode: false
+      darkMode: false,
     }
 
     const afterState = {
-      darkMode: true
+      darkMode: true,
     }
 
     expect(user(beforeState as IUserState, toggleDarkMode())).toEqual(
-      afterState
+      afterState,
     )
   })
 
   it("should set user logged in", () => {
     const beforeState = {
-      loggedIn: true
+      loggedIn: true,
     }
     const afterState = {
-      loggedIn: false
+      loggedIn: false,
     }
     expect(user(beforeState as IUserState, setUserLoggedIn(false))).toEqual(
-      afterState
+      afterState,
     )
   })
 })

--- a/frontend/src/store/reducers/user.ts
+++ b/frontend/src/store/reducers/user.ts
@@ -5,7 +5,7 @@ import {
   createAsyncAction,
   createStandardAction,
   ActionType,
-  getType
+  getType,
 } from "typesafe-actions"
 import { IRecipe } from "@/store/reducers/recipes"
 import {
@@ -15,21 +15,21 @@ import {
   HttpErrorKind,
   toLoading,
   mapSuccessLike,
-  Loading
+  Loading,
 } from "@/webdata"
 import { login, AuthActions } from "@/store/reducers/auth"
 
 export const fetchUserStats = createAsyncAction(
   "FETCH_USER_STATS_START",
   "FETCH_USER_STATS_SUCCESS",
-  "FETCH_USER_STATS_FAILURE"
+  "FETCH_USER_STATS_FAILURE",
 )<void, IUserStats, void>()
 
 // TODO(chdsbd): Replace usage with fetchUser#success. Update user reducer.
 export const logOut = createAsyncAction(
   "LOGOUT_START",
   "LOGOUT_SUCCESS",
-  "LOGOUT_FAILURE"
+  "LOGOUT_FAILURE",
 )<void, void, void>()
 
 export const updateTeamID = createStandardAction("SET_TEAM_ID")<
@@ -39,7 +39,7 @@ export const updateTeamID = createStandardAction("SET_TEAM_ID")<
 export const socialConnections = createAsyncAction(
   "REQUEST_SOCIAL_ACCOUNT_CONNECTIONS",
   "SUCCESS_SOCIAL_ACCOUNT_CONNECTIONS",
-  "FAILURE_SOCIAL_ACCOUNT_CONNECTIONS"
+  "FAILURE_SOCIAL_ACCOUNT_CONNECTIONS",
 )<void, ISocialConnection[], void>()
 
 export const setUserLoggedIn = createStandardAction("SET_USER_LOGGED_IN")<
@@ -48,31 +48,31 @@ export const setUserLoggedIn = createStandardAction("SET_USER_LOGGED_IN")<
 export const fetchUser = createAsyncAction(
   "FETCH_USER_START",
   "FETCH_USER_SUCCESS",
-  "FETCH_USER_FAILURE"
+  "FETCH_USER_FAILURE",
 )<void, IUser, void>()
 export const toggleDarkMode = createStandardAction("TOGGLE_DARK_MODE")()
 export const updateEmail = createAsyncAction(
   "UPDATE_EMAIL_START",
   "UPDATE_EMAIL_SUCCESS",
-  "UPDATE_EMAIL_FAILURE"
+  "UPDATE_EMAIL_FAILURE",
 )<void, IUser, void>()
 
 export const fetchSessions = createAsyncAction(
   "FETCH_SESSIONS_REQUEST",
   "FETCH_SESSIONS_SUCCESS",
-  "FETCH_SESSIONS_FAILURE"
+  "FETCH_SESSIONS_FAILURE",
 )<void, ReadonlyArray<ISession>, void>()
 
 export const logoutSessionById = createAsyncAction(
   "LOGOUT_SESSION_BY_ID_REQUEST",
   "LOGOUT_SESSION_BY_ID_SUCCESS",
-  "LOGOUT_SESSION_BY_ID_FAILURE"
+  "LOGOUT_SESSION_BY_ID_FAILURE",
 )<ISession["id"], ISession["id"], ISession["id"]>()
 
 export const logoutAllSessions = createAsyncAction(
   "LOGOUT_ALL_SESSIONS_REQUEST",
   "LOGOUT_ALL_SESSIONS_SUCCESS",
-  "LOGOUT_ALL_SESSIONS_FAILURE"
+  "LOGOUT_ALL_SESSIONS_FAILURE",
 )<void, void, void>()
 
 export type UserActions =
@@ -141,7 +141,7 @@ export interface ISession {
 export const enum LoggingOutStatus {
   Initial,
   Loading,
-  Failure
+  Failure,
 }
 
 export interface IUserState {
@@ -178,12 +178,12 @@ const initialState: IUserState = {
   teamID: null,
   updatingEmail: false,
   sessions: undefined,
-  loggingOutAllSessionsStatus: LoggingOutStatus.Initial
+  loggingOutAllSessionsStatus: LoggingOutStatus.Initial,
 }
 
 export const user = (
   state: IUserState = initialState,
-  action: UserActions | AuthActions
+  action: UserActions | AuthActions,
 ): IUserState => {
   switch (action.type) {
     case getType(fetchUserStats.success):
@@ -191,7 +191,7 @@ export const user = (
     case getType(fetchUserStats.request): {
       return {
         ...state,
-        stats: toLoading(state.stats)
+        stats: toLoading(state.stats),
       }
     }
     case getType(fetchUserStats.failure):
@@ -207,7 +207,7 @@ export const user = (
     case getType(socialConnections.request):
       return {
         ...state,
-        socialAccountConnections: Loading()
+        socialAccountConnections: Loading(),
       }
     case getType(socialConnections.success): {
       const socialAccountConnections: ISocialAccountsState = action.payload.reduce<
@@ -217,32 +217,32 @@ export const user = (
           acc[cur.provider] = cur.id
           return acc
         },
-        { github: null, gitlab: null, google: null }
+        { github: null, gitlab: null, google: null },
       )
       return {
         ...state,
-        socialAccountConnections: Success(socialAccountConnections)
+        socialAccountConnections: Success(socialAccountConnections),
       }
     }
     case getType(socialConnections.failure):
       return {
         ...state,
-        socialAccountConnections: Failure(undefined)
+        socialAccountConnections: Failure(undefined),
       }
     case getType(fetchSessions.request):
       return {
         ...state,
-        sessions: toLoading(state.sessions)
+        sessions: toLoading(state.sessions),
       }
     case getType(fetchSessions.success):
       return {
         ...state,
-        sessions: Success(action.payload)
+        sessions: Success(action.payload),
       }
     case getType(fetchSessions.failure):
       return {
         ...state,
-        sessions: Failure(HttpErrorKind.other)
+        sessions: Failure(HttpErrorKind.other),
       }
     case getType(logoutSessionById.request):
       return {
@@ -253,15 +253,15 @@ export const user = (
               return { ...s, loggingOut: LoggingOutStatus.Loading }
             }
             return s
-          })
-        )
+          }),
+        ),
       }
     case getType(logoutSessionById.success):
       return {
         ...state,
         sessions: mapSuccessLike(state.sessions, data =>
-          data.filter(s => s.id !== action.payload)
-        )
+          data.filter(s => s.id !== action.payload),
+        ),
       }
     case getType(logoutSessionById.failure):
       return {
@@ -272,27 +272,27 @@ export const user = (
               return { ...s, loggingOut: LoggingOutStatus.Failure }
             }
             return s
-          })
-        )
+          }),
+        ),
       }
 
     case getType(logoutAllSessions.request):
       return {
         ...state,
-        loggingOutAllSessionsStatus: LoggingOutStatus.Loading
+        loggingOutAllSessionsStatus: LoggingOutStatus.Loading,
       }
     case getType(logoutAllSessions.success):
       return {
         ...state,
         sessions: mapSuccessLike(state.sessions, data =>
-          data.filter(s => s.current)
+          data.filter(s => s.current),
         ),
-        loggingOutAllSessionsStatus: LoggingOutStatus.Initial
+        loggingOutAllSessionsStatus: LoggingOutStatus.Initial,
       }
     case getType(logoutAllSessions.failure):
       return {
         ...state,
-        loggingOutAllSessionsStatus: LoggingOutStatus.Failure
+        loggingOutAllSessionsStatus: LoggingOutStatus.Failure,
       }
     case getType(updateTeamID):
       return { ...state, teamID: action.payload }
@@ -316,10 +316,10 @@ export const user = (
       raven.setUserContext({
         ...{
           email: state.email,
-          id: state.id
+          id: state.id,
         },
         email: action.payload.email,
-        id: action.payload.id
+        id: action.payload.id,
       })
       return {
         ...state,
@@ -331,7 +331,7 @@ export const user = (
         id: action.payload.id,
         darkMode: action.payload.dark_mode_enabled,
         teamID: action.payload.selected_team,
-        updatingEmail: false
+        updatingEmail: false,
       }
     default:
       return state

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -3,7 +3,7 @@ import {
   applyMiddleware,
   compose as reduxCompose,
   Store as ReduxStore,
-  StoreEnhancer
+  StoreEnhancer,
 } from "redux"
 
 import {
@@ -12,7 +12,7 @@ import {
   Loop,
   StoreCreator,
   install,
-  ReducerMapObject
+  ReducerMapObject,
 } from "redux-loop"
 
 import pickBy from "lodash/pickBy"
@@ -23,33 +23,33 @@ import {
   RouterState,
   RouterAction,
   connectRouter,
-  routerMiddleware
+  routerMiddleware,
 } from "connected-react-router"
 
 import recipes, { IRecipesState, RecipeActions } from "@/store/reducers/recipes"
 import user, { IUserState, UserActions } from "@/store/reducers/user"
 import notification, {
   INotificationState,
-  NotificationsActions
+  NotificationsActions,
 } from "@/store/reducers/notification"
 import passwordChange, {
   IPasswordChangeState,
-  PasswordChangeActions
+  PasswordChangeActions,
 } from "@/store/reducers/passwordChange"
 import shoppinglist, {
   IShoppingListState,
-  ShoppingListActions
+  ShoppingListActions,
 } from "@/store/reducers/shoppinglist"
 import addrecipe, {
   IAddRecipeState,
-  AddRecipeActions
+  AddRecipeActions,
 } from "@/store/reducers/addrecipe"
 import auth, { IAuthState, AuthActions, login } from "@/store/reducers/auth"
 import teams, { ITeamsState, TeamsActions } from "@/store/reducers/teams"
 import invites, { InviteActions, IInvitesState } from "@/store/reducers/invites"
 import calendar, {
   ICalendarState,
-  CalendarActions
+  CalendarActions,
 } from "@/store/reducers/calendar"
 import { loadState, saveState } from "@/store/localStorage"
 import { getType } from "typesafe-actions"
@@ -115,14 +115,14 @@ const recipeApp: LoopReducer<IState, Action> = combineReducers(
     addrecipe,
     auth,
     teams,
-    calendar
-  })
+    calendar,
+  }),
 )
 
 // reset redux to default state on logout
 export function rootReducer(
   state: IState | undefined,
-  action: Action
+  action: Action,
 ): IState | Loop<IState, Action> {
   if (state == null) {
     return recipeApp(undefined, action)
@@ -134,7 +134,7 @@ export function rootReducer(
       // so we can redirect users to where they were attempting to
       // visit before being asked for authentication
       auth: state.auth,
-      router: state.router
+      router: state.router,
     }
   }
   return recipeApp(state, action)
@@ -162,14 +162,14 @@ const defaultData = (): IState => {
     ...saved,
     user: {
       ...empty.user,
-      ...saved.user
+      ...saved.user,
     },
     // Note(sbdchd): we must spread the initial state for all of these as `undefined` is not
     // passed into the reducers, resulting in a bad state.
     auth: {
       ...empty.auth,
-      ...saved.auth
-    }
+      ...saved.auth,
+    },
   }
 }
 
@@ -180,7 +180,7 @@ if (DEBUG) {
 
 export const enhancer: StoreEnhancer<IState, Action> = compose(
   install(),
-  applyMiddleware(...middleware)
+  applyMiddleware(...middleware),
 )
 
 // We need an empty store for the unit tests & hydrating from localstorage
@@ -205,15 +205,15 @@ store.subscribe(
         // this is acceptable for us for the added performance
         loggedIn: store.getState().user.loggedIn,
         darkMode: store.getState().user.darkMode,
-        teamID: store.getState().user.teamID
+        teamID: store.getState().user.teamID,
       },
       addrecipe: store.getState().addrecipe,
       auth: {
-        fromUrl: store.getState().auth.fromUrl
-      }
+        fromUrl: store.getState().auth.fromUrl,
+      },
       // tslint:disable-next-line:no-any
     } as any) as IState)
-  }, second)
+  }, second),
 )
 
 export default store

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -21,7 +21,7 @@ import {
   ISession,
   logoutSessionById,
   logoutAllSessions,
-  socialConnections
+  socialConnections,
 } from "@/store/reducers/user"
 import {
   ICalRecipe,
@@ -30,18 +30,18 @@ import {
   deleteCalendarRecipe,
   moveCalendarRecipe,
   fetchCalendarRecipes,
-  getExistingRecipe
+  getExistingRecipe,
 } from "@/store/reducers/calendar"
 import {
   IInvite,
   fetchInvites,
   declineInvite,
-  acceptInvite
+  acceptInvite,
 } from "@/store/reducers/invites"
 import {
   INotificationState,
   setNotification,
-  clearNotification
+  clearNotification,
 } from "@/store/reducers/notification"
 import {
   ITeam,
@@ -59,7 +59,7 @@ import {
   fetchTeam,
   setTeam,
   fetchTeamMembers,
-  fetchTeamRecipes
+  fetchTeamRecipes,
 } from "@/store/reducers/teams"
 import {
   IRecipe,
@@ -73,7 +73,7 @@ import {
   fetchRecipeList,
   createRecipe,
   IStep,
-  fetchRecentRecipes
+  fetchRecentRecipes,
 } from "@/store/reducers/recipes"
 import * as api from "@/api"
 import { clearAddRecipeForm } from "@/store/reducers/addrecipe"
@@ -88,7 +88,7 @@ import {
   setLoadingSignup,
   setLoadingReset,
   setLoadingResetConfirmation,
-  login
+  login,
 } from "@/store/reducers/auth"
 import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
@@ -99,7 +99,7 @@ import {
   startOfWeek,
   subWeeks,
   addWeeks,
-  endOfWeek
+  endOfWeek,
 } from "date-fns"
 import { isOk, isErr, Ok, Err, Result } from "@/result"
 import { heldKeys } from "@/components/CurrentKeys"
@@ -128,15 +128,15 @@ export const showNotificationWithTimeoutAsync = (dispatch: Dispatch) => ({
   level = "info",
   closeable = true,
   delay = 2000,
-  sticky = false
+  sticky = false,
 }: INotificationWithTimeout) => {
   clearTimeout(notificationTimeout)
   dispatch(
     setNotification({
       message,
       level,
-      closeable
-    })
+      closeable,
+    }),
   )
 
   if (!sticky) {
@@ -165,7 +165,7 @@ const emailExists = (err: AxiosError) =>
 // tslint:enable:no-unsafe-any
 
 export const updatingEmailAsync = (dispatch: Dispatch) => async (
-  email: IUser["email"]
+  email: IUser["email"],
 ) => {
   dispatch(updateEmail.request())
   const res = await api.updateUser({ email })
@@ -176,7 +176,7 @@ export const updatingEmailAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: "updated email",
       level: "success",
-      delay: 3 * second
+      delay: 3 * second,
     })
   } else {
     dispatch(updateEmail.failure())
@@ -184,14 +184,14 @@ export const updatingEmailAsync = (dispatch: Dispatch) => async (
     dispatch(
       setNotification({
         message: `problem updating email ${messageExtra}`,
-        level: "danger"
-      })
+        level: "danger",
+      }),
     )
   }
 }
 
 export const updatingTeamIDAsync = (dispatch: Dispatch) => async (
-  id: IUserState["teamID"]
+  id: IUserState["teamID"],
 ) => {
   // store old id so we can undo
   const oldID = store.getState().user.teamID
@@ -225,7 +225,7 @@ export const fetchingSessionsAsync = (dispatch: Dispatch) => async () => {
 }
 
 export const loggingOutSessionByIdAsync = (dispatch: Dispatch) => async (
-  id: ISession["id"]
+  id: ISession["id"],
 ) => {
   dispatch(logoutSessionById.request(id))
   const res = await api.deleteSessionById(id)
@@ -257,7 +257,7 @@ export const fetchSocialConnectionsAsync = (dispatch: Dispatch) => async () => {
 }
 
 export const disconnectSocialAccountAsync = (dispatch: Dispatch) => async (
-  provider: SocialProvider
+  provider: SocialProvider,
 ) => {
   const res = await api.disconnectSocialAccount(provider)
   if (isOk(res)) {
@@ -285,7 +285,7 @@ interface IUpdatePassword {
 export const updatingPasswordAsync = (dispatch: Dispatch) => async ({
   password1,
   password2,
-  oldPassword
+  oldPassword,
 }: IUpdatePassword) => {
   dispatch(passwordUpdate.request())
   const res = await api.changePassword(password1, password2, oldPassword)
@@ -294,7 +294,7 @@ export const updatingPasswordAsync = (dispatch: Dispatch) => async ({
     dispatch(push("/"))
     showNotificationWithTimeoutAsync(dispatch)({
       message: "Successfully updated password",
-      level: "success"
+      level: "success",
     })
   } else {
     const err = res.error
@@ -306,8 +306,8 @@ export const updatingPasswordAsync = (dispatch: Dispatch) => async ({
         passwordUpdate.failure({
           newPasswordAgain: data["new_password2"],
           newPassword: data["new_password1"],
-          oldPassword: data["old_password"]
-        })
+          oldPassword: data["old_password"],
+        }),
       )
       return
       // tslint:ebale:no-unsafe-any
@@ -317,7 +317,7 @@ export const updatingPasswordAsync = (dispatch: Dispatch) => async ({
 }
 
 export const fetchingShoppingListAsync = (dispatch: Dispatch) => async (
-  teamID: TeamID
+  teamID: TeamID,
 ) => {
   const startDay = store.getState().shoppinglist.startDay
   const endDay = store.getState().shoppinglist.endDay
@@ -331,7 +331,7 @@ export const fetchingShoppingListAsync = (dispatch: Dispatch) => async (
 }
 
 export const postNewRecipeAsync = (dispatch: Dispatch) => async (
-  recipe: IRecipeBasic
+  recipe: IRecipeBasic,
 ) => {
   dispatch(createRecipe.request())
   const res = await api.createRecipe(recipe)
@@ -346,7 +346,7 @@ export const postNewRecipeAsync = (dispatch: Dispatch) => async (
       (err.response && {
         errorWithName: err.response.data.name != null,
         errorWithIngredients: err.response.data.ingredients != null,
-        errorWithSteps: err.response.data.steps != null
+        errorWithSteps: err.response.data.steps != null,
       }) ||
       {}
     // tslint:enable:no-unsafe-any
@@ -354,7 +354,7 @@ export const postNewRecipeAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: "problem creating new recipe",
       level: "danger",
-      delay: 5 * second
+      delay: 5 * second,
     })
   }
 }
@@ -371,7 +371,7 @@ export const fetchingRecentRecipesAsync = (dispatch: Dispatch) => async () => {
 }
 
 export const fetchingRecipeListAsync = (dispatch: Dispatch) => async (
-  teamID: TeamID
+  teamID: TeamID,
 ) => {
   dispatch(fetchRecipeList.request({ teamID }))
   const res = await api.getRecipeList(teamID)
@@ -389,7 +389,7 @@ interface IDeletingIngredientAsyncPayload {
 
 export async function deletingIngredientAsync(
   { recipeID, ingredientID }: IDeletingIngredientAsyncPayload,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) {
   const res = await api.deleteIngredient(recipeID, ingredientID)
   if (isOk(res)) {
@@ -408,12 +408,12 @@ interface IUpdatingStepPayload {
 
 export const updatingStepAsync = async (
   { recipeID, stepID, ...data }: IUpdatingStepPayload,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) => {
   const res = await api.updateStep(
     recipeID,
     stepID,
-    pickBy(data, x => x != null)
+    pickBy(data, x => x != null),
   )
   if (isOk(res)) {
     dispatch(
@@ -421,8 +421,8 @@ export const updatingStepAsync = async (
         recipeID,
         stepID,
         text: res.data.text,
-        position: res.data.position
-      })
+        position: res.data.position,
+      }),
     )
   } else {
     dispatch(updateStep.failure({ recipeID, stepID }))
@@ -435,7 +435,7 @@ interface IDeletingStepPayload {
 }
 export const deletingStepAsync = async (
   { recipeID, stepID }: IDeletingStepPayload,
-  dispatch: Dispatch
+  dispatch: Dispatch,
 ) => {
   const res = await api.deleteStep(recipeID, stepID)
   if (isOk(res)) {
@@ -448,7 +448,7 @@ export const deletingStepAsync = async (
 export const logUserInAsync = (dispatch: Dispatch) => async (
   email: string,
   password: string,
-  redirectUrl: string = ""
+  redirectUrl: string = "",
 ) => {
   dispatch(clearNotification())
   dispatch(login.request())
@@ -467,8 +467,8 @@ export const logUserInAsync = (dispatch: Dispatch) => async (
         login.failure({
           email: data["email"],
           password1: data["password1"],
-          nonFieldErrors: data["non_field_errors"]
-        })
+          nonFieldErrors: data["non_field_errors"],
+        }),
       )
       // tslint:enable:no-unsafe-any
       return
@@ -480,7 +480,7 @@ export const logUserInAsync = (dispatch: Dispatch) => async (
 export const socialLoginAsync = (dispatch: Dispatch) => async (
   service: SocialProvider,
   token: string,
-  redirectUrl: string = ""
+  redirectUrl: string = "",
 ) => {
   const res = await api.loginUserWithSocial(service, token)
 
@@ -496,8 +496,8 @@ export const socialLoginAsync = (dispatch: Dispatch) => async (
       dispatch(
         setErrorSocialLogin({
           emailSocial: data["email"],
-          nonFieldErrorsSocial: data["non_field_errors"]
-        })
+          nonFieldErrorsSocial: data["non_field_errors"],
+        }),
       )
       // tslint:enable:no-unsafe-any
     }
@@ -507,7 +507,7 @@ export const socialLoginAsync = (dispatch: Dispatch) => async (
 
 export const socialConnectAsync = (dispatch: Dispatch) => async (
   service: SocialProvider,
-  code: unknown
+  code: unknown,
 ) => {
   await api.connectSocial(service, code)
   dispatch(replace("/settings"))
@@ -516,7 +516,7 @@ export const socialConnectAsync = (dispatch: Dispatch) => async (
 export const signupAsync = (dispatch: Dispatch) => async (
   email: string,
   password1: string,
-  password2: string
+  password2: string,
 ) => {
   // TODO(sbdchd): refactor to use createActionAsync
   dispatch(setLoadingSignup(true))
@@ -540,8 +540,8 @@ export const signupAsync = (dispatch: Dispatch) => async (
           email: data["email"],
           password1: data["password1"],
           password2: data["password2"],
-          nonFieldErrors: data["non_field_errors"]
-        })
+          nonFieldErrors: data["non_field_errors"],
+        }),
       )
       // tslint:enable:no-unsafe-any
     }
@@ -560,7 +560,7 @@ export const resetAsync = (dispatch: Dispatch) => async (email: string) => {
     const message = res && res.data && res.data.detail
     showNotificationWithTimeoutAsync(dispatch)({
       message,
-      level: "success"
+      level: "success",
     })
   } else {
     const err = res.error
@@ -568,7 +568,7 @@ export const resetAsync = (dispatch: Dispatch) => async (email: string) => {
     showNotificationWithTimeoutAsync(dispatch)({
       message: "uh oh! problem resetting password",
       level: "danger",
-      sticky: true
+      sticky: true,
     })
     if (isbadRequest(err)) {
       // tslint:disable:no-unsafe-any
@@ -576,15 +576,15 @@ export const resetAsync = (dispatch: Dispatch) => async (email: string) => {
       dispatch(
         setErrorReset({
           email: data["email"],
-          nonFieldErrors: data["non_field_errors"]
-        })
+          nonFieldErrors: data["non_field_errors"],
+        }),
       )
       // tslint:enable:no-unsafe-any
     }
     showNotificationWithTimeoutAsync(dispatch)({
       message: "problem resetting password",
       level: "danger",
-      sticky: true
+      sticky: true,
     })
   }
 }
@@ -593,7 +593,7 @@ export const resetConfirmationAsync = (dispatch: Dispatch) => async (
   uid: string,
   token: string,
   newPassword1: string,
-  newPassword2: string
+  newPassword2: string,
 ) => {
   // TODO(sbdchd): refactor to use createActionAsync
   dispatch(setLoadingResetConfirmation(true))
@@ -604,14 +604,14 @@ export const resetConfirmationAsync = (dispatch: Dispatch) => async (
     uid,
     token,
     newPassword1,
-    newPassword2
+    newPassword2,
   )
   if (isOk(res)) {
     dispatch(setLoadingResetConfirmation(false))
     const message = res && res.data && res.data.detail
     showNotificationWithTimeoutAsync(dispatch)({
       message,
-      level: "success"
+      level: "success",
     })
     dispatch(push("/login"))
   } else {
@@ -620,7 +620,7 @@ export const resetConfirmationAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: "uh oh! problem resetting password",
       level: "danger",
-      sticky: true
+      sticky: true,
     })
     if (isbadRequest(err)) {
       // tslint:disable:no-unsafe-any
@@ -639,8 +639,8 @@ export const resetConfirmationAsync = (dispatch: Dispatch) => async (
         setErrorResetConfirmation({
           newPassword1: data["new_password1"],
           newPassword2: data["new_password2"],
-          nonFieldErrors
-        })
+          nonFieldErrors,
+        }),
       )
       // tslint:enable:no-unsafe-any
     }
@@ -648,7 +648,7 @@ export const resetConfirmationAsync = (dispatch: Dispatch) => async (
 }
 
 export const fetchingTeamAsync = (dispatch: Dispatch) => async (
-  id: ITeam["id"]
+  id: ITeam["id"],
 ) => {
   dispatch(fetchTeam.request(id))
   const res = await api.getTeam(id)
@@ -665,7 +665,7 @@ export const fetchingTeamAsync = (dispatch: Dispatch) => async (
 }
 
 export const fetchingTeamMembersAsync = (dispatch: Dispatch) => async (
-  id: ITeam["id"]
+  id: ITeam["id"],
 ) => {
   dispatch(fetchTeamMembers.request(id))
   const res = await api.getTeamMembers(id)
@@ -677,7 +677,7 @@ export const fetchingTeamMembersAsync = (dispatch: Dispatch) => async (
 }
 
 export const fetchingTeamRecipesAsync = (dispatch: Dispatch) => async (
-  id: ITeam["id"]
+  id: ITeam["id"],
 ) => {
   dispatch(fetchTeamRecipes.request(id))
   const res = await api.getTeamRecipes(id)
@@ -700,7 +700,7 @@ const attemptedDeleteLastAdmin = (res: AxiosResponse) =>
 export const settingUserTeamLevelAsync = (dispatch: Dispatch) => async (
   teamID: ITeam["id"],
   membershipID: IMember["id"],
-  level: IMember["level"]
+  level: IMember["level"],
 ) => {
   // TODO(sbdchd): refactor to use createActionAsync
   dispatch(setUpdatingUserTeamLevel({ id: teamID, updating: true }))
@@ -716,7 +716,7 @@ export const settingUserTeamLevelAsync = (dispatch: Dispatch) => async (
       showNotificationWithTimeoutAsync(dispatch)({
         message,
         level: "danger",
-        delay: 3 * second
+        delay: 3 * second,
       })
       // tslint:enable:no-unsafe-any
     }
@@ -727,7 +727,7 @@ export const settingUserTeamLevelAsync = (dispatch: Dispatch) => async (
 export const deletingMembershipAsync = (dispatch: Dispatch) => async (
   teamID: ITeam["id"],
   id: IMember["id"],
-  leaving: boolean = false
+  leaving: boolean = false,
 ) => {
   dispatch(setDeletingMembership({ teamID, membershipID: id, val: true }))
   const res = await api.deleteTeamMember(teamID, id)
@@ -741,7 +741,7 @@ export const deletingMembershipAsync = (dispatch: Dispatch) => async (
       showNotificationWithTimeoutAsync(dispatch)({
         message,
         level: "success",
-        delay: 3 * second
+        delay: 3 * second,
       })
       dispatch(deleteTeam(teamID))
     }
@@ -752,14 +752,14 @@ export const deletingMembershipAsync = (dispatch: Dispatch) => async (
       // tslint:disable-next-line:no-unsafe-any
       message,
       level: "danger",
-      delay: 3 * second
+      delay: 3 * second,
     })
     dispatch(setDeletingMembership({ teamID, membershipID: id, val: false }))
   }
 }
 
 export const deletingTeamAsync = (dispatch: Dispatch) => async (
-  teamID: ITeam["id"]
+  teamID: ITeam["id"],
 ) => {
   const res = await api.deleteTeam(teamID)
   if (isOk(res)) {
@@ -769,7 +769,7 @@ export const deletingTeamAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: `Team deleted (${teamName})`,
       level: "success",
-      delay: 3 * second
+      delay: 3 * second,
     })
     dispatch(deleteTeam(teamID))
   } else {
@@ -793,7 +793,7 @@ export const deletingTeamAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message,
       level: "danger",
-      delay: 3 * second
+      delay: 3 * second,
     })
   }
 }
@@ -801,7 +801,7 @@ export const deletingTeamAsync = (dispatch: Dispatch) => async (
 export const sendingTeamInvitesAsync = (dispatch: Dispatch) => async (
   teamID: ITeam["id"],
   emails: string[],
-  level: IMember["level"]
+  level: IMember["level"],
 ) => {
   dispatch(setSendingTeamInvites({ teamID, val: true }))
   const res = await api.sendTeamInvites(teamID, emails, level)
@@ -809,7 +809,7 @@ export const sendingTeamInvitesAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: "invites sent!",
       level: "success",
-      delay: 3 * second
+      delay: 3 * second,
     })
     dispatch(setSendingTeamInvites({ teamID, val: false }))
     return Ok(undefined)
@@ -817,7 +817,7 @@ export const sendingTeamInvitesAsync = (dispatch: Dispatch) => async (
   showNotificationWithTimeoutAsync(dispatch)({
     message: "error sending team invite",
     level: "danger",
-    delay: 3 * second
+    delay: 3 * second,
   })
   dispatch(setSendingTeamInvites({ teamID, val: false }))
   return Err(undefined)
@@ -836,7 +836,7 @@ export const fetchingTeamsAsync = (dispatch: Dispatch) => async () => {
 export const creatingTeamAsync = (dispatch: Dispatch) => async (
   name: ITeam["name"],
   emails: string[],
-  level: IMember["level"]
+  level: IMember["level"],
 ) => {
   // TODO(sbdchd): use createAsyncActions
   dispatch(setCreatingTeam(true))
@@ -852,14 +852,14 @@ export const creatingTeamAsync = (dispatch: Dispatch) => async (
 
 export const updatingTeamAsync = (dispatch: Dispatch) => async (
   teamId: ITeam["id"],
-  teamKVs: unknown
+  teamKVs: unknown,
 ) => {
   const res = await api.updateTeam(teamId, teamKVs)
   if (isOk(res)) {
     showNotificationWithTimeoutAsync(dispatch)({
       message: "Team updated",
       level: "success",
-      delay: 3 * second
+      delay: 3 * second,
     })
     dispatch(updateTeamById({ id: res.data.id, teamKeys: res.data }))
   } else {
@@ -872,7 +872,7 @@ export const updatingTeamAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message,
       level: "danger",
-      delay: 3 * second
+      delay: 3 * second,
     })
   }
 }
@@ -880,7 +880,7 @@ export const updatingTeamAsync = (dispatch: Dispatch) => async (
 export const moveRecipeToAsync = (dispatch: Dispatch) => async (
   recipeId: IRecipe["id"],
   ownerId: IUser["id"],
-  type: IRecipe["owner"]["type"]
+  type: IRecipe["owner"]["type"],
 ) => {
   const res = await api.moveRecipe(recipeId, ownerId, type)
   if (isOk(res)) {
@@ -893,7 +893,7 @@ export const moveRecipeToAsync = (dispatch: Dispatch) => async (
 export const copyRecipeToAsync = (dispatch: Dispatch) => async (
   recipeId: IRecipe["id"],
   ownerId: IUser["id"],
-  type: IRecipe["owner"]["type"]
+  type: IRecipe["owner"]["type"],
 ) => {
   // TODO(sbdchd): refactor to use createActionAsync
   dispatch(setCopyingTeam(true))
@@ -908,7 +908,7 @@ export const copyRecipeToAsync = (dispatch: Dispatch) => async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: `Problem copying recipe: ${res.error}`,
       level: "danger",
-      sticky: true
+      sticky: true,
     })
   }
 }
@@ -924,7 +924,7 @@ export const fetchingInvitesAsync = (dispatch: Dispatch) => async () => {
 }
 
 export const acceptingInviteAsync = (dispatch: Dispatch) => async (
-  id: IInvite["id"]
+  id: IInvite["id"],
 ) => {
   dispatch(acceptInvite.request(id))
   const res = await api.acceptInvite(id)
@@ -935,7 +935,7 @@ export const acceptingInviteAsync = (dispatch: Dispatch) => async (
   }
 }
 export const decliningInviteAsync = (dispatch: Dispatch) => async (
-  id: IInvite["id"]
+  id: IInvite["id"],
 ) => {
   dispatch(declineInvite.request(id))
   const res = await api.declineInvite(id)
@@ -962,13 +962,13 @@ export const deleteUserAccountAsync = (dispatch: Dispatch) => async () => {
     ) {
       showNotificationWithTimeoutAsync(dispatch)({
         message: error.response.data.detail,
-        level: "danger"
+        level: "danger",
       })
       // tslint:enable:no-unsafe-any
     } else {
       showNotificationWithTimeoutAsync(dispatch)({
         message: "failed to delete account",
-        level: "danger"
+        level: "danger",
       })
     }
   }
@@ -980,20 +980,20 @@ export const reportBadMergeAsync = (dispatch: Dispatch) => async () => {
     showNotificationWithTimeoutAsync(dispatch)({
       message: "reported bad merge",
       level: "success",
-      delay: 3 * second
+      delay: 3 * second,
     })
   } else {
     showNotificationWithTimeoutAsync(dispatch)({
       message: "error reporting bad merge",
       level: "danger",
-      delay: 3 * second
+      delay: 3 * second,
     })
   }
 }
 
 export const fetchCalendarAsync = (dispatch: Dispatch) => async (
   teamID: TeamID,
-  currentDayTs: number
+  currentDayTs: number,
 ) => {
   dispatch(fetchCalendarRecipes.request())
   // we fetch current month plus and minus 1 week
@@ -1006,8 +1006,8 @@ export const fetchCalendarAsync = (dispatch: Dispatch) => async (
         scheduledRecipes: res.right.scheduledRecipes,
         start,
         end,
-        settings: res.right.settings
-      })
+        settings: res.right.settings,
+      }),
     )
   } else {
     dispatch(fetchCalendarRecipes.failure())
@@ -1018,19 +1018,19 @@ function toCalRecipe(
   recipe: IRecipe,
   tempId: ICalRecipe["id"],
   on: ICalRecipe["on"],
-  count: ICalRecipe["count"]
+  count: ICalRecipe["count"],
 ): ICalRecipe {
   return {
     id: tempId,
     created: String(new Date()),
     recipe: {
       id: recipe.id,
-      name: recipe.name
+      name: recipe.name,
     },
     on: toISODateString(on),
     count,
     user: recipe.owner.type === "user" ? recipe.owner.id : null,
-    team: recipe.owner.type === "team" ? recipe.owner.id : null
+    team: recipe.owner.type === "team" ? recipe.owner.id : null,
   }
 }
 
@@ -1045,7 +1045,13 @@ export interface IAddingScheduledRecipeProps {
 export const addingScheduledRecipeAsync = async (
   dispatch: Dispatch,
   getState: () => IState,
-  { recipeID, teamID, on, count, showNotification }: IAddingScheduledRecipeProps
+  {
+    recipeID,
+    teamID,
+    on,
+    count,
+    showNotification,
+  }: IAddingScheduledRecipeProps,
 ) => {
   // TODO(sbdchd): we should split this into one function for creating a new
   // scheduled recipe and one function for moving a scheduled recipe.
@@ -1063,8 +1069,8 @@ export const addingScheduledRecipeAsync = async (
 
   dispatch(
     setCalendarRecipe(
-      toCalRecipe(recipe.data, tempId, toISODateString(on), count)
-    )
+      toCalRecipe(recipe.data, tempId, toISODateString(on), count),
+    ),
   )
   const res = await api.scheduleRecipe(recipeID, teamID, on, count)
 
@@ -1078,7 +1084,7 @@ export const addingScheduledRecipeAsync = async (
       showNotificationWithTimeoutAsync(dispatch)({
         message,
         level: "success",
-        delay: 3 * second
+        delay: 3 * second,
       })
     }
   } else {
@@ -1086,14 +1092,14 @@ export const addingScheduledRecipeAsync = async (
     showNotificationWithTimeoutAsync(dispatch)({
       message: "error scheduling recipe",
       level: "danger",
-      delay: 3 * second
+      delay: 3 * second,
     })
     dispatch(setSchedulingRecipe({ recipeID, scheduling: false }))
   }
 }
 export const deletingScheduledRecipeAsync = (dispatch: Dispatch) => async (
   id: ICalRecipe["id"],
-  teamID: TeamID
+  teamID: TeamID,
 ) => {
   // HACK(sbdchd): we should have these in byId object / Map
   // TODO(sbdchd): we can just have a marker for deleted recipes and just remove
@@ -1119,7 +1125,7 @@ export interface IMoveScheduledRecipeProps {
 export const moveScheduledRecipe = async (
   dispatch: Dispatch,
   getState: () => IState,
-  { id, teamID, to }: IMoveScheduledRecipeProps
+  { id, teamID, to }: IMoveScheduledRecipeProps,
 ) => {
   // HACK(sbdchd): With an endpoint we can eliminate this
   const state = getState()
@@ -1139,7 +1145,7 @@ export const moveScheduledRecipe = async (
       recipeID: from.recipe.id,
       teamID,
       on: to,
-      count: from.count
+      count: from.count,
     })
   }
   const existing = getExistingRecipe({ state: state.calendar, on: to, from })
@@ -1153,7 +1159,7 @@ export const moveScheduledRecipe = async (
     const resp = await api.deleteScheduledRecipe(from.id, teamID)
     if (isOk(resp)) {
       api.updateScheduleRecipe(existing.id, teamID, {
-        count: existing.count + from.count
+        count: existing.count + from.count,
       })
     } else {
       dispatch(moveCalendarRecipe({ id, to: toISODateString(from.on) }))
@@ -1161,7 +1167,7 @@ export const moveScheduledRecipe = async (
   }
 
   const res = await api.updateScheduleRecipe(id, teamID, {
-    on: toISODateString(to)
+    on: toISODateString(to),
   })
   if (isErr(res)) {
     // on error we want to move it back to the old position
@@ -1172,7 +1178,7 @@ export const moveScheduledRecipe = async (
 export const updatingScheduledRecipeAsync = (dispatch: Dispatch) => async (
   id: ICalRecipe["id"],
   teamID: TeamID,
-  count: ICalRecipe["count"]
+  count: ICalRecipe["count"],
 ): Promise<Result<undefined, undefined>> => {
   if (count <= 0) {
     return deletingScheduledRecipeAsync(dispatch)(id, teamID)

--- a/frontend/src/testUtils.tsx
+++ b/frontend/src/testUtils.tsx
@@ -40,7 +40,7 @@ interface ITestProviderProps {
 
 export const TestProvider: React.FC<ITestProviderProps> = ({
   children,
-  store
+  store,
 }) => {
   return (
     <ThemeProvider theme={theme}>

--- a/frontend/src/text.test.ts
+++ b/frontend/src/text.test.ts
@@ -4,7 +4,7 @@ describe("text", () => {
   test("capitalizeUnits", () => {
     const input = "tablespoon tablespoons Teaspoon Teaspoons"
     expect(capitalizeUnits(input)).toEqual(
-      "Tablespoon Tablespoons teaspoon teaspoons"
+      "Tablespoon Tablespoons teaspoon teaspoons",
     )
   })
 })

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -21,20 +21,20 @@ export const theme: ITheme = {
   color: {
     white: "#f9f9f9",
     primary,
-    primaryShadow: transparentize(0.2, primary)
+    primaryShadow: transparentize(0.2, primary),
   },
   text: {
-    small: "0.875rem"
+    small: "0.875rem",
   },
   medium: "992px",
-  small: "630px"
+  small: "630px",
 }
 
 const {
   default: styled,
   css,
   keyframes,
-  ThemeProvider
+  ThemeProvider,
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 } = styledComponents as styledComponents.ThemedStyledComponentsModule<ITheme>
 

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -9,7 +9,7 @@ interface IStr {
 
 export const recipeURL = <T extends IStr, U extends IStr>(
   id: T,
-  name?: U
+  name?: U,
 ): string => {
   const baseUrl = `/recipes/${id}`
   if (name) {

--- a/frontend/src/webdata.ts
+++ b/frontend/src/webdata.ts
@@ -2,7 +2,7 @@ const enum RDK {
   Loading = "Loading",
   Failure = "Failure",
   Success = "Success",
-  Refetching = "Refetching"
+  Refetching = "Refetching",
 }
 
 export interface ILoading {
@@ -20,7 +20,7 @@ interface IFailure<E> {
 export function Failure<T>(failure: T): IFailure<T> {
   return {
     kind: RDK.Failure,
-    failure
+    failure,
   }
 }
 
@@ -32,7 +32,7 @@ export interface ISuccess<T> {
 export function Success<T>(data: T): ISuccess<T> {
   return {
     kind: RDK.Success,
-    data
+    data,
   }
 }
 
@@ -44,7 +44,7 @@ export interface IRefetching<T> {
 export function Refetching<T>(data: T): IRefetching<T> {
   return {
     kind: RDK.Refetching,
-    data
+    data,
   }
 }
 
@@ -60,7 +60,7 @@ export type WebData<T = void, E = HttpErrorKind | undefined> = RemoteData<E, T>
 
 export const enum HttpErrorKind {
   error404,
-  other
+  other,
 }
 
 // for now we have to specify the type guard
@@ -80,7 +80,7 @@ export const isRefetching = <T, E>(x: WebData<T, E>): x is IRefetching<T> =>
   x != null && x.kind === RDK.Refetching
 
 export const isSuccessOrRefetching = <T, E>(
-  x: WebData<T, E>
+  x: WebData<T, E>,
 ): x is ISuccess<T> | IRefetching<T> => isSuccess(x) || isRefetching(x)
 
 export const isSuccessLike = isSuccessOrRefetching
@@ -88,7 +88,7 @@ export const isSuccessLike = isSuccessOrRefetching
 /** map over WebData with @param func if data is a type structurally similar to Success */
 export function mapSuccessLike<T, R, E>(
   d: WebData<T, E>,
-  func: (data: T) => R
+  func: (data: T) => R,
 ): WebData<R, E> {
   if (isSuccessOrRefetching(d)) {
     return { ...d, data: func(d.data) }
@@ -98,7 +98,7 @@ export function mapSuccessLike<T, R, E>(
 
 /** handle transitioning from Success & InitialState to Loading */
 export function toLoading<T, E>(
-  state: WebData<T, E>
+  state: WebData<T, E>,
 ): IRefetching<T> | ILoading {
   if (isSuccess(state)) {
     return Refetching(state.data)

--- a/frontend/types/react-dev-utils.d.ts
+++ b/frontend/types/react-dev-utils.d.ts
@@ -9,7 +9,7 @@ declare module "react-dev-utils/checkRequiredFiles" {
 declare module "react-dev-utils/FileSizeReporter" {
   // https://github.com/facebook/create-react-app/blob/fd382772a1ab656087c1467c5fe9ab8926af1d01/packages/react-dev-utils/FileSizeReporter.js#L133
   const measureFileSizesBeforeBuild: (
-    buildFolder: string
+    buildFolder: string,
   ) => Promise<{ root: string; sizes: unknown }>
 
   // https://github.com/facebook/create-react-app/blob/fd382772a1ab656087c1467c5fe9ab8926af1d01/packages/react-dev-utils/FileSizeReporter.js#L27
@@ -18,12 +18,12 @@ declare module "react-dev-utils/FileSizeReporter" {
     previousSizeMap: unknown,
     buildFolder?: unknown,
     maxBundleGzipSize?: unknown,
-    maxChunkGzipSize?: unknown
+    maxChunkGzipSize?: unknown,
   ) => void
 
   export = {
     measureFileSizesBeforeBuild,
-    printFileSizesAfterBuild
+    printFileSizesAfterBuild,
   }
 }
 

--- a/frontend/types/redux-loop.d.ts
+++ b/frontend/types/redux-loop.d.ts
@@ -6,14 +6,14 @@ import {
   AnyAction,
   StoreEnhancer,
   Store,
-  Dispatch
+  Dispatch,
 } from "redux"
 
 export interface StoreCreator {
   <S, A extends Action>(
     reducer: LoopReducer<S, A>,
     preloadedState: S | undefined,
-    enhancer: StoreEnhancer<S>
+    enhancer: StoreEnhancer<S>,
   ): Store<S>
 }
 
@@ -97,7 +97,7 @@ declare function install<S>(config?: LoopConfig): StoreEnhancer<S>
 
 declare function loop<S, A extends Action>(
   state: S,
-  cmd: CmdType<A>
+  cmd: CmdType<A>,
 ): Loop<S, A>
 
 type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
@@ -126,13 +126,13 @@ declare namespace Cmd {
       batch?: boolean
       sequence?: boolean
       testInvariants?: boolean
-    }
+    },
   ): ListCmd<A>
 
   export function map<A extends Action, B extends Action>(
     cmd: CmdType<B>,
     tagger: (subAction: B) => A,
-    args?: any[]
+    args?: any[],
   ): MapCmd<A>
 
   // see: https://github.com/antoinewdg/redux-loop/blob/6e4caeb81e563da84741cb3fad83976ce9c601f3/index.d.ts
@@ -142,7 +142,7 @@ declare namespace Cmd {
       failActionCreator?: ActionCreator<A>
       successActionCreator?: (arg: UnwrappedReturn<F>) => B
       forceSync?: boolean
-    }
+    },
   ): RunCmd<A>
 
   export function run<A extends Action, B extends Action, F extends Function>(
@@ -152,7 +152,7 @@ declare namespace Cmd {
       failActionCreator?: ActionCreator<A>
       successActionCreator?: (arg: UnwrappedReturn<F>) => B
       forceSync?: boolean
-    }
+    },
   ): RunCmd<A>
 }
 
@@ -161,13 +161,13 @@ export type ReducerMapObject<S, A extends Action = AnyAction> = {
 }
 
 declare function combineReducers<S, A extends Action = AnyAction>(
-  reducers: ReducerMapObject<S, A>
+  reducers: ReducerMapObject<S, A>,
 ): LiftedLoopReducer<S, A>
 
 declare function mergeChildReducers<S, A extends Action = AnyAction>(
   parentResult: S | Loop<S, A>,
   action: AnyAction,
-  childMap: ReducerMapObject<S, A>
+  childMap: ReducerMapObject<S, A>,
 ): Loop<S, A>
 
 declare function reduceReducers<S, A extends Action = AnyAction>(
@@ -176,7 +176,7 @@ declare function reduceReducers<S, A extends Action = AnyAction>(
 ): LiftedLoopReducer<S, A>
 
 declare function liftState<S, A extends Action>(
-  state: S | Loop<S, A>
+  state: S | Loop<S, A>,
 ): Loop<S, A>
 
 declare function isLoop(test: any): boolean


### PR DESCRIPTION
Previous we had trailingComma set to `none` which made development more
annoying than it had to be.

For example, adding another arg to an existing function was annoying
since you'd need to add the trailing comma first.

This also brings the config to parity with the kodiak config.