### PR TITLE
fix(ui): optimistic updates for calendar scheduling

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -694,8 +694,6 @@ export interface ICalRecipe {
     readonly name: string
     readonly avatar_url: string
   } | null
-  readonly team: ITeam["id"] | null
-  readonly user: IUser["id"] | null
   readonly recipe: {
     readonly id: number
     readonly name: string

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -30,6 +30,7 @@ export function ScheduleModal({
     scheduledRecipeCreate.mutate(
       {
         recipeID: recipeId,
+        recipeName,
         teamID: teamId,
         on: parseISO(isoDate),
       },

--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -158,7 +158,11 @@ export function RecipeItem({
 
   const url = props.url || recipeURL(id, name)
 
-  const item: IRecipeItemDrag = { type: DragDrop.RECIPE, recipeID: id }
+  const item: IRecipeItemDrag = {
+    type: DragDrop.RECIPE,
+    recipeID: id,
+    recipeName: name,
+  }
 
   // We don't actually run this conditionally in production.
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -206,7 +210,8 @@ export function RecipeItem({
 }
 
 export interface IRecipeItemDrag {
-  readonly recipeID: IRecipeItemProps["id"]
+  readonly recipeID: number
+  readonly recipeName: string
   readonly type: DragDrop.RECIPE
 }
 

--- a/frontend/src/pages/schedule/CalendarDay.tsx
+++ b/frontend/src/pages/schedule/CalendarDay.tsx
@@ -137,6 +137,7 @@ function CalendarDay({ date, scheduledRecipes, teamID }: ICalendarDayProps) {
       } else if (item.type === DragDrop.RECIPE) {
         scheduledRecipeCreate.mutate({
           recipeID: item.recipeID,
+          recipeName: item.recipeName,
           teamID,
           on: date,
         })


### PR DESCRIPTION
We aren't caching all the recipes at the moment and the optimistic save was reaching into the cache and not finding anything.

Now we pass in the necessary values as props.