### PR TITLE
revert(ui): break-all in markdown

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -5,9 +5,6 @@ import * as settings from "@/settings"
 import { Link } from "@/components/Routing"
 
 const MarkdownWrapper = styled.div`
-  /* handle long links in markdown */
-  word-break: break-all;
-
   a {
     text-decoration: underline;
   }

--- a/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/ListItem.test.tsx.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ListItem/> snap with capitalization 1`] = `
-.c0 {
-  word-break: break-all;
-}
-
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -61,10 +57,6 @@ exports[`<ListItem/> snap with capitalization 1`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 2`] = `
-.c0 {
-  word-break: break-all;
-}
-
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -121,10 +113,6 @@ exports[`<ListItem/> snap with capitalization 2`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 3`] = `
-.c0 {
-  word-break: break-all;
-}
-
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -181,10 +169,6 @@ exports[`<ListItem/> snap with capitalization 3`] = `
 `;
 
 exports[`<ListItem/> snap with capitalization 4`] = `
-.c0 {
-  word-break: break-all;
-}
-
 .c0 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Recipe.test.tsx.snap
@@ -463,10 +463,6 @@ exports[`<Recipe/> snaps recipe all states 1`] = `
 `;
 
 exports[`<Recipe/> snaps recipe all states 2`] = `
-.c6 {
-  word-break: break-all;
-}
-
 .c6 a {
   -webkit-text-decoration: underline;
   text-decoration: underline;


### PR DESCRIPTION
Break all wraps links correctly, but messes with normal text.