### PR TITLE
add margin between markdown paragraphs.

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -23,6 +23,10 @@ const MarkdownWrapper = styled.div`
     padding-left: 1.5rem;
   }
 
+  p:not(:last-child) {
+    margin-bottom: 1em;
+  }
+
   blockquote {
     padding-left: 0.25rem;
     border-left: 5px solid lightgray;


### PR DESCRIPTION
This helps with dividing steps visually