### PR TITLE
ref(ui): hide team list & team invites behind a dropdown in the nav

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -16,6 +16,7 @@ import Recipe from "@/components/Recipe"
 import PasswordReset from "@/containers/PasswordReset"
 import Settings from "@/containers/Settings"
 import Team from "@/containers/Team"
+import Teams from "@/components/Teams"
 import TeamInvite from "@/components/TeamInvite"
 import TeamCreate from "@/components/TeamCreate"
 import AddRecipe from "@/containers/AddRecipe"
@@ -183,6 +184,7 @@ function Base() {
                       component={Team}
                     />
                     <Route exact path="/t/:id(\d+)(.*)" component={Team} />
+                    <Route exact path="/t/" component={Teams} />
                     <Route component={NoMatch} />
                   </Switch>
                 </Container>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -5,7 +5,7 @@ const StyledFooter = styled.footer`
   font-weight: bold;
   padding: 1rem 1.5rem;
   display: flex;
-  justify-content: space-between;
+  align-items: center;
   margin-top: auto;
 `
 
@@ -14,7 +14,6 @@ const Footer = () => (
     <span>
       Recipe Yak • <a href="https://github.com/recipeyak/recipeyak">src</a>
     </span>
-    <span>Est. 2017</span>
   </StyledFooter>
 )
 

--- a/frontend/src/components/Invites.tsx
+++ b/frontend/src/components/Invites.tsx
@@ -10,12 +10,6 @@ import {
 
 import { teamURL } from "@/urls"
 import { getInvites, IInvite } from "@/store/reducers/invites"
-import {
-  DropdownContainer,
-  useDropdown,
-  DropdownMenu,
-} from "@/components/Dropdown"
-import { Chevron } from "@/components/icons"
 import { useDispatch, useSelector } from "@/hooks"
 import { isLoading, isFailure, isInitial } from "@/webdata"
 import { ITeam } from "@/store/reducers/teams"
@@ -80,7 +74,7 @@ function TeamName({ teamId, name, active }: ITeamNameProps) {
   }
   return <b>{name}</b>
 }
-function Invites() {
+export function Invites() {
   const { invites } = useNotifications()
   if (isLoading(invites) || isInitial(invites)) {
     return <p className="text-muted text-small align-self-center">Loading...</p>
@@ -117,21 +111,5 @@ function Invites() {
         )
       })}
     </div>
-  )
-}
-
-export function NotificationsDropdown() {
-  const { ref, toggle, isOpen } = useDropdown()
-  return (
-    <DropdownContainer ref={ref}>
-      <a onClick={toggle} tabIndex={0} className="better-nav-item">
-        <span>Notifications</span>
-        <Chevron />
-      </a>
-
-      <DropdownMenu isOpen={isOpen}>
-        <Invites />
-      </DropdownMenu>
-    </DropdownContainer>
   )
 }

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -3,22 +3,19 @@ import { Link } from "react-router-dom"
 
 import NavLink from "@/containers/NavLink"
 import Logo from "@/components/Logo"
-import { NotificationsDropdown } from "@/components/NotificationsDropdown"
 import { UserDropdown } from "@/components/UserDropdown"
 
-import { teamURL } from "@/urls"
 import { styled } from "@/theme"
 import {
   DropdownContainer,
-  useDropdown,
   DropdownMenu,
+  useDropdown,
 } from "@/components/Dropdown"
 import { Chevron } from "@/components/icons"
 import { lighten } from "polished"
 import { useSelector, useDispatch } from "@/hooks"
-import { scheduleURLFromTeamID, teamsFrom } from "@/store/mapState"
-import { fetchingTeamsAsync, fetchingUserAsync } from "@/store/thunks"
-import { Loading, Success, isLoading, isFailure, isInitial } from "@/webdata"
+import { scheduleURLFromTeamID } from "@/store/mapState"
+import { fetchingUserAsync } from "@/store/thunks"
 
 const WordMarkContainer = styled.span`
   font-size: 1.5rem;
@@ -29,48 +26,6 @@ const WordMarkContainer = styled.span`
 
 function WordMark() {
   return <WordMarkContainer>Recipe Yak</WordMarkContainer>
-}
-
-function useTeams() {
-  const dispatch = useDispatch()
-  React.useEffect(() => {
-    fetchingTeamsAsync(dispatch)()
-  }, [dispatch])
-  const loading = useSelector(
-    s => s.teams.status === "loading" || s.teams.status === "initial",
-  )
-  const teams = useSelector(teamsFrom)
-  if (loading) {
-    return Loading()
-  }
-  return Success(teams)
-}
-
-function Teams() {
-  const teams = useTeams()
-  if (isLoading(teams) || isInitial(teams)) {
-    return <p>Loading...</p>
-  }
-
-  if (isFailure(teams)) {
-    return <p>failure loading</p>
-  }
-
-  if (teams.data.length === 0) {
-    return <p className="text-muted text-small align-self-center">No teams.</p>
-  }
-
-  return (
-    <div className="text-left">
-      {teams.data.map(({ id, name }) => (
-        <p key={id}>
-          <NavLink to={teamURL(id, name)} activeClassName="fw-500">
-            {name}
-          </NavLink>
-        </p>
-      ))}
-    </div>
-  )
 }
 
 interface INavButtonContainerProps {
@@ -122,24 +77,6 @@ const DropDownButtonContainer = styled.a`
   }
 `
 
-function TeamsDropdown() {
-  const { ref, toggle, isOpen } = useDropdown()
-  return (
-    <DropdownContainer ref={ref}>
-      <a onClick={toggle} tabIndex={0} className="better-nav-item">
-        <span>Teams</span>
-        <Chevron />
-      </a>
-      <DropdownMenu isOpen={isOpen}>
-        <Teams />
-        <Link to="/t/create" className="mt-1 ">
-          Create a Team
-        </Link>
-      </DropdownMenu>
-    </DropdownContainer>
-  )
-}
-
 interface IDropDownButtonProps {
   readonly onClick: () => void
 }
@@ -164,6 +101,39 @@ function AuthButtons() {
   )
 }
 
