### PR TITLE
ref(ci): store test results for vitest & pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,9 @@ jobs:
       - run:
           name: run tests
           working_directory: frontend
-          command: ./s/test
+          command: ./s/test --no-watch --reporter junit --outputFile ~/test-results/frontend_test.xml
+      - store_test_results:
+          path: ~/test-results
 
   frontend_lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
       - run:
           name: run tests
           working_directory: backend
-          command: ./s/test --junitxml=test-results/backend_tests.xml
+          command: ./s/test --junitxml=~/test-results/backend_tests.xml
       - store_test_results:
-          path: test-results
+          path: ~/test-results
 
   backend_lint:
     docker:
@@ -146,9 +146,9 @@ jobs:
       - run:
           name: run tests
           working_directory: frontend
-          command: ./s/test --no-watch --reporter junit --outputFile test-results/frontend_tests.xml
+          command: ./s/test --no-watch --reporter junit --outputFile ~/test-results/frontend_tests.xml
       - store_test_results:
-          path: test-results
+          path: ~/test-results
 
   frontend_lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
       - run:
           name: run tests
           working_directory: backend
-          command: ./s/test
+          command: ./s/test --junitxml=test-results/backend_tests.xml
       - store_test_results:
-          path: reports
+          path: test-results
 
   backend_lint:
     docker:
@@ -146,9 +146,9 @@ jobs:
       - run:
           name: run tests
           working_directory: frontend
-          command: ./s/test --no-watch --reporter junit --outputFile ~/test-results/frontend_test.xml
+          command: ./s/test --no-watch --reporter junit --outputFile test-results/frontend_tests.xml
       - store_test_results:
-          path: ~/test-results
+          path: test-results
 
   frontend_lint:
     docker:


### PR DESCRIPTION
We don't really need to do this, just thought it would be interesting.

https://circleci.com/blog/how-to-output-junit-tests-through-circleci-2-0-for-expanded-insights/

https://circleci.com/docs/collect-test-data#pytest

<img width="149" alt="image" src="https://user-images.githubusercontent.com/7340772/185530756-589aeb45-cab9-4a4b-baba-12a96fa877db.png">

<img width="148" alt="image" src="https://user-images.githubusercontent.com/7340772/185530770-7182ce08-372a-45e6-82e5-6ce023bcdf2e.png">
