### PR TITLE
ref: ingredient section font weight

### DIFF
--- a/frontend/src/components/Section.tsx
+++ b/frontend/src/components/Section.tsx
@@ -148,7 +148,7 @@ export function Section({
     <li
       ref={ref}
       style={style}
-      className="bg-white mt-1 fw-500 text-small"
+      className="bg-white mt-1 bold text-small"
       title="click to edit"
       onClick={handleEnableEditing}>
       {title}


### PR DESCRIPTION
Changing this to be bold so the section stands out more, especially
on mobile. fw-500 was too small.