### PR TITLE
fix(ui): clock skew with timestamp distance formatting

### DIFF
--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react"
-import { formatDistanceToNow, format } from "date-fns"
+import { format } from "date-fns"
 import { Avatar } from "@/components/Avatar"
 import {
   IRecipe,
@@ -19,6 +19,7 @@ import orderBy from "lodash/orderBy"
 import Textarea from "react-textarea-autosize"
 import { Markdown } from "@/components/Markdown"
 import { useLocation } from "react-router-dom"
+import { formatDistanceToNow } from "@/date"
 
 interface IUseNoteEditHandlers {
   readonly note: INote
@@ -95,7 +96,7 @@ function NoteTimeStamp({ created }: { readonly created: string }) {
   const date = new Date(created)
   const dateFormat = format(date, "yyyy-M-d")
   const prettyDate = format(date, "MMM d, yyyy")
-  const humanizedDate = formatDistanceToNow(date, { addSuffix: true })
+  const humanizedDate = formatDistanceToNow(date)
   return (
     <time title={prettyDate} dateTime={dateFormat}>
       {humanizedDate}

--- a/frontend/src/components/Sessions.tsx
+++ b/frontend/src/components/Sessions.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react"
 import { ISession, LoggingOutStatus } from "@/store/reducers/user"
-import { formatDistanceToNow } from "date-fns"
 import { WebData, isLoading, isInitial, isFailure } from "@/webdata"
 import { Button } from "@/components/Buttons"
 import Loader from "@/components/Loader"
@@ -12,6 +11,7 @@ import {
   loggingOutSessionByIdAsync,
   loggingOutAllSessionsAsync,
 } from "@/store/thunks"
+import { formatDistanceToNow } from "@/date"
 
 function getDeviceEmoji(kind: ISession["device"]["kind"]): string | null {
   switch (kind) {
@@ -69,9 +69,7 @@ interface ISessionProps extends ISession {
 }
 
 function Session(props: ISessionProps) {
-  const lastActivity = formatDistanceToNow(new Date(props.last_activity), {
-    addSuffix: true,
-  })
+  const lastActivity = formatDistanceToNow(new Date(props.last_activity))
   return (
     <li className="mb-2">
       <section className="d-flex">

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -5,6 +5,8 @@ import eachDayOfInterval from "date-fns/eachDayOfInterval"
 import parseISO from "date-fns/parseISO"
 import isAfter from "date-fns/isAfter"
 import subDays from "date-fns/subDays"
+import formatDistance from "date-fns/formatDistance"
+import min from "date-fns/min"
 
 export function toISODateString(date: Date | string): string {
   // Note(sbdchd): parseISO("2019-11-09") !== new Date("2019-11-09")
@@ -29,4 +31,11 @@ const DELETION_WINDOW_DAYS = 5
 
 export function isInsideChangeWindow(date: Date): boolean {
   return isAfter(date, subDays(new Date(), DELETION_WINDOW_DAYS))
+}
+
+export function formatDistanceToNow(date: Date): string {
+  const now = new Date()
+  // Avoid clock skew, otherwise the distance can say "in a few seconds"
+  // sometimes, which doesn't make sense.
+  return formatDistance(min([date, now]), now, { addSuffix: true })
 }


### PR DESCRIPTION
Due to clock skew, timestamps would sometimes be formatted as a distance
into the future.

Now we cap the dates to `now()` to avoid `in a few minutes` style
messages.