### PR TITLE
update(nginx): cache gravatar for longer

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -134,6 +134,9 @@ server {
         # Reduce the information we send about users
         proxy_pass_request_headers off;
         proxy_pass https://www.gravatar.com;
+        proxy_hide_header Cache-Control;
+        # max age 5 minutes (gravatar's set value), allow stale for up to 7 days
+        add_header Cache-Control 'max-age=600, stale-while-revalidate=604800';
     }
 
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#location


### PR DESCRIPTION
default gravatar caches for 5mins, this should hopefully allow for staleness of up to 7 days