### PR TITLE
fix(ui): shift & command clicking cal recipe links

### DIFF
--- a/frontend/src/components/CalendarDayItem.tsx
+++ b/frontend/src/components/CalendarDayItem.tsx
@@ -180,6 +180,9 @@ export function CalendarItem({
           name={recipeName}
           id={recipeID}
           onClick={e => {
+            if (e.shiftKey || e.metaKey) {
+              return
+            }
             e.preventDefault()
             setShow(true)
           }}


### PR DESCRIPTION
Instead of opening the modal, they'll use the default browser behavior.