### PR TITLE
add: larger recipe click targets for browse view

### DIFF
--- a/frontend/src/components/RecipeItem.tsx
+++ b/frontend/src/components/RecipeItem.tsx
@@ -61,18 +61,28 @@ export function RecipeItem({ name, author, id, ...props }: IRecipeItemProps) {
     },
   })
 
+  const recipeContent = (
+    <div className="card-content h-100 d-flex flex-column">
+      <RecipeTitle name={name} url={url} dragable={!!props.drag} />
+      <Meta author={author} />
+    </div>
+  )
+
+  if (props.drag) {
+    return (
+      <section
+        ref={drag}
+        className="card cursor-move"
+        style={{ opacity: isDragging ? 0.5 : 1 }}>
+        {recipeContent}
+      </section>
+    )
+  }
+
   return (
-    <section
-      ref={props.drag ? drag : undefined}
-      className={classNames("card", {
-        "cursor-move": props.drag,
-      })}
-      style={{ opacity: isDragging ? 0.5 : 1 }}>
-      <div className="card-content h-100 d-flex flex-column">
-        <RecipeTitle name={name} url={url} dragable={!!props.drag} />
-        <Meta author={author} />
-      </div>
-    </section>
+    <Link tabIndex={0} to={url} className="card">
+      {recipeContent}
+    </Link>
   )
 }
 


### PR DESCRIPTION
Before only a recipe title could be click in the browse view, now the entire recipe item can be clicked.

<img width="1552" alt="Screen Shot 2020-11-21 at 11 53 03 AM" src="https://user-images.githubusercontent.com/1929960/99882665-31a56380-2bf0-11eb-86b3-1b2e860d3c12.png">