### PR TITLE
fix(ui,api): prevent editing other peoples notes

### DIFF
--- a/backend/recipeyak/api/notes_view.py
+++ b/backend/recipeyak/api/notes_view.py
@@ -67,6 +67,9 @@ def note_detail_view(request: AuthedRequest, note_pk: str) -> Response:
 def note_patch_view(request: AuthedRequest, note_pk: str) -> Response:
     params = EditNoteParams.parse_obj(request.data)
     note = get_object_or_404(user_and_team_notes(request.user), pk=note_pk)
+    # only allow the note's author to update the note
+    if note.created_by.id != request.user.id:
+        return Response(status=status.HTTP_403_FORBIDDEN)
     note.last_modified_by = request.user
     if params.text is not None:
         note.text = params.text

--- a/backend/recipeyak/api/notes_view_test.py
+++ b/backend/recipeyak/api/notes_view_test.py
@@ -1,0 +1,31 @@
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from recipeyak.models import Note, Recipe, Team, User
+
+pytestmark = pytest.mark.django_db
+
+
+def test_updating_other_users_note(
+    client: APIClient, recipe: Recipe, user: User, team: Team, user2: User, user3: User
+) -> None:
+    """
+    Prevent editing notes that other users own
+    """
+    recipe.owner = team
+    recipe.save()
+    note = Note.objects.create(text="some note text", created_by=user, recipe=recipe)
+
+    client.force_authenticate(user)
+    res = client.patch(f"/api/v1/notes/{note.id}/")
+    assert res.status_code == status.HTTP_200_OK
+
+    client.force_authenticate(user2)
+    res = client.patch(f"/api/v1/notes/{note.id}/")
+    assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    team.force_join(user3)
+    client.force_authenticate(user3)
+    res = client.patch(f"/api/v1/notes/{note.id}/")
+    assert res.status_code == status.HTTP_403_FORBIDDEN

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -297,12 +297,14 @@ export function Note({ note, recipeId, className }: INoteProps) {
             onPick={async (emoji) => addOrRemoveReaction(emoji)}
             reactions={reactions}
           />
-          <SmallAnchor
-            className="ml-2 text-muted cursor-pointer no-print"
-            onClick={onNoteClick}
-          >
-            edit
-          </SmallAnchor>
+          {note.created_by.id === user.id ? (
+            <SmallAnchor
+              className="ml-2 text-muted cursor-pointer no-print"
+              onClick={onNoteClick}
+            >
+              edit
+            </SmallAnchor>
+          ) : null}
         </div>
         {!isEditing ? (
           <div>


### PR DESCRIPTION
We now hide the `edit` button for notes that a user doesn't own and prevent updating them at the API level.