### PR TITLE
fix(ui): selecting css on windows

### DIFF
--- a/frontend/src/components/scss/helpers.scss
+++ b/frontend/src/components/scss/helpers.scss
@@ -567,7 +567,7 @@
 }
 
 .selectable {
-  user-select: initial !important;
-  -webkit-user-select: initial !important;
+  user-select: text !important;
+  -webkit-user-select: text !important;
   cursor: auto !important;
 }


### PR DESCRIPTION
Idk if it's windows or Firefox, probably Firefox, but we need to make it user-select: text instead of initial

Stole it from tailwinds which we should probably be using already ugh