### PR TITLE
fix(ui): trim ingredients

### DIFF
--- a/frontend/src/pages/recipe-detail/IngredientView.tsx
+++ b/frontend/src/pages/recipe-detail/IngredientView.tsx
@@ -24,8 +24,9 @@ export default function IngredientView({
 
   return (
     <p className="listitem-text justify-space-between selectable" ref={dragRef}>
-      <span className="fw-500">{normalizeUnitsFracs(quantity)}</span> {name}
-      {fmtDescription}{" "}
+      <span className="fw-500">{normalizeUnitsFracs(quantity).trim()}</span>{" "}
+      {name.trim()}
+      {fmtDescription.trim()}{" "}
       {optional ? <span className="text-muted">[optional]</span> : ""}
     </p>
   )

--- a/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
@@ -18,9 +18,9 @@ import { useRecipeUpdate } from "@/queries/recipeUpdate"
 import { toast } from "@/toast"
 
 function ingredientToString(ingre: IIngredient) {
-  const s = ingre.quantity + " " + ingre.name
+  const s = ingre.quantity.trim() + " " + ingre.name.trim()
   if (ingre.description) {
-    return s + ", " + ingre.description
+    return s + ", " + ingre.description.trim()
   }
   return s
 }


### PR DESCRIPTION
Before rendering in the UI / the copy to clipboard, we trim excess whitespace