### PR TITLE
fix(ui): netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,26 +12,50 @@
   force = true
 
 [[redirects]]
-  from = "*.json"
+  from = "/recipes.json"
   to = "https://recipeyak.com/:splat.json"
   status = 200
   force = true
 
 [[redirects]]
-  from = "*.yaml"
+  from = "/recipes.yaml"
   to = "https://recipeyak.com/:splat.yaml"
   status = 200
   force = true
 
 [[redirects]]
-  from = "*.yml"
+  from = "/recipes.yml"
   to = "https://recipeyak.com/:splat.yml"
   status = 200
   force = true
 
 [[redirects]]
-  from = "*.ics"
+  from = "/recipes.ics"
   to = "https://recipeyak.com/:splat.ics"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/recipes/:id.json"
+  to = "https://recipeyak.com/:id.json"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/recipes/:id.yaml"
+  to = "https://recipeyak.com/:id.yaml"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/recipes/:id.yml"
+  to = "https://recipeyak.com/:id.yml"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/recipes/:id.ics"
+  to = "https://recipeyak.com/:id.ics"
   status = 200
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,25 +12,25 @@
   force = true
 
 [[redirects]]
-  from = "/*.json"
+  from = "*.json"
   to = "https://recipeyak.com/:splat.json"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/*.yaml"
+  from = "*.yaml"
   to = "https://recipeyak.com/:splat.yaml"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/*.yml"
+  from = "*.yml"
   to = "https://recipeyak.com/:splat.yml"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/*.ics"
+  from = "*.ics"
   to = "https://recipeyak.com/:splat.ics"
   status = 200
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,49 +13,49 @@
 
 [[redirects]]
   from = "/recipes.json"
-  to = "https://recipeyak.com/:splat.json"
+  to = "https://recipeyak.com/recipes.json"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes.yaml"
-  to = "https://recipeyak.com/:splat.yaml"
+  to = "https://recipeyak.com/recipes.yaml"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes.yml"
-  to = "https://recipeyak.com/:splat.yml"
+  to = "https://recipeyak.com/recipes.yml"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes.ics"
-  to = "https://recipeyak.com/:splat.ics"
+  to = "https://recipeyak.com/recipes.ics"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes/:id.json"
-  to = "https://recipeyak.com/:id.json"
+  to = "https://recipeyak.com/recipes/:id.json"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes/:id.yaml"
-  to = "https://recipeyak.com/:id.yaml"
+  to = "https://recipeyak.com/recipes/:id.yaml"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes/:id.yml"
-  to = "https://recipeyak.com/:id.yml"
+  to = "https://recipeyak.com/recipes/:id.yml"
   status = 200
   force = true
 
 [[redirects]]
   from = "/recipes/:id.ics"
-  to = "https://recipeyak.com/:id.ics"
+  to = "https://recipeyak.com/recipes/:id.ics"
   status = 200
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,30 @@
   force = true
 
 [[redirects]]
+  from = "/*.json"
+  to = "https://recipeyak.com/:splat.json"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*.yaml"
+  to = "https://recipeyak.com/:splat.yaml"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*.yml"
+  to = "https://recipeyak.com/:splat.yml"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*.ics"
+  to = "https://recipeyak.com/:splat.ics"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
Netlify doesn't support full regex like NGINX, so we need to more more explicit in our redirects. Netlify only supports the `*` operator at the end of a URL.

This change fixes our Netlify config to allow `/recipes.json` and `/recipes/435.json` to work.