### PR TITLE
fix(ui): error w/ inflight request while naving to diff hostname on iOS

### DIFF
--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -325,6 +325,7 @@ function runDevServer(host, port, protocol) {
     },
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === "https",
+    disableHostCheck: process.env.DISABLE_HOST_CHECK === "1",
     host,
   })
 

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -328,10 +328,6 @@ function ArchiveBanner({ date }: { readonly date: Date }) {
   )
 }
 
-function isRecipeyakHostname(x: string): boolean {
-  return x.includes("recipeyak.com") || x.includes("localhost")
-}
-
 /** On load, update the recipe URL to include the slugified recipe name */
 function useRecipeUrlUpdate(recipe: { id: number; name: string } | null) {
   const dispatch = useDispatch()
@@ -344,13 +340,6 @@ function useRecipeUrlUpdate(recipe: { id: number; name: string } | null) {
       return
     }
     const pathname = recipeURL(recipeId, recipeName)
-
-    // don't rewrite URL if we're on a different domain.
-    //
-    // this prevents glitchy 404 behavior when navigating to a different domain.
-    if (!isRecipeyakHostname(window.location.hostname)) {
-      return
-    }
     if (pathNamesEqual(location.pathname, pathname)) {
       return
     }

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -67,6 +67,11 @@ async function fetchingRecipeAsync(
   if (isOk(res)) {
     dispatch(fetchRecipe.success(res.data))
   } else {
+    // HACK: edge case where inflight network request is cancelled as we start
+    // navigating to a new site.
+    if (res.error.message === "Network Error") {
+      return
+    }
     const error404 = !!(res.error.response && res.error.response.status === 404)
     dispatch(
       fetchRecipe.failure({


### PR DESCRIPTION
There's been this persistent issue on iOS since we added more network
requests to sync the recipe data.

When naving away there will be an infight network request due to some
onfocus handlers, this network request gets killed by the browser with
an error: NetworkError

This was surfaced in the UI as a 404.

Now we return early from the network request. Really we want to show an
error unless a previous network request has succeeded, but
this is fine for now.