### PR TITLE
fix(ui): rounding images on browse page

### DIFF
--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -4,21 +4,22 @@ import { imgixFmt } from "@/utils/url"
 const CardImgContainer = styled.div<{
   height: number | undefined
   width: number | undefined
+  rounded: boolean | undefined
 }>`
   ${(p) => (p.width != null ? `min-width: ${p.width}px;` : `width: 100%;`)}
 
   ${(p) => (p.height != null ? `min-height: ${p.height}px;` : `height: 100%`)}
 
-  border-radius: 6px;
+  ${(p) => p.rounded && `border-radius: 6px;`}
 
   background-color: rgb(237, 237, 237);
   position: relative;
 `
 
-const CardImg = styled.img`
+const CardImg = styled.img<{ rounded: boolean | undefined }>`
   height: 100%;
   width: 100%;
-  border-radius: 6px;
+  ${(p) => p.rounded && `border-radius: 6px;`}
   object-fit: cover;
   position: absolute;
   z-index: 1;
@@ -27,6 +28,7 @@ const CardImg = styled.img`
 const CardImgBg = styled.div<{
   backgroundImage: string
   blur: "none" | undefined
+  rounded: boolean | undefined
 }>`
   height: 100%;
   width: 100%;
@@ -36,7 +38,7 @@ const CardImgBg = styled.div<{
   background-position: center;
   background-size: cover;
 
-  border-radius: 6px;
+  ${(p) => p.rounded && `border-radius: 6px;`}
 
   ${(p) =>
     p.blur !== "none" &&
@@ -45,7 +47,7 @@ const CardImgBg = styled.div<{
       content: "";
       height: 100%;
       width: 100%;
-      border-radius: 6px;
+      ${p.rounded && `border-radius: 6px;`}
       backdrop-filter: blur(6px);
       pointer-events: none;
     }`}
@@ -56,6 +58,7 @@ export function Image({
   height,
   width,
   blur,
+  rounded,
 }: {
   readonly sources:
     | {
@@ -67,15 +70,17 @@ export function Image({
   readonly height?: number
   readonly width?: number
   readonly blur?: "none"
+  readonly rounded?: boolean
 }) {
   return (
-    <CardImgContainer height={height} width={width}>
+    <CardImgContainer height={height} width={width} rounded={rounded}>
       {sources != null && (
         <>
-          <CardImg src={imgixFmt(sources.url ?? "")} />
+          <CardImg src={imgixFmt(sources.url ?? "")} rounded={rounded} />
           <CardImgBg
             backgroundImage={sources.backgroundUrl ?? ""}
             blur={blur}
+            rounded={rounded}
           />
         </>
       )}

--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -113,6 +113,7 @@ function RecipeListItem({
           // rel: https://graffino.com/til/CjT2jrcLHP-how-to-fix-filter-blur-performance-issue-in-safari
           // rel: https://stackoverflow.com/questions/31713468/css-blur-filter-performance
           blur="none"
+          rounded={false}
         />
       </CardImgContainer>
       {recipeContent}


### PR DESCRIPTION
We were rounding the images inside the card when it has square corners