### PR TITLE
fix(ui): search input zoom on mobile

### DIFF
--- a/frontend/src/pages/recipe-list/RecipeList.page.tsx
+++ b/frontend/src/pages/recipe-list/RecipeList.page.tsx
@@ -194,7 +194,7 @@ function RecipesListSearch({
     <div className={cls(noPadding ? "" : "mw-1000px ml-auto mr-auto")}>
       <TextInput
         value={query}
-        className={cls("fs-14px", noPadding ? "" : "mb-2")}
+        className={cls(noPadding ? "" : "mb-2")}
         onChange={handleQueryChange}
         placeholder="search • optionally prepended a tag, 'author:' 'name:' 'ingredient:"
       />


### PR DESCRIPTION
I set the font to 14px for the input but that causes zoom on mobile -- whoops!

https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/

https://stackoverflow.com/questions/6030319/how-to-trigger-iphone-zoom-out-after-auto-zoom-in-to-a-form/33654789#33654789