### PR TITLE
fix(ui): calendar nav style regression

### DIFF
--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -51,7 +51,6 @@ export const ButtonPlain = ({
       disabled={loading}
       className={classNames("my-button", "br-6", className, buttonSize, {
         "is-loading": loading,
-        "fs-14px": size === "small",
       })}
     >
       {children}

--- a/frontend/src/components/Forms.tsx
+++ b/frontend/src/components/Forms.tsx
@@ -100,7 +100,7 @@ export function Select({
 }: ISelectProps) {
   const inputSize = "is-" + size
   const multipleClass = multiple ? "is-multiple" : ""
-  const selectClass = noBorder ? "my-select" : ""
+  const selectClass = noBorder ? "my-select" : "br-6"
   return (
     <div className={`select ${inputSize} ${multipleClass} ${className}`}>
       <select className={selectClass} multiple={multiple} {...props} />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -100,7 +100,7 @@ const DropDownButtonContainer = styled.a`
   align-items: center;
   flex-grow: 0;
   flex-shrink: 0;
-  font-size: 1rem;
+  font-size: 14px;
   justify-content: center;
   line-height: 1.5;
   padding: 0.5rem 0.75rem;

--- a/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
@@ -136,7 +136,7 @@ export function Dropdown({
 
   return (
     <DropdownContainer ref={ref}>
-      <Button size="small" onClick={toggle}>
+      <Button size="small" className="fs-14px" onClick={toggle}>
         Actions <Chevron />
       </Button>
       <DropdownMenu isOpen={isOpen}>


### PR DESCRIPTION
Adding the fs-14px also updated all the buttons which made the calendar nav look weird.

This reverts that change so we only adjust the size on the detail page.