### PR TITLE
fix(api): primary image backfill

### DIFF
--- a/backend/recipeyak/jobs/backfill_image_placeholders.py
+++ b/backend/recipeyak/jobs/backfill_image_placeholders.py
@@ -64,7 +64,7 @@ async def job(*, dry_run: bool) -> None:
     select id, key from core_upload
     where completed = true
       and background_url is null
-      and note_id is not null
+      and (note_id is not null or recipe_id is not null)
     limit 50;
     """
     )

--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -39,7 +39,8 @@ const CardImgBg = styled.div<{
   width: 100%;
 
   position: relative;
-  background-image: url(${(props) => props.backgroundImage});
+  ${(p) => p.backgroundImage && `background-image: url(${p.backgroundImage});`}
+
   background-position: center;
   background-size: cover;
 


### PR DESCRIPTION
we were skipping images that weren't attached to notes, aka ones that we scrape for the initial primary image

also I think rendering a background-image with an empty string url results in some glitchy looking UI but not 100% sure. So now we don't include the css property when we don't have a backgroundImage url.