### PR TITLE
ui: fix background blur for image

### DIFF
--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -75,7 +75,10 @@ const CardImgBg = styled.div<{
       content: "";
       height: 100%;
       width: 100%;
-      ${p.rounded && `border-radius: 6px;`}
+      ${p.rounded || p.roundDesktop ? `border-radius: 6px;` : ""}
+      -webkit-backdrop-filter: blur(6px);
+      // seems to work on dev without -webkit prefix but fails on prod for some
+      // reason so we prefix above
       backdrop-filter: blur(6px);
       pointer-events: none;
     }`}


### PR DESCRIPTION
I'm not sure why, but backdrop-filter seems to get prefix on dev but not in prod.

from https://github.com/styled-components/styled-components/issues/1045#issuecomment-319359844 it seems like it should be prefixed but doesn't seem to be happening.

related about a bug in an older version but we're on a version newer than that: https://github.com/thysultan/stylis/issues/75#issuecomment-346366676