### PR TITLE
ref(api,ui): remove count from scheduled recipes

### DIFF
--- a/backend/recipeyak/api/calendar_detail_view.py
+++ b/backend/recipeyak/api/calendar_detail_view.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 class ScheduledRecipeUpdateParams(RequestParams):
     on: date | None
-    count: int | None
 
 
 class CreatedBySerializer(pydantic.BaseModel):
@@ -37,6 +36,7 @@ class RecipeMetadataSerializer(pydantic.BaseModel):
 
 class ScheduleRecipeSerializer(pydantic.BaseModel):
     id: int
+    # TODO: remove
     count: int
     created: datetime
     createdBy: CreatedBySerializer | None
@@ -55,8 +55,6 @@ def calendar_detail_patch_view(
     )
     if params.on is not None:
         scheduled_recipe.on = params.on
-    if params.count is not None:
-        scheduled_recipe.count = params.count
     scheduled_recipe.save()
 
     if params.on is not None:

--- a/backend/recipeyak/api/calendar_generic_view_test.py
+++ b/backend/recipeyak/api/calendar_generic_view_test.py
@@ -45,11 +45,11 @@ def test_updating_scheduled_recipe(
 ) -> None:
     url = f"/api/v1/t/me/calendar/{scheduled_recipe.id}/"
     assert scheduled_recipe.count == 1
-    data = {"count": 2}
+    data = {"on": date(1976, 1, 3)}
     client.force_authenticate(user)
     res = client.patch(url, data)
     assert res.status_code == status.HTTP_200_OK
-    assert ScheduledRecipe.objects.get(id=scheduled_recipe.id).count == 2
+    assert ScheduledRecipe.objects.get(id=scheduled_recipe.id).on == date(1976, 1, 3)
 
 
 def test_updating_scheduled_recipe_on_date(

--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -15,13 +15,8 @@ from recipeyak.api.base.permissions import IsTeamMember
 from recipeyak.api.base.request import AuthedRequest
 from recipeyak.api.base.serialization import BaseModelSerializer, RequestParams
 from recipeyak.api.serializers.recipe import RecipeSerializer
-from recipeyak.models import (
-    Membership,
-    ScheduledRecipe,
-    Team,
-    user_and_team_recipes,
-)
 from recipeyak.api.team_detail_view import get_teams
+from recipeyak.models import Membership, ScheduledRecipe, Team, user_and_team_recipes
 
 
 class CalSettings(TypedDict):

--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -16,7 +16,14 @@ from recipeyak.api.base.permissions import IsTeamMember
 from recipeyak.api.base.request import AuthedRequest
 from recipeyak.api.base.serialization import BaseModelSerializer, RequestParams
 from recipeyak.api.serializers.recipe import RecipeSerializer
-from recipeyak.models import Membership, Recipe, ScheduledRecipe, Team
+from recipeyak.models import (
+    Membership,
+    Recipe,
+    ScheduledRecipe,
+    Team,
+    user_and_team_recipes,
+)
+from recipeyak.api.team_detail_view import get_teams
 
 
 class CalSettings(TypedDict):
@@ -40,15 +47,9 @@ def get_cal_settings(*, team_pk: str, request: AuthedRequest) -> CalSettings:
     }
 
 
