### PR TITLE
add(api): recipe tags in export

### DIFF
--- a/backend/core/export/serializers.py
+++ b/backend/core/export/serializers.py
@@ -21,6 +21,7 @@ class RecipeExportSerializer(BaseModelSerializer):
         model = Recipe
         read_only = True
         fields = (
+            "id",
             "name",
             "author",
             "time",

--- a/backend/core/export/serializers.py
+++ b/backend/core/export/serializers.py
@@ -29,4 +29,5 @@ class RecipeExportSerializer(BaseModelSerializer):
             "ingredients",
             "steps",
             "owner",
+            "tags",
         )

--- a/backend/core/export/test_export.py
+++ b/backend/core/export/test_export.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 import yaml
 from django.test import Client

--- a/backend/core/export/test_export.py
+++ b/backend/core/export/test_export.py
@@ -131,6 +131,7 @@ def test_unicode_issues(c: Client, user: User, recipe: Recipe) -> None:
     regression to prevent unicode encoding issues with pyyaml
     """
     recipe.name = "foo 🦠"
+    recipe.tags = ["foo", "bar"]
     recipe.save()
     url = f"/recipes/{recipe.id}.yaml"
     c.force_login(user)
@@ -156,5 +157,8 @@ steps:
 - Place egg in boiling water and cook for ten minutes
 owner:
   user: john@doe.org
+tags:
+- foo
+- bar
 """
     )

--- a/backend/core/export/test_export.py
+++ b/backend/core/export/test_export.py
@@ -1,5 +1,4 @@
-from typing import Dict, Iterable
-
+from __future__ import annotations
 import pytest
 import yaml
 from django.test import Client
@@ -12,34 +11,6 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def c() -> Client:
     return Client()
-
-
-def fields_in(data: Dict[str, object], fields: Iterable[str]) -> bool:
-    for key, value in data.items():
-        if key in fields:
-            return True
-        if isinstance(value, list):
-            for x in value:
-                if isinstance(x, dict) and fields_in(x, fields=fields):
-                    return True
-        elif isinstance(value, dict):
-            if fields_in(value, fields=fields):
-                return True
-    return False
-
-
-@pytest.mark.parametrize(
-    "dict_,expected",
-    [
-        ({"id": 1}, True),
-        ({"blah": 1}, False),
-        ({"blah": 1, "hmm": [{"id": 1}]}, True),
-        ({"blah": 1, "hmm": [{"blah": 1}]}, False),
-        ({"blah": 1, "hmm": [{"blah": 1}], "owner": {"id": 1}}, True),
-    ],
-)
-def test_fields_in(dict_: Dict[str, object], expected: bool) -> None:
-    assert fields_in(dict_, fields=("id",)) == expected
 
 
 def test_bulk_export_json(
@@ -56,20 +27,6 @@ def test_bulk_export_json(
     recipe2.move_to(user2)
     res = c.get(url)
     assert len(res.json()) == 1, "user should only have their recipes"
-
-
-def test_export_fields(
-    c: Client, user: User, user2: User, recipe: Recipe, recipe2: Recipe
-) -> None:
-    """
-    we don't want to return extraneous fields like position and id
-    """
-    url = "/recipes.json"
-    c.force_login(user)
-    res = c.get(url)
-    assert res.status_code == 200
-    recipes = res.json()
-    assert not any(fields_in(r, fields=("id",)) for r in recipes)
 
 
 @pytest.mark.parametrize("filetype", ["yaml", "yml"])
@@ -138,7 +95,8 @@ def test_unicode_issues(c: Client, user: User, recipe: Recipe) -> None:
     res = c.get(url)
     assert (
         res.content.decode()
-        == """\
+        == f"""\
+id: {recipe.id}
 name: foo 🦠
 author: Recipe author
 time: 1 hour


### PR DESCRIPTION
Trying to test out algolia and `tags` are missing in the export but we use them in the current client side search:

https://github.com/recipeyak/recipeyak/blob/0eb33a59aedfe6737d46db608b47ad87cf5d458c/frontend/src/search.ts#L34-L34

We also need the `id` so we can filter by the id.