### PR TITLE
fix(ui): header image decoding ios safari

### DIFF
--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -958,6 +958,10 @@ function RecipeInfo(props: {
         <>
           <HeaderImg
             src={props.recipe.primaryImage?.url ?? ""}
+            // NOTE: not entirely sure if we want async or sync
+            // see: https://stackoverflow.com/a/66967317/3720597
+            // and: https://css-tricks.com/newsletter/249-decoding-async-tree-rings-and-flexbox-gap/
+            decoding="async"
             onClick={() => {
               props.openImage()
             }}


### PR DESCRIPTION
not entirely sure if we want async or sync


sometimes safari on iOS gets stuck loading images, granted, these images are large, like 10 MB:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/7340772/209414615-d5941ba7-b0aa-476a-82dc-5eac3641e8f7.png">


rel: https://stackoverflow.com/a/66967317/3720597
rel: https://css-tricks.com/newsletter/249-decoding-async-tree-rings-and-flexbox-gap/

This suggests using `"sync"`:

https://stackoverflow.com/a/58323810/3720597


