### PR TITLE
fix(api): n + 1 queries with calendar list & recipe list

### DIFF
--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -48,7 +48,10 @@ class ScheduledRecipeCreateParams(RequestParams):
 def get_scheduled_recipes(team_pk: int) -> QuerySet[ScheduledRecipe]:
     team = get_object_or_404(Team, pk=team_pk)
     return ScheduledRecipe.objects.filter(team=team).select_related(
-        "recipe", "created_by", "recipe__primary_image"
+        "recipe",
+        "created_by",
+        "recipe__primary_image",
+        "recipe__primary_image__created_by",
     )
 
 

--- a/backend/recipeyak/api/recipe_list_view.py
+++ b/backend/recipeyak/api/recipe_list_view.py
@@ -67,7 +67,7 @@ def recipe_get_view(request: AuthedRequest) -> Response:
         )
     ):
         ingredients = list[RecipeListItemIngredient]()
-        for ingre in recipe.ingredients:
+        for ingre in recipe.ingredient_set.all():
             ingredients.append(
                 RecipeListItemIngredient(
                     id=ingre.id, quantity=ingre.quantity, name=ingre.name


### PR DESCRIPTION
from tailing postgres logs I think I fixed the n + 1 queries, Django ORM doesn't make it easy

<img width="775" alt="image" src="https://user-images.githubusercontent.com/7340772/210289869-84f4374b-d4f6-4d28-a628-99d95eb048da.png">
