### PR TITLE
ui: lazy load images in browse list view

### DIFF
--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -91,7 +91,7 @@ export function Image({
   grayscale,
   loading,
   onClick,
-  loadWhenInView,
+  lazyLoad,
 }: {
   readonly sources:
     | {
@@ -108,7 +108,7 @@ export function Image({
   readonly rounded?: boolean
   readonly roundDesktop?: boolean
   readonly onClick?: () => void
-  readonly loadWhenInView?: boolean
+  readonly lazyLoad?: boolean
 }) {
   const ref = useRef<HTMLDivElement | null>(null)
   const entry = useIntersectionObserver(ref, {
@@ -118,7 +118,7 @@ export function Image({
     // NOTE: Might need to tweak this, maybe consider scroll velocity?
     rootMargin: "500px",
   })
-  const isVisible = !loadWhenInView || entry?.isIntersecting
+  const isVisible = !lazyLoad || entry?.isIntersecting
   return (
     <CardImgContainer
       ref={ref}

--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -91,7 +91,7 @@ export function Image({
   grayscale,
   loading,
   onClick,
-  forceLoad,
+  loadWhenInView,
 }: {
   readonly sources:
     | {
@@ -108,7 +108,7 @@ export function Image({
   readonly rounded?: boolean
   readonly roundDesktop?: boolean
   readonly onClick?: () => void
-  readonly forceLoad?: boolean
+  readonly loadWhenInView?: boolean
 }) {
   const ref = useRef<HTMLDivElement | null>(null)
   const entry = useIntersectionObserver(ref, {
@@ -118,7 +118,7 @@ export function Image({
     // NOTE: Might need to tweak this, maybe consider scroll velocity?
     rootMargin: "500px",
   })
-  const isVisible = forceLoad || entry?.isIntersecting
+  const isVisible = !loadWhenInView || entry?.isIntersecting
   return (
     <CardImgContainer
       ref={ref}

--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -1,4 +1,7 @@
+import { useRef } from "react"
+
 import { styled } from "@/theme"
+import { useIntersectionObserver } from "@/useIntersectionObserver"
 import { imgixFmt } from "@/utils/url"
 
 const CardImgContainer = styled.div<{
@@ -88,6 +91,7 @@ export function Image({
   grayscale,
   loading,
   onClick,
+  forceLoad,
 }: {
   readonly sources:
     | {
@@ -104,16 +108,27 @@ export function Image({
   readonly rounded?: boolean
   readonly roundDesktop?: boolean
   readonly onClick?: () => void
+  readonly forceLoad?: boolean
 }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const entry = useIntersectionObserver(ref, {
+    // How much to expand element's margin before calculating intersections
+    // Means we load images before they're in view so there isn't a pop in.
+    //
+    // NOTE: Might need to tweak this, maybe consider scroll velocity?
+    rootMargin: "500px",
+  })
+  const isVisible = forceLoad || entry?.isIntersecting
   return (
     <CardImgContainer
+      ref={ref}
       roundDesktop={roundDesktop}
       height={height}
       width={width}
       rounded={rounded}
       onClick={onClick}
     >
-      {sources != null && (
+      {sources != null && isVisible && (
         <>
           <CardImg
             src={imgixFmt(sources.url ?? "")}

--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -100,8 +100,8 @@ function RecipeListItem({
     <Link tabIndex={0} to={url} className="card">
       <CardImgContainer>
         <Image
-          // always load the first 20ish
-          forceLoad={index < 20}
+          // lazy load everything after the first 20ish
+          loadWhenInView={index > 20}
           sources={
             props.primaryImage && {
               url: imgixFmt(props.primaryImage.url ?? ""),

--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -101,7 +101,7 @@ function RecipeListItem({
       <CardImgContainer>
         <Image
           // lazy load everything after the first 20ish
-          loadWhenInView={index > 20}
+          lazyLoad={index > 20}
           sources={
             props.primaryImage && {
               url: imgixFmt(props.primaryImage.url ?? ""),

--- a/frontend/src/pages/recipe-list/RecipeItem.tsx
+++ b/frontend/src/pages/recipe-list/RecipeItem.tsx
@@ -54,15 +54,18 @@ type IRecipeItemProps = {
   readonly url?: string
   readonly drag?: boolean
   readonly match: Match[]
+  readonly index: number
 } & TRecipeListItem
 
 function RecipeListItem({
+  index,
   name,
   author,
   id,
   match: matches,
   ...props
 }: {
+  readonly index: number
   readonly url?: string
   readonly match: Match[]
 } & TRecipeListItem) {
@@ -97,6 +100,8 @@ function RecipeListItem({
     <Link tabIndex={0} to={url} className="card">
       <CardImgContainer>
         <Image
+          // always load the first 20ish
+          forceLoad={index < 20}
           sources={
             props.primaryImage && {
               url: imgixFmt(props.primaryImage.url ?? ""),
@@ -138,12 +143,14 @@ export function RecipeItem({
   name,
   author,
   id,
+  index,
   match: matches,
   ...props
 }: IRecipeItemProps) {
   if (!props.drag) {
     return (
       <RecipeListItem
+        index={index}
         name={name}
         author={author}
         id={id}

--- a/frontend/src/pages/recipe-list/RecipeList.page.tsx
+++ b/frontend/src/pages/recipe-list/RecipeList.page.tsx
@@ -67,9 +67,10 @@ function RecipeList(props: IRecipeList) {
 
   const normalResults = results.recipes
     .filter((result) => !result.recipe.archived_at)
-    .map((result) => (
+    .map((result, index) => (
       <RecipeItem
         {...result.recipe}
+        index={index}
         match={result.match}
         drag={props.drag}
         key={result.recipe.id}
@@ -77,9 +78,10 @@ function RecipeList(props: IRecipeList) {
     ))
   const archivedResults = results.recipes
     .filter((result) => result.recipe.archived_at)
-    .map((result) => (
+    .map((result, index) => (
       <RecipeItem
         {...result.recipe}
+        index={index}
         match={result.match}
         drag={props.drag}
         key={result.recipe.id}

--- a/frontend/src/useIntersectionObserver.ts
+++ b/frontend/src/useIntersectionObserver.ts
@@ -1,0 +1,45 @@
+import { RefObject, useEffect, useState } from "react"
+
+interface Args extends IntersectionObserverInit {
+  freezeOnceVisible?: boolean
+}
+
+// from: https://usehooks-ts.com/react-hook/use-intersection-observer
+export function useIntersectionObserver(
+  elementRef: RefObject<Element>,
+  {
+    threshold = 0,
+    root = null,
+    rootMargin = "0%",
+    freezeOnceVisible = true,
+  }: Args,
+): IntersectionObserverEntry | undefined {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>()
+
+  const frozen = entry?.isIntersecting && freezeOnceVisible
+
+  const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
+    setEntry(entry)
+  }
+
+  useEffect(() => {
+    const node = elementRef?.current // DOM Ref
+    const hasIOSupport = !!window.IntersectionObserver
+
+    if (!hasIOSupport || frozen || !node) return
+    const observer = new IntersectionObserver(updateEntry, {
+      threshold,
+      root,
+      rootMargin,
+    })
+
+    observer.observe(node)
+
+    return () => {
+      observer.disconnect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementRef?.current, JSON.stringify(threshold), root, rootMargin, frozen])
+
+  return entry
+}

--- a/frontend/src/useIntersectionObserver.ts
+++ b/frontend/src/useIntersectionObserver.ts
@@ -1,9 +1,5 @@
 import { RefObject, useEffect, useState } from "react"
 
-interface Args extends IntersectionObserverInit {
-  freezeOnceVisible?: boolean
-}
-
 // from: https://usehooks-ts.com/react-hook/use-intersection-observer
 export function useIntersectionObserver(
   elementRef: RefObject<Element>,
@@ -12,7 +8,7 @@ export function useIntersectionObserver(
     root = null,
     rootMargin = "0%",
     freezeOnceVisible = true,
-  }: Args,
+  }: IntersectionObserverInit & { freezeOnceVisible?: boolean },
 ): IntersectionObserverEntry | undefined {
   const [entry, setEntry] = useState<IntersectionObserverEntry>()
 

--- a/frontend/src/useIntersectionObserver.ts
+++ b/frontend/src/useIntersectionObserver.ts
@@ -20,9 +20,8 @@ export function useIntersectionObserver(
 
   useEffect(() => {
     const node = elementRef?.current // DOM Ref
-    const hasIOSupport = !!window.IntersectionObserver
 
-    if (!hasIOSupport || frozen || !node) return
+    if (!window.IntersectionObserver || frozen || !node) return
     const observer = new IntersectionObserver(updateEntry, {
       threshold,
       root,


### PR DESCRIPTION
Trying out https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API

via https://usehooks-ts.com/react-hook/use-intersection-observer

also helpful: https://blog.webdevsimplified.com/2022-01/intersection-observer/

A big problem with the list view was the paint/layout taking a while with all the large-ish images.
This is an attempt to avoid loading all them at once.