### PR TITLE
fix(api): vscode flake8 errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,10 @@
     "tox.ini"
   ],
   "python.linting.flake8Enabled": true,
-  "python.linting.flake8Args": ["--config", "tox.ini"],
+  "python.linting.flake8Args": [
+    "--config",
+    "${workspaceFolder}/backend/tox.ini"
+  ],
   "python.testing.pytestArgs": ["backend"],
   "python.testing.unittestEnabled": false,
   "python.testing.nosetestsEnabled": false,


### PR DESCRIPTION
VSCode was using relative paths for the tox.ini config file, so opening vscode at the root of the repo wouldn't work -- we'd get a ton of flake8 errors that we've already ignored.