### PR TITLE
ui: fix date input width

### DIFF
--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -62,12 +62,11 @@ export function ScheduleModal({
             value={toISODateString(isoDate)}
             onChange={handleDateChange}
             type="date"
-            className="mt-2"
+            className="mt-2 w-100"
             style={{
               border: "1px solid var(--color-border)",
               borderRadius: 5,
               padding: "0.25rem",
-              minWidth: "max-content",
             }}
           />
 

--- a/frontend/src/pages/schedule/CalendarDayItemModal.tsx
+++ b/frontend/src/pages/schedule/CalendarDayItemModal.tsx
@@ -144,6 +144,7 @@ export function CalendarDayItemModal({
                   value={toISODateString(localDate)}
                   onChange={handleDateChange}
                   type="date"
+                  className="w-100"
                   style={{
                     border: "1px solid var(--color-border)",
                     borderRadius: 5,


### PR DESCRIPTION
probably need to bite the bullet at some point and use a custom input for dates, but for now this is fine

trying to get iOS and Mac OS to match up is annoying