### PR TITLE
fix(api): ingredient and step ordering for scraper

### DIFF
--- a/backend/core/recipes/scraper.py
+++ b/backend/core/recipes/scraper.py
@@ -140,11 +140,13 @@ def scrape_recipe(*, url: str) -> ScrapeResult:
         instructions=r.instructions_list(),
         author=r.author(),
     )
+    parsed = asdict(scrape_result)
+    del parsed["id"]
     scrape = Scrape.objects.create(
         html=page_data,
         url=url,
         duration_sec=end - start,
-        parsed=asdict(scrape_result),
+        parsed=parsed,
     )
     scrape_result.id = scrape.id
 

--- a/backend/core/views/recipe_list_view.py
+++ b/backend/core/views/recipe_list_view.py
@@ -11,8 +11,8 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from core import ordering
 
+from core import ordering
 from core.cumin.quantity import parse_ingredient
 from core.models import (
     Ingredient,

--- a/backend/core/views/recipe_list_view.py
+++ b/backend/core/views/recipe_list_view.py
@@ -11,6 +11,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from core import ordering
 
 from core.cumin.quantity import parse_ingredient
 from core.models import (
@@ -234,11 +235,12 @@ def recipe_post_view(request: AuthedRequest) -> Response:
         )
 
         ingredients: list[Ingredient] = []
-        for idx, ingredient in enumerate(scrape_result.ingredients):
+        position = ordering.FIRST_POSITION
+        for ingredient in scrape_result.ingredients:
             parsed_ingredient = parse_ingredient(ingredient)
             ingredients.append(
                 Ingredient(
-                    position=idx,
+                    position=position,
                     recipe=recipe,
                     quantity=parsed_ingredient.quantity,
                     name=parsed_ingredient.name,
@@ -246,12 +248,14 @@ def recipe_post_view(request: AuthedRequest) -> Response:
                     optional=parsed_ingredient.optional,
                 )
             )
+            position = ordering.position_after(position)
         Ingredient.objects.bulk_create(ingredients)
 
-        steps = [
-            Step(text=step, position=idx, recipe=recipe)
-            for idx, step in enumerate(scrape_result.instructions)
-        ]
+        steps: list[Step] = []
+        position = ordering.FIRST_POSITION
+        for step in scrape_result.instructions:
+            steps.append(Step(text=step, position=position, recipe=recipe))
+            position = ordering.position_after(position)
         Step.objects.bulk_create(steps)
     else:
         recipe = Recipe.objects.create(owner=team, name=params.name)


### PR DESCRIPTION
I think we should probably have some more clearly defined "one way" to create a recipe row.