### PR TITLE
fix(ui): calendar modal ids

### DIFF
--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -142,7 +142,7 @@ function CalendarDay({
       const item = dropped as ICalendarDragItem | IRecipeItemDrag
       // TOOD(sbdchd): We should move this logic into the calendar reducer
       if (item.type === DragDrop.CAL_RECIPE) {
-        move({ id: item.id, teamID, to: date })
+        move({ id: item.scheduledId, teamID, to: date })
       } else if (item.type === DragDrop.RECIPE) {
         create({ recipeID: item.recipeID, teamID, on: date, count: 1 })
       }

--- a/frontend/src/components/CalendarDay.tsx
+++ b/frontend/src/components/CalendarDay.tsx
@@ -172,7 +172,7 @@ function CalendarDay({
         {scheduled.map(x => (
           <CalendarItem
             key={x.id}
-            id={x.id}
+            scheduledId={x.id}
             date={date}
             recipeName={x.recipe.name}
             recipeID={x.recipe.id}

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -201,6 +201,9 @@ export function CalendarItem({
 }
 
 export interface ICalendarDragItem
-  extends Pick<ICalendarItemProps, "recipeID" | "count" | "scheduledId" | "date"> {
+  extends Pick<
+    ICalendarItemProps,
+    "recipeID" | "count" | "scheduledId" | "date"
+  > {
   readonly type: DragDrop.CAL_RECIPE
 }

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -146,7 +146,7 @@ export function CalendarItem({
     type: DragDrop.CAL_RECIPE,
     recipeID,
     count,
-    id: scheduledId,
+    scheduledId,
     date,
   }
 
@@ -201,6 +201,6 @@ export function CalendarItem({
 }
 
 export interface ICalendarDragItem
-  extends Pick<ICalendarItemProps, "recipeID" | "count" | "id" | "date"> {
+  extends Pick<ICalendarItemProps, "recipeID" | "count" | "scheduledId" | "date"> {
   readonly type: DragDrop.CAL_RECIPE
 }

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -188,9 +188,10 @@ export function CalendarItem({
       </CalendarListItem>
       {show ? (
         <CalendarDayItemModal
-          id={id}
+          scheduledId={id}
           teamID={teamID}
           recipeName={recipeName}
+          recipeId={recipeID}
           date={date}
           onClose={() => setShow(false)}
         />

--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -81,7 +81,7 @@ export interface ICalendarItemProps {
   readonly date: Date
   readonly recipeID: IRecipe["id"] | string
   readonly recipeName: IRecipe["name"]
-  readonly id: ICalRecipe["id"]
+  readonly scheduledId: ICalRecipe["id"]
   readonly teamID: TeamID
 }
 
@@ -94,7 +94,7 @@ export function CalendarItem({
   recipeName,
   recipeID,
   teamID,
-  id,
+  scheduledId,
 }: ICalendarItemProps) {
   const [count, setCount] = React.useState(propsCount)
   const ref = React.useRef<HTMLLIElement>(null)
@@ -146,7 +146,7 @@ export function CalendarItem({
     type: DragDrop.CAL_RECIPE,
     recipeID,
     count,
-    id,
+    id: scheduledId,
     date,
   }
 
@@ -188,7 +188,7 @@ export function CalendarItem({
       </CalendarListItem>
       {show ? (
         <CalendarDayItemModal
-          scheduledId={id}
+          scheduledId={scheduledId}
           teamID={teamID}
           recipeName={recipeName}
           recipeId={recipeID}

--- a/frontend/src/components/CalendarDayItemModal.tsx
+++ b/frontend/src/components/CalendarDayItemModal.tsx
@@ -22,13 +22,15 @@ const options = [
 ] as const
 
 export function CalendarDayItemModal({
-  id,
+  scheduledId,
   recipeName,
+  recipeId,
   teamID,
   date,
   onClose,
 }: {
-  readonly id: number
+  readonly scheduledId: number
+  readonly recipeId: number | string
   readonly teamID: TeamID
   readonly recipeName: string
   readonly date: Date
@@ -59,7 +61,7 @@ export function CalendarDayItemModal({
   const handleDelete = () => {
     if (confirm(`Are you sure you want to delete '${recipeName}'?`)) {
       setDeleting(true)
-      api.deleteScheduledRecipe(id, teamID).then(() => {
+      api.deleteScheduledRecipe(scheduledId, teamID).then(() => {
         setDeleting(false)
         onClose()
       })
@@ -68,10 +70,17 @@ export function CalendarDayItemModal({
   const handleSave = () => {
     setSaving(true)
     api
-      .updateScheduleRecipe(id, teamID, { on: toISODateString(localDate) })
+      .updateScheduleRecipe(scheduledId, teamID, {
+        on: toISODateString(localDate),
+      })
       .then(res => {
         if (isOk(res)) {
-          dispatch(moveCalendarRecipe({ id, to: toISODateString(res.data.on) }))
+          dispatch(
+            moveCalendarRecipe({
+              id: scheduledId,
+              to: toISODateString(res.data.on),
+            }),
+          )
           setSaving(false)
           onClose()
         }
@@ -79,7 +88,7 @@ export function CalendarDayItemModal({
       })
   }
 
-  const to = recipeURL(id, recipeName)
+  const to = recipeURL(recipeId, recipeName)
 
   return (
     <Modal show onClose={onClose} style={{ maxWidth: 400 }}>


### PR DESCRIPTION
We were using the scheduled item ids instead of the recipe ids.
Many 404s were had, whoops!