### PR TITLE
fix(CI): docker lint failing due to fd-find not installing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,14 +160,13 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            yarn global add fd-find@1.0.6
             curl -L https://github.com/hadolint/hadolint/releases/download/v1.17.1/hadolint-Linux-x86_64 -o hadolint
             chmod +x hadolint
             mv hadolint /bin/
       - run:
           name: run linter
           command: |
-            fd Dockerfile | xargs hadolint
+            find . -name '*.Dockerfile' | xargs hadolint
 
   shellcheck:
     docker:


### PR DESCRIPTION
Use `find` instead of `fd` since `fd` isn't installing.