+function IconThreeDots() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 16 16">
+      <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z" />
+    </svg>
+  )
+}
+
+function MoreDropdown() {
+  const { ref, toggle, isOpen, close } = useDropdown()
+  return (
+    <DropdownContainer ref={ref} className="d-flex justify-content-center">
+      <a onClick={toggle} tabIndex={0} className="better-nav-item">
+        <IconThreeDots />
+      </a>
+      <DropdownMenu isOpen={isOpen} style={{ top: 30 }}>
+        <NavLink
+          to="/t/"
+          onClick={close}
+          activeClassName="active"
+          className="better-nav-item">
+          Teams
+        </NavLink>
+      </DropdownMenu>
+    </DropdownContainer>
+  )
+}
+
 function NavButtons() {
   const scheduleURL = useSelector(scheduleURLFromTeamID)
   const { ref, isOpen, close, toggle } = useDropdown()
@@ -172,6 +142,8 @@ function NavButtons() {
       <DropdownContainer ref={ref}>
         <DropDownButton onClick={toggle} />
         <NavButtonContainer show={isOpen}>
+          <MoreDropdown />
+
           <NavLink
             to="/recipes/add"
             onClick={close}
@@ -179,8 +151,6 @@ function NavButtons() {
             className="better-nav-item">
             Add
           </NavLink>
-          <TeamsDropdown />
-          <NotificationsDropdown />
           <NavLink
             to="/recipes"
             onClick={close}

--- a/frontend/src/components/Teams.tsx
+++ b/frontend/src/components/Teams.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { useSelector, useDispatch } from "@/hooks"
+import { fetchingTeamsAsync } from "@/store/thunks"
+import { Loading, Success, isInitial, isFailure, isLoading } from "@/webdata"
+import { NavLink } from "react-router-dom"
+import { teamURL } from "@/urls"
+import { teamsFrom } from "@/store/mapState"
+import { Link } from "@/components/Routing"
+import { Invites } from "@/components/Invites"
+
+function useTeams() {
+  const dispatch = useDispatch()
+  React.useEffect(() => {
+    fetchingTeamsAsync(dispatch)()
+  }, [dispatch])
+  const loading = useSelector(
+    s => s.teams.status === "loading" || s.teams.status === "initial",
+  )
+  const teams = useSelector(teamsFrom)
+  if (loading) {
+    return Loading()
+  }
+  return Success(teams)
+}
+
+function TeamsList() {
+  const teams = useTeams()
+  if (isLoading(teams) || isInitial(teams)) {
+    return <p>Loading...</p>
+  }
+
+  if (isFailure(teams)) {
+    return <p>failure loading</p>
+  }
+
+  if (teams.data.length === 0) {
+    return <p className="text-muted text-small align-self-center">No teams.</p>
+  }
+
+  return (
+    <div className="text-left">
+      {teams.data.map(({ id, name }) => (
+        <p key={id}>
+          <NavLink to={teamURL(id, name)} activeClassName="fw-500">
+            {name}
+          </NavLink>
+        </p>
+      ))}
+    </div>
+  )
+}
+
+export default function TeamsPage() {
+  return (
+    <div style={{ maxWidth: 800 }} className="mx-auto mw-800">
+      <section className="d-flex justify-space-between align-items-center">
+        <h2 className="fs-6">Teams</h2>
+        <Link to="/t/create" className="mt-1 ">
+          Create a Team
+        </Link>
+      </section>
+
+      <TeamsList />
+
+      <div>
+        <h2 className="fs-6">Invites</h2>
+        <Invites />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/scss/ListItem.scss
+++ b/frontend/src/components/scss/ListItem.scss
@@ -6,7 +6,7 @@
 .listitem-text {
   white-space: pre-wrap;
   line-height: 1.25rem;
-  padding-bottom: 0.25rem;
+  padding-bottom: 0.4rem;
   .on-hover {
     display: none;
   }

--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -203,16 +203,11 @@
   grid-row: 1;
 }
 
-.max-width-200px {
-  max-width: 200px;
-}
-
-.max-width-400px {
-  max-width: 400px;
-}
-
-.mw-1000px {
-  max-width: 1000px !important;
+@each $i in (200px, 400px, 800px, 1000px) {
+  .mw-#{$i},
+  .max-width-#{$i} {
+    max-width: $i !important;
+  }
 }
 
 @for $i from 0 through 16 {

--- a/frontend/src/containers/Team.ts
+++ b/frontend/src/containers/Team.ts
@@ -28,9 +28,7 @@ const mapStateToProps = (state: IState, props: RouteProps) => {
   const teamMembers = Object.values(members).filter(notUndefined)
 
   const loadingTeam = team ? !!team.loadingTeam && !team.name : false
-  const loadingMembers = team
-    ? !!team.loadingMembers && teamMembers.length === 0
-    : false
+  const loadingMembers = team?.loadingMembers ?? true
 
   return {
     id,


### PR DESCRIPTION
We hardly ever use these so might as well hide them away.

The new and existing teams related pages are really crufty, but we never use them so fine for now.