### PR TITLE
fix(ui): note rendering wiping edited text

### DIFF
--- a/frontend/src/components/Notes.tsx
+++ b/frontend/src/components/Notes.tsx
@@ -29,7 +29,7 @@ function useNoteEditHandlers({ note, recipeId }: IUseNoteEditHandlers) {
   const [draftText, setNewText] = useState(note.text)
   useEffect(() => {
     setNewText(note.text)
-  }, [note])
+  }, [note.text])
   const [isEditing, setIsEditing] = React.useState(false)
   const [isUpdating, setIsUpdating] = React.useState(false)
 


### PR DESCRIPTION
We were accidentally clearing the edited text of a note on rerender.