### PR TITLE
fix(ui): meta tag ios share

### DIFF
--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -384,6 +384,36 @@ function useRecipeUrlUpdate(recipe: { id: number; name: string } | null) {
 
 type IRecipeProps = RouteComponentProps<{ id: string }>
 
+function Meta({ title }: { title: string }) {
+  React.useEffect(() => {
+    const metaTags = document.querySelectorAll<HTMLMetaElement>(
+      `meta[property="og:title"]`,
+    )
+    if (metaTags.length > 0) {
+      if (metaTags[0].content !== title) {
+        metaTags[0].content = title
+      }
+      // clear out any dupe tags
+      if (metaTags.length > 1) {
+        metaTags.forEach((x, i) => {
+          // we only want one metatag
+          if (i > 0) {
+            x.remove()
+          }
+        })
+      }
+    } else {
+      // setup the missing metatag
+      const metaTag = document.createElement("meta")
+      // NOTE: property is missing from the type
+      metaTag.setAttribute("property", "og:title")
+      metaTag.content = title
+      document.head.appendChild(metaTag)
+    }
+  }, [title])
+  return null
+}
+
 export function Recipe(props: IRecipeProps) {
   const recipeId = parseInt(props.match.params.id, 10)
 
@@ -429,6 +459,7 @@ export function Recipe(props: IRecipeProps) {
   return (
     <div className="d-grid grid-gap-2 mx-auto mw-1000px">
       <Helmet title={recipe.name} />
+      <Meta title={recipe.name} />
       {archivedAt != null && <RecipeBanner>Archived {archivedAt}</RecipeBanner>}
       {editingEnabled && (
         <RecipeBanner>


### PR DESCRIPTION
Add a better `og:title` via some hacky JS so that using the iOS share sheet works well in addition to the unfurling logic for links.

I think ideally we'd render all the meta tags on the server but this is good enough for now

the [react-helmet-async](https://github.com/staylor/react-helmet-async) library we using will create dupe meta tags with the same property name which isn't what we want so we do it ourselves