### PR TITLE
ui(schedule): workaround react-dnd bug

### DIFF
--- a/frontend/src/components/RecipeItem.tsx
+++ b/frontend/src/components/RecipeItem.tsx
@@ -72,7 +72,6 @@ export function RecipeItem({
   const [{ isDragging }, drag] = useDrag({
     type: DragDrop.RECIPE,
     item,
-    options: { dropEffect: "copy" },
     canDrag: () => {
       return !!props.drag
     },


### PR DESCRIPTION
We're hitting https://github.com/react-dnd/react-dnd/issues/3345#issuecomment-1105475910 with the drag and drop dropEffect.

https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect

Easy enough to remove the options, they didn't seem to do anything anyways.