### PR TITLE
fix(ui): 404 on outgoing navigation

### DIFF
--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -328,6 +328,10 @@ function ArchiveBanner({ date }: { readonly date: Date }) {
   )
 }
 
+function isRecipeyakHostname(x: string): boolean {
+  return x.includes("recipeyak.com") || x.includes("localhost")
+}
+
 /** On load, update the recipe URL to include the slugified recipe name */
 function useRecipeUrlUpdate(recipe: { id: number; name: string } | null) {
   const dispatch = useDispatch()
@@ -340,6 +344,13 @@ function useRecipeUrlUpdate(recipe: { id: number; name: string } | null) {
       return
     }
     const pathname = recipeURL(recipeId, recipeName)
+
+    // don't rewrite URL if we're on a different domain.
+    //
+    // this prevents glitchy 404 behavior when navigating to a different domain.
+    if (!isRecipeyakHostname(window.location.hostname)) {
+      return
+    }
     if (pathNamesEqual(location.pathname, pathname)) {
       return
     }


### PR DESCRIPTION
Previously if you clicked an outgoing link on the recipe page, you would see a momentary 404 before the browser redirected to the URL. This only affected iOS.

Now we only update the recipe URL if the hostname is recipeyak or localhost.