### PR TITLE
fix(vscode): hide .venv and node_modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,5 +54,6 @@
   "isort.importStrategy": "fromEnvironment",
   "isort.args": ["--sp", "./backend/pyproject.toml"],
   "python.testing.autoTestDiscoverOnSaveEnabled": false,
-  "python.testing.promptToConfigure": false
+  "python.testing.promptToConfigure": false,
+  "explorer.excludeGitIgnore": true
 }


### PR DESCRIPTION
prevents git ignored files and folders from showing up in the file explorer