### PR TITLE
fix: tabbing disabling note editing

### DIFF
--- a/frontend/src/store/reducers/recipes.test.ts
+++ b/frontend/src/store/reducers/recipes.test.ts
@@ -631,33 +631,6 @@ describe("Recipes", () => {
     )
   })
 
-  it("overwrites the recipe correctly", () => {
-    const beforeState: IRecipesState = recipeStoreWith([
-      {
-        ...baseRecipe,
-        name: "Initial recipe name",
-        updating: true,
-      },
-    ])
-
-    const newRecipe = {
-      ...baseRecipe,
-      name: "new recipe name",
-    }
-
-    const afterState: IRecipesState = {
-      ...recipeStoreWith({
-        ...baseRecipe,
-        name: "new recipe name",
-      }),
-      personalIDs: Success([baseRecipe.id]),
-    }
-
-    expect(recipes(beforeState, fetchRecipe.success(newRecipe))).toEqual(
-      afterState,
-    )
-  })
-
   it("sets recipe owner for recipe move", () => {
     const beforeState: IRecipesState = recipeStoreWith([
       {

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -772,11 +772,18 @@ export const recipes = (
       )
     }
     case getType(fetchRecipe.success):
+      const originalRecipe = state.byId[action.payload.id]
+
       return {
         ...state,
         byId: {
           ...state.byId,
-          [action.payload.id]: Success(action.payload),
+          [action.payload.id]: Success({
+            ...(isSuccessOrRefetching(originalRecipe)
+              ? originalRecipe.data
+              : {}),
+            ...action.payload,
+          }),
         },
       }
     case getType(fetchRecipe.failure): {


### PR DESCRIPTION
Previously tabbing away from the page while editing a new note would clear the note editor when you tabbed back. This was because the creatingNewNote field was being removed by the refetch of the recipe on window focus change.

Now we preserve the creatingNewNote data between fetches.