### PR TITLE
fix(ui): CSP image policy `data:`

### DIFF
--- a/nginx/general_headers.conf
+++ b/nginx/general_headers.conf
@@ -3,7 +3,7 @@ add_header X-Request-Time $request_time;
 
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#Directives
 # https://sentry.io/magnus-montis/recipeyak/settings/csp/
-add_header Content-Security-Policy "default-src 'self' https://sentry.io https://recipeyak-production.s3.amazonaws.com https://recipeyak.imgix.net; img-src * 'self' blob:; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/250295/csp-report/?sentry_key=3b11e5eed068478390e1e8f01e2190a9";
+add_header Content-Security-Policy "default-src 'self' https://sentry.io https://recipeyak-production.s3.amazonaws.com https://recipeyak.imgix.net; img-src * 'self' data: blob:; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; report-uri https://sentry.io/api/250295/csp-report/?sentry_key=3b11e5eed068478390e1e8f01e2190a9";
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
 add_header Referrer-Policy "strict-origin-when-cross-origin";
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options


### PR DESCRIPTION
For some reason Safari is totally cool with `data:` images without explicitly having it in the CSP header but Chrome logs an error and doesn't load them.

This means that without the header update, the place holder images don't load in chrome.

<img width="626" alt="Screen Shot 2022-12-14 at 7 11 09 PM" src="https://user-images.githubusercontent.com/7340772/207743603-f951f97f-1afa-444c-8a01-a2044e64dde9.png">
