### PR TITLE
don't remove scheduled recipes on drop of unknown target

### DIFF
--- a/frontend/src/pages/schedule/CalendarDayItem.tsx
+++ b/frontend/src/pages/schedule/CalendarDayItem.tsx
@@ -163,13 +163,8 @@ export function CalendarItem({
   const [{ isDragging }, drag] = useDrag({
     type: DragDrop.CAL_RECIPE,
     item: dragItem,
-    end: (_dropResult, monitor) => {
-      // when dragged onto something that isn't a target, we remove it
-      // but we don't remove when in past as we only copy from the past
-      if (!monitor.didDrop() && isInsideChangeWindow(date)) {
-        remove()
-      }
-    },
+    // don't do anything when on drop
+    end: () => {},
     collect: (monitor) => {
       return {
         isDragging: monitor.isDragging(),


### PR DESCRIPTION
This causes a lot of weird behavior and unexpected deletions. We want to make it harder to accidentally remove a scheduled recipe, so now we do nothing when a recipe is dropped on an unknown target.