### PR TITLE
fix recipe list to only remove specific search params

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -15,6 +15,7 @@ import { Link } from "react-router-dom"
 import { useDispatch } from "@/hooks"
 import { replace } from "connected-react-router"
 import { styled } from "@/theme"
+import { updateQueryString } from "@/utils/querystring"
 
 interface IResultsProps {
   readonly recipes: JSX.Element[]
@@ -158,7 +159,15 @@ function RecipesListSearch({
   const dispatch = useDispatch()
   const [query, setQuery] = useState(() => {
     const urlQuery = getSearch(window.location.search)
-    dispatch(replace({ search: "" }))
+    // remove search and recipeId from query string on load.
+    dispatch(
+      replace({
+        search: updateQueryString(
+          { search: undefined, recipeId: undefined },
+          window.location.search,
+        ),
+      }),
+    )
     return urlQuery
   })
 

--- a/frontend/src/utils/querystring.test.ts
+++ b/frontend/src/utils/querystring.test.ts
@@ -1,0 +1,9 @@
+import { updateQueryString } from "@/utils/querystring"
+
+test("updateQueryString removes undefined params", () => {
+  const actual = updateQueryString(
+    { search: undefined },
+    "?week=2021-06-06&search=cake",
+  )
+  expect(actual).toEqual("week=2021-06-06")
+})

--- a/frontend/src/utils/querystring.ts
+++ b/frontend/src/utils/querystring.ts
@@ -1,0 +1,9 @@
+import queryString from "query-string"
+
+export function updateQueryString(
+  params: { [key: string]: string | undefined },
+  querystring: string,
+): string {
+  const parsed = queryString.parse(querystring)
+  return queryString.stringify({ ...parsed, ...params })
+}


### PR DESCRIPTION
Previously on load we deleted the entire URL search. This broke navigation so you couldn't visit a recipe and return to your place in the calendar, because the "week" parameter would be removed on load.

Now we only remove specific keys from the query string: "recipeId" and "search"