### PR TITLE
ref(api): last_viewed_at should always update

### DIFF
--- a/backend/core/recipes/views/__init__.py
+++ b/backend/core/recipes/views/__init__.py
@@ -106,12 +106,7 @@ class RecipeViewSet(viewsets.ModelViewSet):
                 ON CONFLICT
                 ON CONSTRAINT one_user_view_row_per_recipe
                 DO UPDATE SET
-                    last_visited_at =
-                        CASE WHEN recipe_view.last_visited_at < now() - '1 hour'::interval THEN
-                            now()
-                        ELSE
-                            recipe_view.last_visited_at
-                        END,
+                    last_visited_at = now(),
                     count =
                         CASE WHEN recipe_view.last_visited_at < now() - '1 hour'::interval THEN
                             recipe_view.count + 1


### PR DESCRIPTION
Basically if you click one of the recently viewed recipes, viewing it should always update its position.
Updating count is still bucketed to the hour, but I think last_modified_at should always be updated.