### PR TITLE
fix incorrect object serialization for timeline items

### DIFF
--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -206,7 +206,8 @@ def test_recipe_archived_at(client, user, recipe):
     assert len(res.json()) == 1
     assert isinstance(res.json()[0]["archived_at"], str), "should be a date string"
     assert all(
-        item["created_by"]["email"] == user.email for item in res.json()[0]["timelineItems"]
+        item["created_by"]["email"] == user.email
+        for item in res.json()[0]["timelineItems"]
     ), "should have user email"
 
     assert (

--- a/backend/core/recipes/test_recipes.py
+++ b/backend/core/recipes/test_recipes.py
@@ -205,6 +205,9 @@ def test_recipe_archived_at(client, user, recipe):
     assert res.status_code == status.HTTP_200_OK
     assert len(res.json()) == 1
     assert isinstance(res.json()[0]["archived_at"], str), "should be a date string"
+    assert all(
+        item["created_by"]["email"] == user.email for item in res.json()[0]["timelineItems"]
+    ), "should have user email"
 
     assert (
         TimelineEvent.objects.count()

--- a/backend/core/recipes/views.py
+++ b/backend/core/recipes/views.py
@@ -171,7 +171,6 @@ class RecipeViewSet(viewsets.ModelViewSet):
                     email=email,
                     avatar_url=get_avatar_url(email),
                 )
-            event.pop("created_by", None)
             event.pop("created_by__email", None)
             event["type"] = "recipe"
             timeline_events[event["recipe_id"]].append(event)


### PR DESCRIPTION
This was causing a flash when loading a recipe after viewing the recipe list view. The "created" and "archived" timeline views would start with null users and then flash with the actual user after loading the detail view.

io-ts would have prevented this nonsense.