### PR TITLE
ref(ui): browse from auto-fit to auto-fill, ignore empty search param

### DIFF
--- a/frontend/src/components/scss/main.scss
+++ b/frontend/src/components/scss/main.scss
@@ -131,11 +131,11 @@ a {
   // support two columns on iOS.
 
   @media (max-width: 449px) {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     gap: 0.5rem;
   }
   @media (min-width: 450px) {
-    grid-template-columns: repeat(auto-fit, minmax(225px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
     gap: 1rem;
   }
 }

--- a/frontend/src/pages/recipe-list/RecipeList.page.tsx
+++ b/frontend/src/pages/recipe-list/RecipeList.page.tsx
@@ -11,7 +11,7 @@ import RecipeItem from "@/pages/recipe-list/RecipeItem"
 import { parseIntOrNull } from "@/parseIntOrNull"
 import { useRecipeList } from "@/queries/recipeList"
 import { searchRecipes } from "@/search"
-import { setQueryParams } from "@/utils/querystring"
+import { removeQueryParams, setQueryParams } from "@/utils/querystring"
 
 interface IResultsProps {
   readonly recipes: JSX.Element[]
@@ -168,7 +168,11 @@ function RecipesListSearch({
   const history = useHistory()
 
   useEffect(() => {
-    setQueryParams(history, { search: query })
+    if (query === "") {
+      removeQueryParams(history, ["search"])
+    } else {
+      setQueryParams(history, { search: query })
+    }
   }, [query, history])
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
- now we use auto-fill for our grid so that individual grid items don't expand the entire width:

  https://defensivecss.dev/tip/auto-fit-fill/

- remove the search query param when it's empty


Also I was futzing around with `translate3D` and `loading=lazy` for the images but I didn't see any noticeable performance difference in the browse list
