### PR TITLE
fix(ui): background color for disabled buttons

### DIFF
--- a/frontend/src/components/scss/buttons.scss
+++ b/frontend/src/components/scss/buttons.scss
@@ -108,6 +108,9 @@
     background-color: $danger;
     border-color: transparent !important;
     color: #fff;
+    &[disabled] {
+      background-color: darken($danger, 20%);
+    }
   }
 
   &.is-primary {
@@ -133,10 +136,12 @@
       border-right-color: transparent;
       border-top-color: transparent;
     }
+    &[disabled] {
+      background-color: darken($primary-color, 20%);
+    }
   }
 
   &[disabled] {
-    background-color: darken($primary-color, 20%);
     color: darken(#fff, 15%);
     cursor: default;
   }

--- a/frontend/src/pages/recipe-detail/ListItem.tsx
+++ b/frontend/src/pages/recipe-detail/ListItem.tsx
@@ -221,7 +221,7 @@ export default class ListItem extends React.Component<
       <div ref={this.element}>
         <section
           className={cls({ "cursor-pointer": this.props.isEditing })}
-          title="click to edit"
+          title={this.props.isEditing ? "click to edit" : undefined}
           onClick={() => {
             if (!this.props.isEditing) {
               return


### PR DESCRIPTION
We were using the primary color as the basis for the background colors of all disabled buttons -- whoops

Also fix an edit mode tooltip that was showing up in non-edit mode.