### PR TITLE
add(ui): mobile scheduling

### DIFF
--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -186,3 +186,7 @@ export function useApi<A, O, T>(
 export function useCurrentUser() {
   return useSelector((s) => s.user)
 }
+
+export function useTeamId(): number | "personal" {
+  return useSelector((state) => state.user.recipeTeamID) ?? "personal"
+}

--- a/frontend/src/pages/recipe-detail/RecipeTitle.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeTitle.tsx
@@ -9,6 +9,7 @@ import GlobalEvent from "@/components/GlobalEvent"
 import MetaData from "@/pages/recipe-detail/MetaData"
 import Owner from "@/pages/recipe-detail/Owner"
 import { Dropdown } from "@/pages/recipe-detail/RecipeTitleDropdown"
+import { ScheduleModal } from "@/pages/recipe-detail/ScheduleModal"
 import {
   IRecipe,
   toggleEditingRecipe,
@@ -95,6 +96,7 @@ export interface IRecipeBasic {
 interface IRecipeTitleState {
   readonly show: boolean
   readonly recipe: IRecipeBasic
+  readonly showScheduleModal: boolean
 }
 
 class RecipeTitle extends React.Component<
@@ -104,6 +106,7 @@ class RecipeTitle extends React.Component<
   state: IRecipeTitleState = {
     show: false,
     recipe: {},
+    showScheduleModal: false,
   }
 
   componentDidMount() {
@@ -167,15 +170,27 @@ class RecipeTitle extends React.Component<
     }))
   }
 
+  handleScheduleToggle = () => {
+    this.setState((s) => ({ ...s, showScheduleModal: !s.showScheduleModal }))
+  }
+
   render() {
     const { id, name, author, source, servings, tags, time, owner, updating } =
       this.props
 
     const ownerName = owner.type === "team" ? owner.name : "you"
+
     return (
       <div>
         <div className="grid-entire-row d-flex justify-space-between p-rel">
           <GlobalEvent keyUp={this.handleGlobalKeyUp} />
+          {this.state.showScheduleModal && (
+            <ScheduleModal
+              recipeId={id}
+              recipeName={name}
+              onClose={this.handleScheduleToggle}
+            />
+          )}
           {!this.props.editing ? (
             <div className="d-flex align-items-center">
               <h1
@@ -204,6 +219,7 @@ class RecipeTitle extends React.Component<
             recipeId={id}
             editingEnabled={this.props.editingModeEnabled}
             toggleEditing={this.props.toggleEditMode}
+            toggleScheduling={this.handleScheduleToggle}
           />
         </div>
 

--- a/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/Dropdown"
 import { Chevron } from "@/components/icons"
 import { useDispatch, useSelector } from "@/hooks"
-import { scheduleURLFromTeamID } from "@/store/mapState"
 import {
   deleteRecipe,
   duplicateRecipe,
@@ -22,10 +21,6 @@ import {
 } from "@/store/reducers/recipes"
 import { showNotificationWithTimeoutAsync } from "@/store/thunks"
 import { isSuccessLike } from "@/webdata"
-
-function useScheduleUrl(recipeId: number) {
-  return useSelector(scheduleURLFromTeamID) + `?recipeId=${recipeId}`
-}
 
 function ingredientToString(ingre: IIngredient) {
   const s = ingre.quantity + " " + ingre.name
@@ -71,11 +66,13 @@ interface IDropdownProps {
   readonly recipeId: number
   readonly toggleEditing: () => void
   readonly editingEnabled: boolean
+  readonly toggleScheduling: () => void
 }
 export function Dropdown({
   recipeId,
   toggleEditing,
   editingEnabled,
+  toggleScheduling,
 }: IDropdownProps) {
   const { ref, isOpen, toggle, close } = useDropdown()
 
@@ -132,7 +129,10 @@ export function Dropdown({
     }
   }, [dispatch, recipeId])
 
-  const scheduleUrl = useScheduleUrl(recipeId)
+  const handleSchedule = () => {
+    toggleScheduling()
+    close()
+  }
 
   return (
     <DropdownContainer ref={ref}>
@@ -140,9 +140,9 @@ export function Dropdown({
         Actions <Chevron />
       </Button>
       <DropdownMenu isOpen={isOpen}>
-        <DropdownItemLink to={scheduleUrl} onClick={close}>
+        <DropdownItemButton onClick={handleSchedule}>
           Schedule
-        </DropdownItemLink>
+        </DropdownItemButton>
         <DropdownItemButton onClick={handleCopyIngredients}>
           Copy Ingredients
         </DropdownItemButton>

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+import Modal from "@/components/Modal"
+import { toISODateString } from "@/date"
+import { useSelector } from "@/hooks"
+import { scheduleURLFromTeamID } from "@/store/mapState"
+
+function useScheduleUrl(recipeId: number) {
+  return useSelector(scheduleURLFromTeamID) + `?recipeId=${recipeId}`
+}
+
+export function ScheduleModal({
+  recipeName,
+  recipeId,
+  onClose,
+}: {
+  readonly recipeId: number
+  readonly recipeName: string
+  readonly onClose: () => void
+}) {
+  const [localDate, setLocalDate] = React.useState(toISODateString(new Date()))
+  const [saving, setSaving] = React.useState(false)
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocalDate(e.target.value)
+  }
+  const handleSave = () => {
+    setSaving(true)
+  }
+
+  const scheduleUrl = useScheduleUrl(recipeId)
+
+  return (
+    <Modal show onClose={onClose} style={{ maxWidth: 400 }}>
+      <section className="d-flex space-between">
+        <h1 className="fs-5">Schedule: {recipeName}</h1>
+        <button className="delete" onClick={onClose} />
+      </section>
+
+      <div>
+        <div className="mr-2" style={{ display: "grid", gridGap: "0.25rem" }}>
+          <input
+            value={toISODateString(localDate)}
+            onChange={handleDateChange}
+            type="date"
+            className="mr-4 mt-2"
+            style={{
+              border: "1px solid lightgray",
+              borderRadius: 5,
+              padding: "0.25rem",
+            }}
+          />
+        </div>
+
+        <div className="d-flex justify-space-between align-items-center mt-2">
+          <Link to={scheduleUrl} className="text-small">
+            open in schedule
+          </Link>
+          <div className="align-items-center d-flex">
+            <button className="mr-2" onClick={onClose}>
+              cancel
+            </button>
+            <button onClick={handleSave} disabled={saving}>
+              {!saving ? "schedule" : "scheduling..."}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
+import { isMobile } from "@/browser"
 import Modal from "@/components/Modal"
 import { toISODateString } from "@/date"
 import { useSelector } from "@/hooks"
@@ -53,9 +54,13 @@ export function ScheduleModal({
         </div>
 
         <div className="d-flex justify-space-between align-items-center mt-2">
-          <Link to={scheduleUrl} className="text-small">
-            open in schedule
-          </Link>
+          {!isMobile() ? (
+            <Link to={scheduleUrl} className="text-small">
+              open in schedule
+            </Link>
+          ) : (
+            <div />
+          )}
           <div className="align-items-center d-flex">
             <button className="mr-2" onClick={onClose}>
               cancel


### PR DESCRIPTION
<img width="426" alt="image" src="https://user-images.githubusercontent.com/7340772/186326612-48d4a6b2-089b-4a8a-b83a-cfae14dd8587.png">

Previously we only linked to the schedule page with the recipe list filtered to the given recipe, but this didn't work on mobile because the recipe list doesn't show up on mobile.