### PR TITLE
fix(api): don't cache api responses

### DIFF
--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -103,7 +103,7 @@ def test_cache_headers(client: APIClient, user: User, recipe: Recipe) -> None:
 
     res = client.get(f"/api/v1/recipes/{recipe.id}/")
     assert res.status_code == status.HTTP_200_OK
-    assert res['Cache-Control'] == 'no-store, no-cache, must-revalidate'
+    assert res["Cache-Control"] == "no-store, no-cache, must-revalidate"
 
 
 def test_recipe_creation_for_a_team(client, team, user):

--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -95,6 +95,17 @@ def test_creating_recipe_with_empty_ingredients_and_steps(client, user):
     assert res.data["steps"] is not None
 
 
+def test_cache_headers(client: APIClient, user: User, recipe: Recipe) -> None:
+    """
+    check that we actually disable caching
+    """
+    client.force_authenticate(user)
+
+    res = client.get(f"/api/v1/recipes/{recipe.id}/")
+    assert res.status_code == status.HTTP_200_OK
+    assert res['Cache-Control'] == 'no-store, no-cache, must-revalidate'
+
+
 def test_recipe_creation_for_a_team(client, team, user):
     """
     ensure that the user can create recipe for a team

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -145,6 +145,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
+    "core.middleware.NoCacheMiddleware",
 ]
 
 


### PR DESCRIPTION
We removed the cache middleware back in 6fc14b469d7eaf80a7d083e209fb50b0a3d76bb6
which was a mistake.

I thought about adding these headers in nginx, but it's kind of a pain
to test and this will also apply in dev which is nice.