### PR TITLE
fix(ui): recipe list perf issue with css blur

### DIFF
--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -41,6 +41,13 @@ const CardImg = styled.img`
   position: absolute;
   z-index: 1;
 `
+
+// TODO: add back background image with backdrop-filter: blur /
+// filter: blur when it isn't super slow in safari or when we add
+// windowing / virtualized lists or maybe an intersection observer?
+// rel: https://discourse.webflow.com/t/my-site-is-extremely-slow-in-safari-practically-unusable/167272/9
+// rel: https://graffino.com/til/CjT2jrcLHP-how-to-fix-filter-blur-performance-issue-in-safari
+// rel: https://stackoverflow.com/questions/31713468/css-blur-filter-performance
 const CardImgBg = styled.div<{ backgroundImage: string }>`
   height: 100%;
   width: 100%;
@@ -48,15 +55,6 @@ const CardImgBg = styled.div<{ backgroundImage: string }>`
   background-image: url(${(props) => props.backgroundImage});
   background-position: center;
   background-size: cover;
-  &:after {
-    position: absolute;
-    content: "";
-    height: 100%;
-    width: 100%;
-    border-radius: 6px;
-    backdrop-filter: blur(6px);
-    pointer-events: none;
-  }
 `
 const CardImgContainer = styled.div`
   min-height: 160px;


### PR DESCRIPTION
CSS' `filter: blur(6px);` and `backdrop-filter: blur(6px);` are slow and really really slow in Safari.

This means searching on the recipe list page is really slow with the placeholder image blurring setup.

Some ideas for fixes:
- improve filter perf in the browser
- `IntersectionObserver` to only use blur for images that are in view
- windowing / virtualization in general for the list view
- delete the blur

going with delete the blur for now as it's the easiest


<img width="1624" alt="Screen Shot 2022-12-26 at 5 03 56 PM" src="https://user-images.githubusercontent.com/7340772/209588661-38ac5a5a-639e-4a42-8674-27a3f5f861f4.png">



rel: https://discourse.webflow.com/t/my-site-is-extremely-slow-in-safari-practically-unusable/167272/9
rel: https://graffino.com/til/CjT2jrcLHP-how-to-fix-filter-blur-performance-issue-in-safari
rel: https://stackoverflow.com/questions/31713468/css-blur-filter-performance