### PR TITLE
compress images with imgix

### DIFF
--- a/backend/recipeyak/api/recipe_bot_detail_view.py
+++ b/backend/recipeyak/api/recipe_bot_detail_view.py
@@ -17,7 +17,7 @@ template = Template(
 <head>
 <meta property="og:title" content="{{ recipe_title }}" />
 {% if recipe_image_url %}
-<meta property="og:image" content="{{ recipe_image_url }}" />
+<meta property="og:image" content="{{ recipe_image_url | safe }}" />
 {% endif %}
 <link rel="apple-touch-icon" href="https://recipeyak.imgix.net/recipeyak-logo-3x-white.png">
 <meta http-equiv="refresh" content="0; url=https://recipeyak.com/recipes/{{ recipe_pk }}/">
@@ -30,7 +30,16 @@ def format_img_open_graph(x: str) -> str:
     """
     Open graph images are recommended to be 1200x630, so we use Imgix to crop.
     """
-    return str(URL(x).with_query({"w": "1200", "h": "630", "fit": "crop"}))
+    return str(
+        URL(x).with_query(
+            {
+                "w": "1200",
+                "h": "630",
+                "fit": "crop",
+                "q": "30",
+            }
+        )
+    )
 
 
 def recipe_get_view(request: AuthedRequest, recipe_pk: str) -> Response:

--- a/frontend/src/pages/recipe-detail/ImageGallery.tsx
+++ b/frontend/src/pages/recipe-detail/ImageGallery.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft, ChevronRight, Star, X } from "react-feather"
 
 import { Button } from "@/components/Buttons"
 import { styled } from "@/theme"
+import { imgixFmt } from "@/utils/url"
 
 const MyGalleryContainer = styled.div`
   opacity: 1 !important;
@@ -115,7 +116,7 @@ export const Gallery = (props: {
       <MyGalleryBackground />
       <MyGalleryScrollWrap>
         <MyGalleryImgContainer onClick={onClick}>
-          <MyGalleryImg src={props.imageUrl} onClick={onClick} />
+          <MyGalleryImg src={imgixFmt(props.imageUrl)} onClick={onClick} />
         </MyGalleryImgContainer>
         <MyGalleryControlOverlay>
           <TopRow>

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -32,6 +32,7 @@ import { styled } from "@/theme"
 import { toast } from "@/toast"
 import { notUndefined } from "@/utils/general"
 import { uuid4 } from "@/uuid"
+import { imgixFmt } from "@/utils/url"
 
 interface IUseNoteEditHandlers {
   readonly note: INote
@@ -623,7 +624,7 @@ function ImagePreview({
   return (
     <div className="d-grid" onClick={onClick}>
       <Image100Px
-        src={src}
+        src={imgixFmt(src)}
         isLoading={isLoading}
         style={{
           gridArea: "1 / 1",

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -31,8 +31,8 @@ import {
 import { styled } from "@/theme"
 import { toast } from "@/toast"
 import { notUndefined } from "@/utils/general"
-import { uuid4 } from "@/uuid"
 import { imgixFmt } from "@/utils/url"
+import { uuid4 } from "@/uuid"
 
 interface IUseNoteEditHandlers {
   readonly note: INote

--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -48,7 +48,7 @@ import {
 } from "@/store/reducers/recipes"
 import { styled } from "@/theme"
 import { recipeURL } from "@/urls"
-import { pathNamesEqual } from "@/utils/url"
+import { imgixFmt, pathNamesEqual } from "@/utils/url"
 import { isFailure, isInitial, isLoading, isSuccessLike } from "@/webdata"
 
 type SectionsAndIngredients = ReadonlyArray<
@@ -958,7 +958,7 @@ function RecipeInfo(props: {
       {(props.recipe.primaryImage || props.editingEnabled) && (
         <>
           <HeaderImg
-            src={props.recipe.primaryImage?.url ?? ""}
+            src={imgixFmt(props.recipe.primaryImage?.url ?? "")}
             // NOTE: not entirely sure if we want async or sync
             // see: https://stackoverflow.com/a/66967317/3720597
             // and: https://css-tricks.com/newsletter/249-decoding-async-tree-rings-and-flexbox-gap/

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -3,3 +3,22 @@ export function pathNamesEqual(a: string, b: string): boolean {
   const urlB = new URL(b, "https://example.com")
   return urlA.pathname === urlB.pathname
 }
+
+/**
+ * Image sizes supported:
+ * 100x100 for comment thumbnail images
+ * 620x470 for header image
+ * 1152x864 for gallery
+ */
+export function imgixFmt(url: string) {
+  if (url === "") {
+    return url
+  }
+  const u = new URL(url)
+  u.searchParams.set("max-w", "1200")
+  u.searchParams.set("max-h", "900")
+  u.searchParams.set("q", "30")
+  u.searchParams.set("dpr", "2")
+  u.searchParams.set("fit", "crop")
+  return u.toString()
+}


### PR DESCRIPTION
On slow connections, serving full size 2MB-4MB images is too slow. We need to compress our images to improve load times.

These Imgix settings don't appear to cause any negative display issues, and allow us to serve one image for the thumbnails, recipe header, and gallery. This improves our cache hit ratio and makes the Gallery more responsive.

I also fixed an encoding issue with our iMessage response.