### PR TITLE
fix(ui): env vars not being passed in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
             docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
             docker build -f react.Dockerfile \
               --tag recipeyak/react:$CIRCLE_SHA1 \
-              --build-arg GIT_SHA=$CIRCLE_SHA1 \
+              --build-arg FRONTEND_GIT_SHA=$CIRCLE_SHA1 \
               --build-arg FRONTEND_SENTRY_DSN=$FRONTEND_SENTRY_DSN .
             docker push recipeyak/react:$CIRCLE_SHA1
 

--- a/frontend/react.Dockerfile
+++ b/frontend/react.Dockerfile
@@ -12,7 +12,7 @@ RUN yarn install
 COPY . /var/app/
 
 ARG FRONTEND_SENTRY_DSN
-ARG GIT_SHA
+ARG FRONTEND_GIT_SHA
 
 RUN s/build
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -3,7 +3,9 @@
 export const DEBUG = import.meta.env.DEV
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-export const GIT_SHA: string = DEBUG ? "development" : import.meta.env.GIT_SHA
+export const GIT_SHA: string = DEBUG
+  ? "development"
+  : import.meta.env.FRONTEND_GIT_SHA
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 export const SENTRY_DSN: string = import.meta.env.FRONTEND_SENTRY_DSN

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     // see: https://github.com/btd/rollup-plugin-visualizer/issues/96
     visualizer(),
   ],
+  envPrefix: "FRONTEND_",
   resolve: {
     alias: [
       {


### PR DESCRIPTION
vite will only pass in env vars to the build that have a given prefix.
This defaults to `VITE_` so we update the config to use `FRONTEND_`.

see: https://vitejs.dev/config/shared-options.html#envprefix