### PR TITLE
fix(ci): pip fails to install pkgs with missing setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ exclude = '''
 
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "setuptools"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
rel: https://github.com/chdsbd/kodiak/pull/519