### PR TITLE
ref(ui): allow changing a little bit of scheduling history

### DIFF
--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -7,7 +7,7 @@ import startOfDay from "date-fns/startOfDay"
 import endOfDay from "date-fns/endOfDay"
 import isFirstDayOfMonth from "date-fns/isFirstDayOfMonth"
 import sortBy from "lodash/sortBy"
-import { beforeCurrentDay } from "@/date"
+import { isInsideChangeWindow } from "@/date"
 import { CalendarItem, ICalendarDragItem } from "@/components/CalendarDayItem"
 import {
   updatingScheduledRecipeAsync,
@@ -134,8 +134,7 @@ function CalendarDay({
   const [{ isOver, canDrop }, drop] = useDrop({
     accept: [DragDrop.RECIPE, DragDrop.CAL_RECIPE],
     canDrop: () => {
-      // event when copying from past, we don't want to copy to past dates
-      return !beforeCurrentDay(date)
+      return isInsideChangeWindow(date)
     },
     drop: dropped => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -2,13 +2,12 @@ import React from "react"
 import { styled } from "@/theme"
 import { Link } from "react-router-dom"
 import { useDrag } from "react-dnd"
-import { beforeCurrentDay } from "@/date"
+import { isInsideChangeWindow } from "@/date"
 import { recipeURL } from "@/urls"
 import { DragDrop } from "@/dragDrop"
 import { IRecipe } from "@/store/reducers/recipes"
 import { ICalRecipe } from "@/store/reducers/calendar"
 import { TextInput } from "@/components/Forms"
-import { isPast, endOfDay } from "date-fns"
 import { Result, isOk } from "@/result"
 import { useGlobalEvent } from "@/hooks"
 
@@ -101,7 +100,7 @@ export function CalendarItem({
   }, [propsCount])
 
   const updateCount = (newCount: number) => {
-    if (beforeCurrentDay(date)) {
+    if (!isInsideChangeWindow(date)) {
       return
     }
     const oldCount = count
@@ -120,7 +119,7 @@ export function CalendarItem({
       return
     }
 
-    if (beforeCurrentDay(date)) {
+    if (!isInsideChangeWindow(date)) {
       return
     }
 
@@ -151,7 +150,7 @@ export function CalendarItem({
     end: (_dropResult, monitor) => {
       // when dragged onto something that isn't a target, we remove it
       // but we don't remove when in past as we only copy from the past
-      if (!monitor.didDrop() && !isPast(endOfDay(date))) {
+      if (!monitor.didDrop() && isInsideChangeWindow(date)) {
         remove()
       }
     },
@@ -162,7 +161,8 @@ export function CalendarItem({
     },
   })
 
-  const visibility = isDragging && !isPast(date) ? "hidden" : "visible"
+  const visibility =
+    isDragging && isInsideChangeWindow(date) ? "hidden" : "visible"
 
   useGlobalEvent({ keyUp: handleKeyPress })
 

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -5,6 +5,9 @@ import * as settings from "@/settings"
 import { Link } from "@/components/Routing"
 
 const MarkdownWrapper = styled.div`
+  /* handle long links in markdown */
+  word-break: break-all;
+
   a {
     text-decoration: underline;
   }

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -360,7 +360,6 @@ export function Recipe(props: IRecipeProps) {
         time={recipe.time}
         owner={recipe.owner}
         updating={recipe.updating}
-        deleting={recipe.deleting}
         editing={recipe.editing}
       />
 

--- a/frontend/src/components/RecipeTitle.tsx
+++ b/frontend/src/components/RecipeTitle.tsx
@@ -4,7 +4,6 @@ import MetaData from "@/components/MetaData"
 import {
   IRecipe,
   updateRecipe,
-  deleteRecipe,
   toggleEditingRecipe,
 } from "@/store/reducers/recipes"
 import GlobalEvent from "@/components/GlobalEvent"
@@ -23,8 +22,6 @@ interface IRecipeTitleProps {
   readonly owner: IRecipe["owner"]
   readonly update: (args: { id: IRecipe["id"]; data: IRecipeBasic }) => void
   readonly updating?: boolean
-  readonly remove: (id: IRecipe["id"]) => void
-  readonly deleting?: boolean
   readonly editing?: boolean
   readonly toggleEditing: (recipeID: IRecipe["id"]) => void
 }
@@ -71,16 +68,6 @@ class RecipeTitle extends React.Component<
     }))
   }
 
-  handleDelete = () => {
-    if (
-      confirm(
-        `Are you sure you want to delete this recipe "${this.props.name}"?`,
-      )
-    ) {
-      this.props.remove(this.props.id)
-    }
-  }
-
   handleGlobalKeyUp = (e: KeyboardEvent) => {
     // Pass if we aren't editing
     if (!this.props.editing) {
@@ -108,7 +95,6 @@ class RecipeTitle extends React.Component<
       time,
       owner,
       updating,
-      deleting,
     } = this.props
     return (
       <div>
@@ -193,34 +179,23 @@ class RecipeTitle extends React.Component<
                 />
               </label>
             </div>
-            <div className="d-flex grid-entire-row align-items-center justify-space-between">
+            <div className="d-flex grid-entire-row align-items-end justify-content-end">
               <Button
                 size="small"
                 type="submit"
-                loading={deleting}
-                onClick={this.handleDelete}
-                name="delete recipe">
-                Delete
+                loading={updating}
+                onClick={this.handleSave}
+                name="save recipe">
+                Save
               </Button>
-              <div>
-                <Button
-                  size="small"
-                  className="ml-2"
-                  type="submit"
-                  loading={updating}
-                  onClick={this.handleSave}
-                  name="save recipe">
-                  Save
-                </Button>
-                <Button
-                  size="small"
-                  className="ml-2"
-                  type="button"
-                  name="cancel recipe update"
-                  onClick={this.toggleEdit}>
-                  Cancel
-                </Button>
-              </div>
+              <Button
+                size="small"
+                className="ml-2"
+                type="button"
+                name="cancel recipe update"
+                onClick={this.toggleEdit}>
+                Cancel
+              </Button>
             </div>
           </div>
         )}
@@ -231,7 +206,6 @@ class RecipeTitle extends React.Component<
 
 const mapDispatchToProps = {
   update: updateRecipe.request,
-  remove: deleteRecipe.request,
   toggleEditing: toggleEditingRecipe,
 }
 

--- a/frontend/src/components/RecipeTitleDropdown.tsx
+++ b/frontend/src/components/RecipeTitleDropdown.tsx
@@ -10,6 +10,7 @@ import {
   duplicateRecipe,
   IRecipe,
   updateRecipe,
+  deleteRecipe,
 } from "@/store/reducers/recipes"
 import { Button } from "@/components/Buttons"
 import {
@@ -70,12 +71,12 @@ export function Dropdown({ recipeId }: IDropdownProps) {
 
   const dispatch = useDispatch()
   const ingredients = useIngredientString(recipeId)
-  const isArchived = useSelector(s => {
+  const [isArchived, isDeleting] = useSelector(s => {
     const maybeRecipe = s.recipes.byId[recipeId]
     if (maybeRecipe?.kind === "Success") {
-      return Boolean(maybeRecipe.data.archived_at)
+      return [!!maybeRecipe.data.archived_at, !!maybeRecipe.data.deleting]
     }
-    return false
+    return [false, false]
   })
 
   const [creatingDuplicate, onDuplicate] = useDuplicateRecipe({
@@ -114,6 +115,12 @@ export function Dropdown({ recipeId }: IDropdownProps) {
     close()
   }, [close, dispatch, recipeId])
 
+  const handleDeleteRecipe = React.useCallback(() => {
+    if (confirm("Are you sure you want to delete this recipe?")) {
+      dispatch(deleteRecipe.request(recipeId))
+    }
+  }, [dispatch, recipeId])
+
   const scheduleUrl = useScheduleUrl(recipeId)
 
   const exportYamlUrl = `/recipes/${recipeId}.yaml`
@@ -150,6 +157,9 @@ export function Dropdown({ recipeId }: IDropdownProps) {
             Unarchive Recipe
           </DropdownItemButton>
         )}
+        <DropdownItemButton onClick={handleDeleteRecipe}>
+          {!isDeleting ? "Delete Recipe" : "Deleting Recipe.."}
+        </DropdownItemButton>
       </DropdownMenu>
     </DropdownContainer>
   )

--- a/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ListItem/> snap with capitalization 1`] = `
+.c0 {
+  word-break: break-all;
+}
+
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -57,6 +61,10 @@ exports[`<ListItem/> snap with capitalization 1`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 2`] = `
+.c0 {
+  word-break: break-all;
+}
+
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -113,6 +121,10 @@ exports[`<ListItem/> snap with capitalization 2`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 3`] = `
+.c0 {
+  word-break: break-all;
+}
+
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -169,6 +181,10 @@ exports[`<ListItem/> snap with capitalization 3`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 4`] = `
+.c0 {
+  word-break: break-all;
+}
+
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -262,6 +262,12 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
           >
             Archive Recipe
           </button>
+          <button
+            className="c3"
+            onClick={[Function]}
+          >
+            Delete Recipe
+          </button>
         </div>
       </div>
     </div>
@@ -457,6 +463,10 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
 `;
 
 exports[`<Recipe/> snaps recipe all states 2`] = `
+.c6 {
+  word-break: break-all;
+}
+
 .c6 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -688,6 +698,12 @@ exports[`<Recipe/> snaps recipe all states 2`] = `
             onClick={[Function]}
           >
             Archive Recipe
+          </button>
+          <button
+            className="c3"
+            onClick={[Function]}
+          >
+            Delete Recipe
           </button>
         </div>
       </div>

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -2,9 +2,9 @@ import format from "date-fns/format"
 import startOfMonth from "date-fns/startOfMonth"
 import lastDayOfMonth from "date-fns/lastDayOfMonth"
 import eachDayOfInterval from "date-fns/eachDayOfInterval"
-import isBefore from "date-fns/isBefore"
-import startOfDay from "date-fns/startOfDay"
 import parseISO from "date-fns/parseISO"
+import isAfter from "date-fns/isAfter"
+import subDays from "date-fns/subDays"
 
 export function toISODateString(date: Date | string): string {
   // Note(sbdchd): parseISO("2019-11-09") !== new Date("2019-11-09")
@@ -23,8 +23,10 @@ export function daysFromSunday(date: Date) {
   return startOfMonth(date).getDay()
 }
 
-export function beforeCurrentDay(date: Date) {
-  return isBefore(date, startOfDay(new Date()))
-}
-
 export const second = 1000
+
+const DELETION_WINDOW_DAYS = 5
+
+export function isInsideChangeWindow(date: Date): boolean {
+  return isAfter(date, subDays(new Date(), DELETION_WINDOW_DAYS))
+}

--- a/frontend/src/store/thunks.ts
+++ b/frontend/src/store/thunks.ts
@@ -1,6 +1,6 @@
 import pickBy from "lodash/pickBy"
 import { random32Id } from "@/uuid"
-import { toISODateString, second } from "@/date"
+import { toISODateString, second, isInsideChangeWindow } from "@/date"
 import { push, replace } from "connected-react-router"
 // eslint-disable-next-line no-restricted-imports
 import { Dispatch as ReduxDispatch } from "redux"
@@ -93,15 +93,7 @@ import {
 } from "@/store/reducers/auth"
 import { recipeURL } from "@/urls"
 import { isSuccessOrRefetching } from "@/webdata"
-import {
-  isPast,
-  endOfDay,
-  parseISO,
-  startOfWeek,
-  subWeeks,
-  addWeeks,
-  endOfWeek,
-} from "date-fns"
+import { parseISO, startOfWeek, subWeeks, addWeeks, endOfWeek } from "date-fns"
 import { isOk, isErr, Ok, Err, Result } from "@/result"
 import { heldKeys } from "@/components/CurrentKeys"
 import { isRight } from "fp-ts/lib/Either"
@@ -1154,7 +1146,7 @@ export const moveScheduledRecipe = async (
   // - recipe from the past
   // - user is holding shift
   const holdingShift = heldKeys.size === 1 && heldKeys.has("Shift")
-  const copyRecipe = isPast(endOfDay(parseISO(from.on))) || holdingShift
+  const copyRecipe = !isInsideChangeWindow(parseISO(from.on)) || holdingShift
   if (copyRecipe) {
     return addingScheduledRecipeAsync(dispatch, getState, {
       recipeID: from.recipe.id,


### PR DESCRIPTION
Allow users to change the past 5 days of scheduling history. Helpful when
you made something, or didn't make something and want to change it.

Fix text wrapping bug with long links in markdown.

Move recipe deletion to the "options" dropdown where the archive button
is located.