### PR TITLE
fix(ui): header in safari

### DIFF
--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -218,6 +218,7 @@ const NavContainer = styled.nav`
   padding-right: 0.75rem;
   display: flex;
   justify-content: space-between;
+  flex-shrink: 0;
 `
 
 export function Navbar() {

--- a/frontend/src/components/__snapshots__/Nav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Nav.test.tsx.snap
@@ -92,6 +92,9 @@ exports[`<Nav/> render when logged in 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 @media (max-width:630px) {
@@ -370,6 +373,9 @@ exports[`<Nav/> renders default 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 @media (max-width:630px) {


### PR DESCRIPTION
The header was broken in Safari (not Chrome though) because of #607.