### PR TITLE
cut(ui): timeout for api requests

### DIFF
--- a/frontend/src/http.ts
+++ b/frontend/src/http.ts
@@ -12,7 +12,7 @@ import { Result, Ok, Err } from "@/result"
 import * as t from "io-ts"
 import { Either, left } from "fp-ts/lib/Either"
 
-export const baseHttp = axios.create({ timeout: 15000 })
+export const baseHttp = axios.create()
 
 type Method =
   | "GET"


### PR DESCRIPTION
This timeout isn't helpful because on poor connections it will take a while for the API requests to be received. Timeouts matter on the backend.