### PR TITLE
feat(api): add sentry span for api delay middleware

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -90,7 +90,12 @@ class APIDelayMiddleware:
         self.API_DELAY_MS = getattr(settings, "API_DELAY_MS", 200)
 
     def __call__(self, request):
-        time.sleep(self.API_DELAY_MS / 1000)
+        with sentry_sdk.start_span(
+            op="recipeyak.middleware", description="api delay"
+        ) as span:
+            delay = self.API_DELAY_MS / 1000
+            span.set_data("delay", delay)
+            time.sleep(self.API_DELAY_MS / 1000)
         return self.get_response(request)
 
 

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -95,7 +95,7 @@ class APIDelayMiddleware:
         ) as span:
             delay = self.API_DELAY_MS / 1000
             span.set_data("delay", delay)
-            time.sleep(self.API_DELAY_MS / 1000)
+            time.sleep(delay)
         return self.get_response(request)
 
 


### PR DESCRIPTION
This should prevent any confusion during local dev