### PR TITLE
ref(api): cut dead api field 'edits'

### DIFF
--- a/backend/core/recipes/serializers.py
+++ b/backend/core/recipes/serializers.py
@@ -143,7 +143,6 @@ class RecipeSerializer(BaseModelSerializer):
             "timelineItems",
             "sections",
             "servings",
-            "edits",
             "modified",
             "owner",
             "team",

--- a/backend/core/views/recipe_list_view.py
+++ b/backend/core/views/recipe_list_view.py
@@ -56,7 +56,6 @@ def recipe_get_view(request: AuthedRequest) -> Response:
             "source",
             "time",
             "servings",
-            "edits",
             "modified",
             "owner_team",
             "owner_team__name",

--- a/frontend/src/search.test.ts
+++ b/frontend/src/search.test.ts
@@ -12,7 +12,6 @@ function createRecipe(properties?: Partial<IRecipe>): IRecipe {
     steps: [],
     modified: "",
     last_scheduled: "",
-    edits: [],
     team: 10,
     owner: { type: "user", id: 5 },
     ingredients: [],

--- a/frontend/src/store/reducers/recipes.ts
+++ b/frontend/src/store/reducers/recipes.ts
@@ -384,7 +384,6 @@ export interface IRecipeBasic
   extends Omit<
     IRecipe,
     | "id"
-    | "edits"
     | "modified"
     | "last_scheduled"
     | "owner"
@@ -523,7 +522,6 @@ export interface IRecipe {
   readonly time: string
   readonly servings: string | null
   readonly steps: ReadonlyArray<IStep>
-  readonly edits: ReadonlyArray<unknown>
   readonly timelineItems: readonly TimelineItem[]
   readonly modified: string
   readonly last_scheduled: string


### PR DESCRIPTION
We don't use this anymore -- probably haven't in a very very long time since it was typed as `unknown[]` in the UI.