### PR TITLE
update archived marker to use nicer date format

### DIFF
--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -11,6 +11,7 @@ import { RouteComponentProps } from "react-router"
 import { useLocation } from "react-router-dom"
 import { recipeURL } from "@/urls"
 import { pathNamesEqual } from "@/utils/url"
+import { formatHumanDate } from "@/date"
 import { replace } from "connected-react-router"
 
 import {
@@ -310,11 +311,11 @@ const ArchiveMessage = styled.div`
 `
 
 function ArchiveBanner({ date }: { readonly date: Date }) {
-  const formattedDate = date.toLocaleDateString()
+  const formattedDate = formatHumanDate(date, false)
   return (
     <div className="d-flex align-items-center">
       <hr className="flex-grow mb-0 mt-0" />
-      <ArchiveMessage>Recipe Archived on {formattedDate}</ArchiveMessage>
+      <ArchiveMessage>Archived {formattedDate}</ArchiveMessage>
       <hr className="flex-grow mb-0 mt-0" />
     </div>
   )

--- a/frontend/src/components/Recipe.tsx
+++ b/frontend/src/components/Recipe.tsx
@@ -311,7 +311,7 @@ const ArchiveMessage = styled.div`
 `
 
 function ArchiveBanner({ date }: { readonly date: Date }) {
-  const formattedDate = formatHumanDate(date, false)
+  const formattedDate = formatHumanDate(date)
   return (
     <div className="d-flex align-items-center">
       <hr className="flex-grow mb-0 mt-0" />

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -68,3 +68,31 @@ export function formatHumanDateTimeRaw(date: Date, now: Date): string {
 export function formatHumanDateTime(date: Date): string {
   return formatHumanDateTimeRaw(date, new Date())
 }
+
+export function formatAbsoluteDate(
+  date: Date,
+  options?: { readonly includeYear?: boolean },
+): string {
+  if (options?.includeYear) {
+    return format(date, "MMM d, yyyy")
+  }
+  return format(date, "MMM d")
+}
+
+function formatHumanDateRaw(date: Date, now: Date): string {
+  if (!isSameYear(date, now)) {
+    return formatAbsoluteDate(date, { includeYear: true })
+  }
+  if (isSameDay(date, now)) {
+    return "Today"
+  }
+  const withinNineMonths = Math.abs(differenceInMonths(date, now)) < 9
+  if (withinNineMonths) {
+    return formatAbsoluteDate(date)
+  }
+  return formatAbsoluteDate(date, { includeYear: true })
+}
+
+export function formatHumanDate(date: Date): string {
+  return formatHumanDateRaw(date, new Date())
+}


### PR DESCRIPTION
This is like the formatDateTime, but includes only the date portion. Relative dates say "Today" instead of "10 minutes ago"