### PR TITLE
fix(api): expanding fractions

### DIFF
--- a/backend/recipeyak/cumin/quantity.py
+++ b/backend/recipeyak/cumin/quantity.py
@@ -43,7 +43,11 @@ def unicode_fractions_to_ascii(s: str) -> str:
 
     output = ""
     for char in s:
-        output += UNICODE_FRACTION_MAPPING.get(char, char)
+        expanded = UNICODE_FRACTION_MAPPING.get(char, char)
+        # ensure 1¾ becomes 1 3/4, not 13/4
+        if output and output[-1].isdigit() and expanded != char:
+            output += " "
+        output += expanded
 
     return output
 

--- a/backend/recipeyak/cumin/test_quantity.py
+++ b/backend/recipeyak/cumin/test_quantity.py
@@ -45,6 +45,10 @@ from recipeyak.cumin.quantity import (
         ("1 pound", Quantity(quantity=Decimal(1), unit=Unit.POUND)),
         ("1 bag", Quantity(quantity=Decimal(1), unit=Unit.UNKNOWN, unknown_unit="bag")),
         (
+            "1¾ cups",
+            Quantity(quantity=Decimal(1.75), unit=Unit.CUP),
+        ),
+        (
             "1 Tablespoon + 1 teaspoon",
             Quantity(quantity=Decimal(4), unit=Unit.TEASPOON),
         ),
@@ -251,6 +255,14 @@ def test_adding_incompatible_units() -> None:
             ("", "Chopped fresh parsley, for serving (optional)"),
         ),
         ("Pinch of ground cardamom", ("Pinch of", "ground cardamom")),
+        (
+            "8 ounces frozen (no need to thaw) or fresh green peas (about 1¾ cups)",
+            # NOTE: parser limitation
+            (
+                "8 ounces",
+                "frozen (no need to thaw) or fresh green peas (about 1 3/4 cups)",
+            ),
+        ),
     ],
 )
 def test_parse_quantity_name(ingredient: str, expected: tuple[str, str]) -> None:


### PR DESCRIPTION
ensure `1¾ cups` expands to `1 3/4 cups`, not `13/4 cups`