### PR TITLE
fix(ui): sort steps in components

### DIFF
--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -213,6 +213,8 @@ function RecipeDetails({
     }
   }, [editingEnabled])
 
+  const steps = sortBy(recipe.steps, (x) => x.position)
+
   return (
     <section className="ingredients-preparation-grid">
       <div>
@@ -281,14 +283,14 @@ function RecipeDetails({
       <div>
         <SectionTitle>Preparation</SectionTitle>
         <StepContainer
-          steps={recipe.steps}
+          steps={steps}
           isEditing={editingEnabled}
           recipeID={recipe.id}
         />
         {addStep ? (
           <AddStep
             id={recipe.id}
-            index={recipe.steps.length + 1}
+            index={steps.length + 1}
             step={recipe.draftStep}
             autoFocus
             onCancel={() => {
@@ -296,7 +298,7 @@ function RecipeDetails({
             }}
             loading={recipe.addingStepToRecipe}
             position={ordering.positionAfter(
-              last(recipe.steps)?.position ?? ordering.FIRST_POSITION,
+              last(steps)?.position ?? ordering.FIRST_POSITION,
             )}
           />
         ) : (


### PR DESCRIPTION
We already sort ingredients now we sort steps as well in the UI since the API doesn't return the steps sorted.


I'm not sure why, but the UI was flipping from unsorted to sorted, but I think this should fix that.


https://user-images.githubusercontent.com/7340772/192419568-1e055d35-33cf-4985-83fd-4e911e69be64.mov

