### PR TITLE
ref(ui): smaller nav items, rename schedule tab

### DIFF
--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { assertNever } from "@/assert"
 import { classNames } from "@/classnames"
 
 export const ButtonLink = (props: IButtonProps) => (
@@ -29,7 +30,7 @@ export const ButtonSecondary = (props: IButtonProps) => (
 
 interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   readonly loading?: boolean
-  readonly size?: "small" | "normal" | "medium" | "large"
+  readonly size?: "small" | "normal"
 }
 export const ButtonPlain = ({
   loading = false,
@@ -38,13 +39,19 @@ export const ButtonPlain = ({
   children,
   ...props
 }: IButtonProps) => {
-  const buttonSize = "is-" + size
+  const buttonSize =
+    size === "small"
+      ? "is-small"
+      : size === "normal"
+      ? "is-normal"
+      : assertNever(size)
   return (
     <button
       {...props}
       disabled={loading}
-      className={classNames("my-button", className, buttonSize, {
+      className={classNames("my-button", "br-6", className, buttonSize, {
         "is-loading": loading,
+        "fs-14px": size === "small",
       })}
     >
       {children}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -219,7 +219,7 @@ function NavButtons() {
             activeClassName="active"
             className="better-nav-item"
           >
-            Schedule
+            Calendar
           </NavLink>
         </NavButtonContainer>
       </DropdownContainer>

--- a/frontend/src/components/scss/nav.scss
+++ b/frontend/src/components/scss/nav.scss
@@ -33,7 +33,7 @@
   display: flex;
   flex-grow: 0;
   flex-shrink: 0;
-  font-size: 1rem;
+  font-size: 14px;
   justify-content: center;
   line-height: 1.5;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
Rename schedule to calendar so it's clear it's not for scheduling the current recipe

Also make the nav items smaller so they don't seem like primary actions

Minor change to buttons to be a little more round