### PR TITLE
fix(ui): format ingredient description units

### DIFF
--- a/frontend/src/components/IngredientView.tsx
+++ b/frontend/src/components/IngredientView.tsx
@@ -18,7 +18,9 @@ export default function IngredientView({
   optional,
   dragRef,
 }: IIngredientVIewProps) {
-  const fmtDescription = description ? ", " + description : ""
+  const fmtDescription = description
+    ? ", " + normalizeUnitsFracs(description)
+    : ""
 
   return (
     <p className="listitem-text justify-space-between" ref={dragRef}>


### PR DESCRIPTION
Now we properly capitalize units in ingredient descriptions.