### PR TITLE
ref(ui): update recipe detail to less wide

### DIFF
--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -371,7 +371,7 @@ export function Recipe(props: IRecipeProps) {
   const isTimeline = !!parsed.timeline
 
   return (
-    <div className="d-grid grid-gap-2">
+    <div className="d-grid grid-gap-2 mx-auto mw-1000px">
       <Helmet title={recipe.name} />
       {recipe.archived_at != null && (
         <ArchiveBanner date={new Date(recipe.archived_at)} />

--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -211,6 +211,10 @@
   max-width: 400px;
 }
 
+.mw-1000px {
+  max-width: 1000px !important;
+}
+
 @for $i from 0 through 16 {
   .max-width-#{$i} {
     max-width: #{$i/4}rem;


### PR DESCRIPTION
Looks better when we squish the page to 1000px wide instead of ~1500px

<img width="1792" alt="Screen Shot 2021-12-25 at 1 23 47 PM" src="https://user-images.githubusercontent.com/7340772/147391384-7936f76e-8f46-431f-a197-4c41c43cad03.png">
<img width="1792" alt="Screen Shot 2021-12-25 at 1 23 21 PM" src="https://user-images.githubusercontent.com/7340772/147391385-9b01ae54-60bf-4d33-aff9-c617aad6ff33.png">
