### PR TITLE
add(ui): block quotes and paragraph spacing for notes markdown

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -19,12 +19,29 @@ const MarkdownWrapper = styled.div`
   ol {
     padding-left: 1.5rem;
   }
+
+  blockquote {
+    padding-left: 0.25rem;
+    border-left: 5px solid lightgray;
+    & > p {
+      margin-bottom: 0rem;
+    }
+
+    &:last-of-type > p {
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  p {
+    margin-bottom: 0.5rem;
+  }
 `
 
 const ALLOWED_MARKDOWN_TYPES: NodeType[] = [
   "root",
   "text",
   "delete",
+  "blockquote",
   "paragraph",
   "strong",
   "emphasis",

--- a/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
@@ -20,6 +20,23 @@ exports[`<ListItem/> snap with capitalization 1`] = `
   padding-left: 1.5rem;
 }
 
+.c0 blockquote {
+  padding-left: 0.25rem;
+  border-left: 5px solid lightgray;
+}
+
+.c0 blockquote > p {
+  margin-bottom: 0rem;
+}
+
+.c0 blockquote:last-of-type > p {
+  margin-bottom: 0.5rem;
+}
+
+.c0 p {
+  margin-bottom: 0.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
@@ -57,6 +74,23 @@ exports[`<ListItem/> snap with capitalization 2`] = `
 
 .c0 ol {
   padding-left: 1.5rem;
+}
+
+.c0 blockquote {
+  padding-left: 0.25rem;
+  border-left: 5px solid lightgray;
+}
+
+.c0 blockquote > p {
+  margin-bottom: 0rem;
+}
+
+.c0 blockquote:last-of-type > p {
+  margin-bottom: 0.5rem;
+}
+
+.c0 p {
+  margin-bottom: 0.5rem;
 }
 
 <div>
@@ -98,6 +132,23 @@ exports[`<ListItem/> snap with capitalization 3`] = `
   padding-left: 1.5rem;
 }
 
+.c0 blockquote {
+  padding-left: 0.25rem;
+  border-left: 5px solid lightgray;
+}
+
+.c0 blockquote > p {
+  margin-bottom: 0rem;
+}
+
+.c0 blockquote:last-of-type > p {
+  margin-bottom: 0.5rem;
+}
+
+.c0 p {
+  margin-bottom: 0.5rem;
+}
+
 <div>
   <section
     className="cursor-pointer"
@@ -135,6 +186,23 @@ exports[`<ListItem/> snap with capitalization 4`] = `
 
 .c0 ol {
   padding-left: 1.5rem;
+}
+
+.c0 blockquote {
+  padding-left: 0.25rem;
+  border-left: 5px solid lightgray;
+}
+
+.c0 blockquote > p {
+  margin-bottom: 0rem;
+}
+
+.c0 blockquote:last-of-type > p {
+  margin-bottom: 0.5rem;
+}
+
+.c0 p {
+  margin-bottom: 0.5rem;
 }
 
 <div>

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -470,6 +470,23 @@ exports[`<Recipe/> snaps recipe all states 2`] = `
   padding-left: 1.5rem;
 }
 
+.c6 blockquote {
+  padding-left: 0.25rem;
+  border-left: 5px solid lightgray;
+}
+
+.c6 blockquote > p {
+  margin-bottom: 0rem;
+}
+
+.c6 blockquote:last-of-type > p {
+  margin-bottom: 0.5rem;
+}
+
+.c6 p {
+  margin-bottom: 0.5rem;
+}
+
 .c0 {
   position: relative;
 }


### PR DESCRIPTION
Enable `blockquote`s via react-markdown.

Also add margin to space out the paragraphs. Mindful not to mess up the
block quotes