### PR TITLE
fix(api): scraper accepting compressed data

### DIFF
--- a/backend/core/recipes/scraper.py
+++ b/backend/core/recipes/scraper.py
@@ -98,7 +98,6 @@ def scrape_recipe(*, url: str) -> ScrapeResult:
             stream=True,
             headers={
                 # naive attempt to look like a browser
-                "Accept-Encoding": "gzip, deflate, br",
                 "Host": URL(url).host,
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15",
                 "Accept-Language": "en-US,en;q=0.9",


### PR DESCRIPTION
We shouldn't say we accept compression if we don't handle it.