### PR TITLE
fix(api): category for fennel seed

### DIFF
--- a/backend/recipeyak/cumin/__snapshots__/cat_test.ambr
+++ b/backend/recipeyak/cumin/__snapshots__/cat_test.ambr
@@ -221,6 +221,10 @@
       'produce',
     ),
     tuple(
+      'fennel seed',
+      'spices',
+    ),
+    tuple(
       'finely chopped cornichons or small kosher dill pickles',
       'condiments',
     ),

--- a/backend/recipeyak/cumin/cat.py
+++ b/backend/recipeyak/cumin/cat.py
@@ -387,6 +387,7 @@ DEPARTMENT_MAPPING = {
         "bay leaves",
         "miso",
         "cloves",
+        "fennel seed",
         "ground clove",
         "red chile flakes",
         "chile flakes",

--- a/backend/recipeyak/cumin/cat_test.py
+++ b/backend/recipeyak/cumin/cat_test.py
@@ -91,6 +91,7 @@ def test_categorize_ingredient_test_cases(snapshot: Any) -> None:
     cloves garlic
     garlic cloves
     graham cracker crumbs
+    fennel seed
     ground ginger
     hamburger buns
     haricot vert fins or green beans


### PR DESCRIPTION
fix categorization for fennel seed

we could do something more special for items with "seed" in the name, but for now we're continuing with the hard coded approach.