-class ScheduledRecipeSerializerCreate(BaseModelSerializer):
-    class Meta:
-        model = ScheduledRecipe
-        fields = ("id", "recipe", "created", "on", "count")
-
-    def create(self, validated_data: dict[str, Any]) -> ScheduledRecipe:
-        recipe: Recipe = validated_data.pop("recipe")
-        validated_data.pop("user", None)
-        return recipe.schedule(**validated_data, user=self.context["request"].user)
+class ScheduledRecipeCreateParams(RequestParams):
+    recipe: int
+    on: date
 
 
 def get_scheduled_recipes(
@@ -84,20 +85,20 @@ class ScheduledRecipeSerializer(BaseModelSerializer):
 
 
 def calendar_list_post_view(request: AuthedRequest, team_pk: str) -> Response:
-    # use different create serializer since we create via primary key, and
-    # return an objects
-    serializer = ScheduledRecipeSerializerCreate(
-        data=request.data, context={"request": request}
-    )
-    serializer.is_valid(raise_exception=True)
+    params = ScheduledRecipeCreateParams.parse_obj(request.data)
 
-    if team_pk == "me":
-        data = serializer.save(user=request.user)
-    else:
-        team = get_object_or_404(Team, pk=team_pk)
-        data = serializer.save(team=team)
+    recipe = get_object_or_404(user_and_team_recipes(request.user), id=params.recipe)
+
+    scheduled_recipe = recipe.schedule(
+        on=params.on,
+        user=request.user,
+        # TODO: remove this weird team thing we have where "personal" is a special case
+        team=get_object_or_404(get_teams(request.user), pk=team_pk)
+        if team_pk != "me"
+        else None,
+    )
     return Response(
-        ScheduledRecipeSerializer(data, dangerously_allow_db=True).data,
+        ScheduledRecipeSerializer(scheduled_recipe, dangerously_allow_db=True).data,
         status=status.HTTP_201_CREATED,
     )
 

--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Any
 
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
@@ -18,7 +17,6 @@ from recipeyak.api.base.serialization import BaseModelSerializer, RequestParams
 from recipeyak.api.serializers.recipe import RecipeSerializer
 from recipeyak.models import (
     Membership,
-    Recipe,
     ScheduledRecipe,
     Team,
     user_and_team_recipes,

--- a/backend/recipeyak/api/team_calendar_test.py
+++ b/backend/recipeyak/api/team_calendar_test.py
@@ -44,11 +44,11 @@ def test_updating_team_schedule_recipe(
     scheduled = recipe.schedule(on=date(1976, 1, 2), team=team, user=user)
     assert scheduled.count == 1
     url = f"/api/v1/t/{team.pk}/calendar/{scheduled.id}/"
-    data = {"count": 2}
+    data = {"on": date(1976, 1, 3)}
     client.force_authenticate(user)
     res = client.patch(url, data)
     assert res.status_code == status.HTTP_200_OK
-    assert ScheduledRecipe.objects.get(id=scheduled.id).count == 2
+    assert ScheduledRecipe.objects.get(id=scheduled.id).on == date(1976, 1, 3)
 
 
 def test_fetching_team_calendar(

--- a/backend/recipeyak/models/scheduled_recipe.py
+++ b/backend/recipeyak/models/scheduled_recipe.py
@@ -47,6 +47,7 @@ class ScheduledRecipe(CommonInfo):
     recipe_id: int
 
     on = models.DateField(help_text="day when recipe is scheduled")
+    # TODO: remove this field
     count = models.PositiveIntegerField(validators=[MinValueValidator(1)])
     # TODO(sbdchd): add restriction so that only one of these is set
     user = models.ForeignKey["User"](

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -438,7 +438,6 @@ export function getCalendarRecipeListRequestBuilder({
       scheduledRecipes: t.array(
         t.type({
           id: t.number,
-          count: t.number,
           on: t.string,
           created: t.string,
           createdBy: t.union([
@@ -533,13 +532,11 @@ export const scheduleRecipe = (
   recipeID: IRecipe["id"],
   teamID: number | "personal",
   on: Date | string,
-  count: string | number = 1,
 ) => {
   const id = teamID === "personal" ? "me" : teamID
   return http.post<ICalRecipe>(`/api/v1/t/${id}/calendar/`, {
     recipe: recipeID,
     on: toISODateString(on),
-    count,
   })
 }
 

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -36,7 +36,6 @@ export function ScheduleModal({
       {
         recipeID: recipeId,
         teamID: teamId,
-        count: 1,
         on: parseISO(isoDate),
       },
       {

--- a/frontend/src/pages/schedule/CalendarDay.tsx
+++ b/frontend/src/pages/schedule/CalendarDay.tsx
@@ -177,7 +177,6 @@ function CalendarDay({ date, scheduledRecipes, teamID }: ICalendarDayProps) {
                 teamId: teamID,
               })
             }}
-            count={x.count}
           />
         ))}
       </ul>

--- a/frontend/src/pages/schedule/CalendarDay.tsx
+++ b/frontend/src/pages/schedule/CalendarDay.tsx
@@ -133,7 +133,6 @@ function CalendarDay({ date, scheduledRecipes, teamID }: ICalendarDayProps) {
           recipeID: item.recipeID,
           teamID,
           on: date,
-          count: 1,
         })
       } else {
         assertNever(item)

--- a/frontend/src/pages/schedule/CalendarDayItem.tsx
+++ b/frontend/src/pages/schedule/CalendarDayItem.tsx
@@ -49,7 +49,6 @@ const CalendarListItem = styled.li<ICalendarListItemProps>`
 `
 
 export interface ICalendarItemProps {
-  readonly count: ICalRecipe["count"]
   readonly remove: () => void
   readonly date: Date
   readonly recipeID: IRecipe["id"] | string
@@ -65,7 +64,6 @@ export interface ICalendarItemProps {
 }
 
 export function CalendarItem({
-  count,
   date,
   remove,
   recipeName,
@@ -95,7 +93,6 @@ export function CalendarItem({
   const dragItem: ICalendarDragItem = {
     type: DragDrop.CAL_RECIPE,
     recipeID,
-    count,
     scheduledId,
     date,
   }
@@ -151,9 +148,6 @@ export function CalendarItem({
 }
 
 export interface ICalendarDragItem
-  extends Pick<
-    ICalendarItemProps,
-    "recipeID" | "count" | "scheduledId" | "date"
-  > {
+  extends Pick<ICalendarItemProps, "recipeID" | "scheduledId" | "date"> {
   readonly type: DragDrop.CAL_RECIPE
 }

--- a/frontend/src/queries/scheduledRecipeCreate.ts
+++ b/frontend/src/queries/scheduledRecipeCreate.ts
@@ -16,7 +16,6 @@ function toCalRecipe(
   recipe: Pick<IRecipe, "id" | "name" | "owner">,
   tempId: number,
   on: string | Date,
-  count: number,
   user: {
     id: number | null
     name: string
@@ -31,7 +30,6 @@ function toCalRecipe(
       name: recipe.name,
     },
     on: toISODateString(on),
-    count,
     user: recipe.owner.type === "user" ? recipe.owner.id : null,
     team: recipe.owner.type === "team" ? recipe.owner.id : null,
     createdBy:
@@ -49,14 +47,12 @@ function scheduleRecipeV2({
   recipeID,
   teamID,
   on,
-  count,
 }: {
   recipeID: number
   teamID: number | "personal"
   on: Date
-  count?: string | number
 }): Promise<ICalRecipe> {
-  return scheduleRecipe(recipeID, teamID, on, count).then(unwrapResult)
+  return scheduleRecipe(recipeID, teamID, on).then(unwrapResult)
 }
 
 export function useScheduleRecipeCreate() {
@@ -77,7 +73,6 @@ export function useScheduleRecipeCreate() {
         recipe.data,
         tempId,
         vars.on,
-        1,
         /* user */ null,
       )
       const weekId = startOfWeek(vars.on)

--- a/frontend/src/store/reducers/calendar.ts
+++ b/frontend/src/store/reducers/calendar.ts
@@ -78,7 +78,6 @@ export type CalendarActions =
 // TODO(sbdchd): this should be imported from the recipes reducer
 export interface ICalRecipe {
   readonly id: number
-  readonly count: number
   readonly on: string
   readonly created: string
   readonly createdBy: {


### PR DESCRIPTION
Removed most of the UI related functionality in an earlier PR but this removes all the UI references.

We still return the params in the API to support older UI clients, but later we can remove those too.

We didn't really use the count feature and it was rather complicated.