### PR TITLE
fix(ui): react-query persistence

### DIFF
--- a/frontend/src/pages/recipe-detail/AddIngredient.tsx
+++ b/frontend/src/pages/recipe-detail/AddIngredient.tsx
@@ -40,7 +40,13 @@ function AddIngredientForm({
     createIngredient.mutate(
       {
         recipeId,
-        payload: { quantity, name, description, position: newPosition },
+        payload: {
+          quantity,
+          name,
+          description,
+          position: newPosition,
+          optional,
+        },
       },
       {
         onSuccess: () => {
@@ -98,8 +104,8 @@ function AddIngredientForm({
 
       <label className="d-flex align-items-center cursor-pointer mb-2">
         <CheckBox
-          onChange={(e) => {
-            setOptional(e.target.value === "on")
+          onChange={() => {
+            setOptional((prev) => !prev)
           }}
           checked={optional}
           className="mr-2"

--- a/frontend/src/pages/recipe-detail/Ingredient.tsx
+++ b/frontend/src/pages/recipe-detail/Ingredient.tsx
@@ -166,7 +166,13 @@ export function Ingredient(props: {
       </div>
 
       <label className="d-flex align-items-center cursor-pointer mb-2">
-        <CheckBox onChange={() => {}} checked={optional} className="mr-2" />
+        <CheckBox
+          onChange={() => {
+            setOptional((prev) => !prev)
+          }}
+          checked={optional}
+          className="mr-2"
+        />
         Optional
       </label>
 
@@ -184,7 +190,7 @@ export function Ingredient(props: {
               size="small"
               loading={removeIngredient.isLoading}
             >
-              Remove
+              Delete
             </Button>
           </p>
         </div>

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -827,7 +827,7 @@ function ImageUploader({
               />
               <CloseButton
                 onClick={() => {
-                  if (confirm("Remove image?")) {
+                  if (confirm("Delete image?")) {
                     removeFile(f.localId)
                   }
                 }}

--- a/frontend/src/pages/recipe-detail/Section.tsx
+++ b/frontend/src/pages/recipe-detail/Section.tsx
@@ -120,7 +120,7 @@ export function Section({
                 }}
                 loading={deleteSection.isLoading}
               >
-                Remove
+                Delete
               </Button>
             </p>
             <p className="control">

--- a/frontend/src/queries/ingredientCreate.ts
+++ b/frontend/src/queries/ingredientCreate.ts
@@ -19,6 +19,7 @@ export function useIngredientCreate() {
         name: string
         description: string
         position: string
+        optional: boolean
       }
     }) => addIngredientToRecipe(recipeId, payload).then(unwrapResult),
     onSuccess: (res, vars) => {

--- a/frontend/src/queries/recipeList.ts
+++ b/frontend/src/queries/recipeList.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 
 import { getRecipeList } from "@/api"
 import { useTeamId } from "@/hooks"
@@ -6,18 +6,14 @@ import { unwrapResult } from "@/query"
 
 export function useRecipeList() {
   const teamID = useTeamId()
-  const queryClient = useQueryClient()
   return useQuery(
     [teamID, "recipes-list"],
     () => getRecipeList().then(unwrapResult),
     {
-      onSuccess: (res) => {
-        // TODO: this is kind of slow, it takes ~100ms w/ ~400 recipes
-        // we either need to prioritize non-recipe list items to save or skip
-        // doing this
-        res.forEach((recipe) => {
-          queryClient.setQueryData([teamID, "recipes", recipe.id], recipe)
-        })
+      onSuccess: () => {
+        // NOTE: we don't save all these recipes as it exceeds the localStorage
+        // limit of 5MB (we try to save 3MB of data but that ends up being too
+        // much for safari.)
       },
     },
   )


### PR DESCRIPTION
We were saving too much data to localStorage and react-query was silently erroring.

Now we report serialize, deserialize, and storage related errors to Sentry.

Also fix some issues with `optional` settings in ingredient forms & adjust some copy.

<img width="526" alt="Pasted Graphic 10" src="https://user-images.githubusercontent.com/7340772/210096326-4a3fff89-f2d7-4b44-868e-e8fd8f1a12ec.png">


rel: https://github.com/TanStack/query/discussions/4730