### PR TITLE
ref(ui): tighten spacing of list view cards

### DIFF
--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -72,7 +72,7 @@ function RecipeListItem({
   const authorMatch = matches.find((x) => x.kind === "author")
 
   const recipeContent = (
-    <div className="h-100 p-2 pt-0">
+    <div className="h-100 p-2 pt-0 line-height-tight">
       <div tabIndex={0} className="mb-1">
         {name}
       </div>


### PR DESCRIPTION
looks a little nicer with less space between lines in the recipe titles

Before:

<img width="1036" alt="Screen Shot 2023-01-07 at 9 21 52 PM" src="https://user-images.githubusercontent.com/7340772/211177821-49b8f3e6-c30b-4a87-b30a-a39217d85aae.png">


After:

<img width="1055" alt="Screen Shot 2023-01-07 at 9 21 37 PM" src="https://user-images.githubusercontent.com/7340772/211177820-bfab0983-d6ce-4108-a246-440d16c987d5.png">
