### PR TITLE
feat(ui): change calendar item color

### DIFF
--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -42,14 +42,10 @@ const StyledLink = styled(Link)`
   line-height: 1.3;
   font-size: ${props => props.theme.text.small};
   word-break: break-word;
-  background-color: ${props => props.theme.color.primary};
+  background-color: ${props => props.theme.color.background};
   border-radius: 5px;
   padding: 0.35rem;
-  color: ${props => props.theme.color.white};
   font-weight: 600;
-  :hover {
-    color: ${props => props.theme.color.white};
-  }
 `
 
 function RecipeLink({ name, id }: IRecipeLink) {

--- a/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CalendarDayItem.test.tsx.snap
@@ -5,15 +5,10 @@ exports[`<CalendarDayItem> Snap smoke test render with styled components 1`] = `
   line-height: 1.3;
   font-size: 0.875rem;
   word-break: break-word;
-  background-color: #ff7247;
+  background-color: white;
   border-radius: 5px;
   padding: 0.35rem;
-  color: #f9f9f9;
   font-weight: 600;
-}
-
-.c1:hover {
-  color: #f9f9f9;
 }
 
 .c0 {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -5,6 +5,7 @@ import { transparentize } from "polished"
 export interface ITheme {
   readonly color: {
     readonly white: string
+    readonly background: string
     readonly primary: string
     readonly muted: string
     readonly primaryShadow: string
@@ -22,6 +23,7 @@ const muted = "#7a7a7a"
 export const theme: ITheme = {
   color: {
     white: "#f9f9f9",
+    background: "white",
     primary,
     muted,
     primaryShadow: transparentize(0.2, primary),


### PR DESCRIPTION
Black text and a white background is more legible than the previous orange background and white text.


<img width="183" alt="Screen Shot 2021-11-08 at 11 40 12 PM" src="https://user-images.githubusercontent.com/1929960/140863341-fc91c9eb-0e41-411e-89b6-c8541c27732a.png">

<img width="255" alt="Screen Shot 2021-11-08 at 11 39 49 PM" src="https://user-images.githubusercontent.com/1929960/140863307-eb08de2e-a026-41e5-8af0-11027f67f697.png">
