### PR TITLE
fix(ios): Find On Page not working for ingredients

### DIFF
--- a/frontend/src/browser.ts
+++ b/frontend/src/browser.ts
@@ -1,0 +1,4 @@
+export function isMobile(): boolean {
+  // via: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_device_detection
+  return /mobi/i.test(navigator.userAgent)
+}

--- a/frontend/src/components/Ingredient.tsx
+++ b/frontend/src/components/Ingredient.tsx
@@ -7,6 +7,7 @@ import { TextInput, selectTarget, CheckBox } from "@/components/Forms"
 import { hasSelection } from "@/utils/general"
 import { useDrop, useDrag } from "react-dnd"
 import { DragDrop, handleDndHover } from "@/dragDrop"
+import { isMobile } from "@/browser"
 
 const emptyField = ({
   quantity,
@@ -222,7 +223,8 @@ export function Ingredient(props: {
     }),
   })
 
-  const dragAndDropEnabled = props.completeMove != null && props.move != null
+  const dragAndDropEnabled =
+    props.completeMove != null && props.move != null && !isMobile()
 
   const style = {
     opacity: isDragging ? 0 : 1,


### PR DESCRIPTION
Find On Page in Safari for iOS won't find text that is inside an element
marked `draggable="true"`

Since the current drag and drop doesn't work on iOS, we disable it entirely
to prevent writing the `draggable` prop.

https://bugs.webkit.org/show_bug.cgi?id=234716
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable