### PR TITLE
fix(api): pyyaml unicode encoding issues

### DIFF
--- a/backend/core/export/test_export.py
+++ b/backend/core/export/test_export.py
@@ -152,5 +152,5 @@ steps:
 - Place egg in boiling water and cook for ten minutes
 owner:
   user: john@doe.org
-"""    )
-
+"""
+    )

--- a/backend/core/export/test_export.py
+++ b/backend/core/export/test_export.py
@@ -120,3 +120,37 @@ def test_single_export_yaml(
     ), "we don't want python objects to be serialized"
     assert res.status_code == 200
     assert next(yaml.safe_load_all(res.content)).get("name") == recipe.name
+
+
+def test_unicode_issues(c: Client, user: User, recipe: Recipe) -> None:
+    """
+    regression to prevent unicode encoding issues with pyyaml
+    """
+    recipe.name = "foo 🦠"
+    recipe.save()
+    url = reverse("export-recipe", kwargs={"pk": recipe.id, "filetype": "yaml"})
+    c.force_login(user)
+    res = c.get(url)
+    assert (
+        res.content.decode()
+        == """\
+name: foo 🦠
+author: Recipe author
+time: 1 hour
+source: www.exmple.com
+servings: null
+ingredients:
+- quantity: 1 lbs
+  name: egg
+  description: scrambled
+  optional: false
+- quantity: 2 tbs
+  name: soy sauce
+  description: ''
+  optional: false
+steps:
+- Place egg in boiling water and cook for ten minutes
+owner:
+  user: john@doe.org
+"""    )
+

--- a/backend/core/response.py
+++ b/backend/core/response.py
@@ -28,6 +28,8 @@ class YamlResponse(HttpResponse):
             data = yaml.dump_all(data, default_flow_style=False, allow_unicode=True)
         else:
             # we wrap in an OrderedDict since PyYaml sorts dict keys for some odd reason!
-            data = yaml.dump(OrderedDict(data), default_flow_style=False, allow_unicode=True)
+            data = yaml.dump(
+                OrderedDict(data), default_flow_style=False, allow_unicode=True
+            )
 
         super().__init__(content=data, **kwargs)

--- a/backend/core/response.py
+++ b/backend/core/response.py
@@ -25,9 +25,9 @@ class YamlResponse(HttpResponse):
     def __init__(self, data, **kwargs):
         kwargs.setdefault("content_type", "text/x-yaml")
         if isinstance(data, list):
-            data = yaml.dump_all(data, default_flow_style=False)
+            data = yaml.dump_all(data, default_flow_style=False, allow_unicode=True)
         else:
             # we wrap in an OrderedDict since PyYaml sorts dict keys for some odd reason!
-            data = yaml.dump(OrderedDict(data), default_flow_style=False)
+            data = yaml.dump(OrderedDict(data), default_flow_style=False, allow_unicode=True)
 
         super().__init__(content=data, **kwargs)


### PR DESCRIPTION
Pyyaml was garbling unicode chars in the exports