### PR TITLE
ref(ui): bold ingredient quantities

### DIFF
--- a/backend/core/cumin/quantity.py
+++ b/backend/core/cumin/quantity.py
@@ -326,8 +326,8 @@ UNIT_TO_ALIASES: dict[Unit, list[str]] = {
     Unit.TEASPOON: ["tsp", "teaspoon", "teaspoons", "t"],
     Unit.TABLESPOON: ["tablespoon", "tablespoons", "tbs", "T"],
     Unit.POUND: [
+        "pound",
         "pounds",
-        "lbs",
         "lbs",
         "lb",
     ],

--- a/backend/core/cumin/test_quantity.py
+++ b/backend/core/cumin/test_quantity.py
@@ -228,6 +228,13 @@ def test_adding_incompatible_units() -> None:
             ("2 pounds", "boneless skinless chicken thighs"),
         ),
         (
+            "1 pound rigatoni or another ridged dried pasta, or fresh pappardelle or tagliatelle",
+            (
+                "1 pound",
+                "rigatoni or another ridged dried pasta, or fresh pappardelle or tagliatelle",
+            ),
+        ),
+        (
             "Chopped fresh parsley, for serving (optional)",
             ("", "Chopped fresh parsley, for serving (optional)"),
         ),

--- a/frontend/src/pages/recipe-detail/IngredientView.tsx
+++ b/frontend/src/pages/recipe-detail/IngredientView.tsx
@@ -24,7 +24,7 @@ export default function IngredientView({
 
   return (
     <p className="listitem-text justify-space-between" ref={dragRef}>
-      {normalizeUnitsFracs(quantity)} {name}
+      <span className="fw-500">{normalizeUnitsFracs(quantity)}</span> {name}
       {fmtDescription}{" "}
       {optional ? <span className="text-muted">[optional]</span> : ""}
     </p>

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -69,7 +69,7 @@ export function ScheduleModal({
         <div className="d-flex justify-space-between align-items-center mt-2">
           {!isMobile() ? (
             <Link to={scheduleUrl} className="text-small">
-              open in schedule
+              open in calendar
             </Link>
           ) : (
             <div />


### PR DESCRIPTION
Now we bold the ingredient quantities a bit to make it easier to parse -- that's the idea anyway.

Also another schedule -> calendar copy change & a parser fix

Before:
<img width="393" alt="image" src="https://user-images.githubusercontent.com/7340772/190654441-e381184a-ccb2-482d-88d0-8f6d4963b39b.png">


After:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/7340772/190654493-e4851c75-8bea-48e2-b2f1-51dde956fe61.png">



