### PR TITLE
ref(markdown): render in app links with react-router links

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,8 +1,16 @@
 import React from "react"
 import ReactMarkdown, { NodeType } from "react-markdown"
 import { styled } from "@/theme"
+import * as settings from "@/settings"
+import { Link } from "@/components/Routing"
 
 const MarkdownWrapper = styled.div`
+  a {
+    text-decoration: underline;
+  }
+  a:hover {
+    text-decoration: none;
+  }
   ul {
     list-style-type: disc;
     padding-left: 1.5rem;
@@ -26,6 +34,25 @@ const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "listItem",
 ]
 
+function renderLink({
+  href,
+  ...props
+}: React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>) {
+  if (href && href.startsWith(settings.DOMAIN)) {
+    const to = new URL(href).pathname
+    return <Link {...props} to={to} children={to.substring(1)} />
+  }
+  return <a {...props} href={href} />
+}
+
+const renderers = {
+  link: renderLink,
+  linkReference: renderLink,
+}
+
 interface IMarkdownProps {
   readonly children: string
   readonly onClick?: (_: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
@@ -44,6 +71,7 @@ export function Markdown({
       <ReactMarkdown
         allowedTypes={ALLOWED_MARKDOWN_TYPES}
         source={text}
+        renderers={renderers}
         unwrapDisallowed
       />
     </MarkdownWrapper>

--- a/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ListItem/> snap with capitalization 1`] = `
+.c0 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 a:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c0 ul {
   list-style-type: disc;
   padding-left: 1.5rem;
@@ -30,6 +40,16 @@ exports[`<ListItem/> snap with capitalization 1`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 2`] = `
+.c0 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 a:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c0 ul {
   list-style-type: disc;
   padding-left: 1.5rem;
@@ -59,6 +79,16 @@ exports[`<ListItem/> snap with capitalization 2`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 3`] = `
+.c0 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 a:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c0 ul {
   list-style-type: disc;
   padding-left: 1.5rem;
@@ -88,6 +118,16 @@ exports[`<ListItem/> snap with capitalization 3`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 4`] = `
+.c0 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0 a:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c0 ul {
   list-style-type: disc;
   padding-left: 1.5rem;

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -451,6 +451,16 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
 `;
 
 exports[`<Recipe/> snaps recipe all states 2`] = `
+.c6 a {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c6 a:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c6 ul {
   list-style-type: disc;
   padding-left: 1.5rem;

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -6,7 +6,7 @@ export const GIT_SHA = DEBUG ? "development" : process.env.GIT_SHA
 
 export const SENTRY_DSN = process.env.FRONTEND_SENTRY_DSN
 
-const DOMAIN = DEBUG ? "http://localhost:3000" : "https://recipeyak.com"
+export const DOMAIN = DEBUG ? "http://localhost:3000" : "https://recipeyak.com"
 
 // TODO(sbdchd): we export these as a quick hack since we aren't using them
 export const OAUTH_BITBUCKET_CLIENT_ID = process.env.OAUTH_BITBUCKET_CLIENT_ID


### PR DESCRIPTION
Use react-router links for URLs that reference app so you do nicer react
re-renders, instead of full page reloads.

Also render `https://recipeyak.com/recipes/17-potato-stew/` as
`recipes/17-potato-stew`.