### PR TITLE
fix(api): scraper parsing of '7 to 8 cups'

### DIFF
--- a/backend/core/cumin/quantity.py
+++ b/backend/core/cumin/quantity.py
@@ -382,7 +382,8 @@ def parse_quantity_name(text: str) -> tuple[str, str]:
                 name += c
             idx += 1
             continue
-        # ensure 7 to 8 cups all is added to the quantity
+        # ensure w/ '7 to 8 cups', the 'to 8` is added to the quantity portion
+        # of the result
         elif in_quantity and c == "t" and value[idx - 1 : idx + 3] == " to ":
             letters = "to "
             quantity += letters

--- a/backend/core/cumin/quantity.py
+++ b/backend/core/cumin/quantity.py
@@ -317,11 +317,11 @@ class IngredientResult:
 
 # TODO(sbdchd): these should be all the units available!!!
 UNIT_TO_ALIASES: dict[Unit, list[str]] = {
-    Unit.CUP: ["cup"],
-    Unit.KILOGRAM: ["kg", "kilogram"],
-    Unit.GRAM: ["gram", "g"],
-    Unit.GALLON: ["gal", "gallon"],
-    Unit.OUNCE: ["oz", "ounce"],
+    Unit.CUP: ["cup", "cups"],
+    Unit.KILOGRAM: ["kg", "kgs", "kilogram", "kilograms"],
+    Unit.GRAM: ["gram", "grams", "g"],
+    Unit.GALLON: ["gal", "gallon", "gallons"],
+    Unit.OUNCE: ["oz", "ounce", "ounces"],
     Unit.MILLILITER: ["millilter", "ml"],
     Unit.TEASPOON: ["tsp", "teaspoon", "teaspoons", "t"],
     Unit.TABLESPOON: ["tablespoon", "tablespoons", "tbs", "T"],
@@ -339,9 +339,11 @@ UNIT_TO_ALIASES: dict[Unit, list[str]] = {
     ],
     Unit.QUART: [
         "quart",
+        "quarts",
     ],
     Unit.LITER: [
         "liter",
+        "liters",
         "l",
     ],
 }
@@ -379,6 +381,12 @@ def parse_quantity_name(text: str) -> tuple[str, str]:
             else:
                 name += c
             idx += 1
+            continue
+        # ensure 7 to 8 cups all is added to the quantity
+        elif in_quantity and c == "t" and value[idx - 1 : idx + 3] == " to ":
+            letters = "to "
+            quantity += letters
+            idx += len(letters)
             continue
         elif c.isspace():
             if in_quantity:

--- a/backend/core/cumin/test_quantity.py
+++ b/backend/core/cumin/test_quantity.py
@@ -224,6 +224,14 @@ def test_adding_incompatible_units() -> None:
             ("1-3 lbs", "ground turkey breast"),
         ),
         (
+            "7 to 8 cups poison",
+            ("7 to 8 cups", "poison"),
+        ),
+        (
+            "3 1/2 cups water",
+            ("3 1/2 cups", "water"),
+        ),
+        (
             "2 pounds boneless skinless chicken thighs",
             ("2 pounds", "boneless skinless chicken thighs"),
         ),


### PR DESCRIPTION
Fix a couple more cases with the recipe scraper's ingredient parsing.