### PR TITLE
fix(ui): shopping list select

### DIFF
--- a/frontend/src/pages/schedule/ShoppingList.tsx
+++ b/frontend/src/pages/schedule/ShoppingList.tsx
@@ -151,7 +151,7 @@ class ShoppingListList extends React.Component<IShoppingListContainerProps> {
         >
           Copy
         </Button>
-        <section ref={this.shoppingList}>
+        <section ref={this.shoppingList} className="selectable">
           {groups.map(([groupName, values], groupIndex) => {
             values.sort((x, y) => ingredientByNameAlphabetical(x[0], y[0]))
             return (


### PR DESCRIPTION
The `user-select: none` work had a casualty: the shopping list copy.

This PR updates the generated list to be user selectable, which is
necessary for how the copy button works.
