### PR TITLE
ui: recipe-detail show recent schedules

### DIFF
--- a/backend/recipeyak/models/recipe.py
+++ b/backend/recipeyak/models/recipe.py
@@ -105,9 +105,7 @@ class Recipe(CommonInfo):
         # TODO(sbdchd): can use reverse relation instead
         return Step.objects.filter(recipe=self).order_by("position", "created")
 
-    @property
-    def scheduledrecipe_set(self) -> QuerySet[ScheduledRecipe]:
-        return ScheduledRecipe.objects.filter(recipe=self)
+    scheduledrecipe_set: QuerySet[ScheduledRecipe]
 
     @property
     def step_set(self) -> BaseManager[Step]:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -89,6 +89,11 @@ export type RecipeTimelineItem = {
 
 export type TimelineItem = INote | RecipeTimelineItem
 
+export type RecentSchedule = {
+  readonly id: number
+  readonly on: string
+}
+
 export interface IRecipe {
   readonly id: number
   readonly name: string
@@ -101,6 +106,7 @@ export interface IRecipe {
   readonly modified: string
   readonly tags?: string[]
   readonly ingredients: ReadonlyArray<IIngredient>
+  readonly recentSchedules: ReadonlyArray<RecentSchedule>
   readonly sections: ReadonlyArray<{
     readonly id: number
     readonly title: string

--- a/frontend/src/clock.svg
+++ b/frontend/src/clock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-clock"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>

--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -1,3 +1,4 @@
+import { LocationDescriptor } from "history"
 import * as React from "react"
 
 import { Link } from "@/components/Routing"
@@ -184,7 +185,7 @@ interface IButtonProps {
   readonly disabled?: boolean
   readonly value?: string | ReadonlyArray<string> | number | undefined
   readonly onClick?: (e: React.MouseEvent) => void
-  readonly to?: string
+  readonly to?: string | LocationDescriptor<unknown>
 }
 export const Button = ({
   loading = false,

--- a/frontend/src/components/Routing.tsx
+++ b/frontend/src/components/Routing.tsx
@@ -1,3 +1,4 @@
+import { LocationDescriptor } from "history"
 import {
   Link as RRLink,
   LinkProps as RRLinkProps,
@@ -7,11 +8,14 @@ import {
 
 interface ILinkProps extends RRLinkProps {
   readonly isRaw?: boolean
-  readonly to: string
+  readonly to: string | LocationDescriptor<unknown>
 }
 
 export function Link({ to, replace, isRaw, ...rest }: ILinkProps) {
   if (isRaw) {
+    if (typeof to !== "string") {
+      throw new Error("invalid param passed to link with href")
+    }
     return <a href={to} {...rest} />
   }
   return <RRLink to={to} replace={replace} {...rest} />

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -39,3 +39,24 @@ export const Chevron = () => (
     </g>
   </svg>
 )
+
+const Clock = ({ size }: { size: number }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    // width={24}
+    // height={24}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-clock"
+  >
+    <circle cx={12} cy={12} r={10} />
+    <path d="M12 6v6l4 2" />
+  </svg>
+)
+
+export default Clock

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -44,8 +44,6 @@ const Clock = ({ size }: { size: number }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={size}
-    // width={24}
-    // height={24}
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -18,11 +18,19 @@ export function isInsideChangeWindow(date: Date): boolean {
   return isAfter(date, subDays(new Date(), DELETION_WINDOW_DAYS))
 }
 
-export function formatDistanceToNow(date: Date): string {
+export function formatDistanceToNow(
+  date: Date,
+  options: { allowFuture?: boolean } = {},
+): string {
   const now = new Date()
   // Avoid clock skew, otherwise the distance can say "in a few seconds"
   // sometimes, which doesn't make sense.
-  return formatDistance(min([date, now]), now, { addSuffix: true })
+  //
+  // TODO: I don't think this really handles clock skew
+  if (!options.allowFuture) {
+    date = min([date, now])
+  }
+  return formatDistance(date, now, { addSuffix: true })
 }
 
 export function formatAbsoluteDateTime(

--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -729,6 +729,7 @@ function RecipeInfo(props: {
           recipeId={props.recipe.id}
           recipeName={props.recipe.name}
           recipeIngredients={props.recipe.ingredients}
+          recipeRecentScheduleHistory={props.recipe.recentSchedules}
           editingEnabled={props.editingEnabled}
           toggleEditing={props.toggleEditMode}
         />

--- a/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeTitleDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { useLocation } from "react-router-dom"
 
-import { IIngredient } from "@/api"
+import { IIngredient, RecentSchedule } from "@/api"
 import { copyToClipboard } from "@/clipboard"
 import { Button } from "@/components/Buttons"
 import {
@@ -30,6 +30,7 @@ interface IDropdownProps {
   readonly recipeName: string
   readonly recipeIsArchived: boolean
   readonly recipeIngredients: readonly IIngredient[]
+  readonly recipeRecentScheduleHistory: readonly RecentSchedule[]
   readonly toggleEditing: () => void
   readonly editingEnabled: boolean
   readonly className: string
@@ -39,6 +40,7 @@ export function Dropdown({
   recipeName,
   recipeIsArchived: isArchived,
   recipeIngredients,
+  recipeRecentScheduleHistory,
   toggleEditing,
   editingEnabled,
   className,
@@ -151,6 +153,7 @@ export function Dropdown({
         <ScheduleModal
           recipeId={recipeId}
           recipeName={recipeName}
+          scheduleHistory={recipeRecentScheduleHistory}
           onClose={() => {
             setShowScheduleModal(false)
           }}

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -1,24 +1,30 @@
-import { parseISO } from "date-fns"
+import { format, isFuture, isToday, parseISO, startOfWeek } from "date-fns"
+import { orderBy } from "lodash-es"
 import React from "react"
 import { Link } from "react-router-dom"
 
+import { RecentSchedule } from "@/api"
 import { isMobile } from "@/browser"
 import { Box } from "@/components/Box"
 import { Button } from "@/components/Buttons"
+import Clock from "@/components/icons"
 import { Modal } from "@/components/Modal"
-import { toISODateString } from "@/date"
+import { formatDistanceToNow, formatHumanDate, toISODateString } from "@/date"
 import { useTeamId } from "@/hooks"
 import { useScheduleRecipeCreate } from "@/queries/scheduledRecipeCreate"
 import { scheduleURLFromTeamID } from "@/urls"
+import { addQueryParams } from "@/utils/querystring"
 
 export function ScheduleModal({
   recipeName,
   recipeId,
   onClose,
+  scheduleHistory,
 }: {
   readonly recipeId: number
   readonly recipeName: string
   readonly onClose: () => void
+  readonly scheduleHistory: readonly RecentSchedule[]
 }) {
   const [isoDate, setIsoDate] = React.useState(toISODateString(new Date()))
   const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -92,6 +98,45 @@ export function ScheduleModal({
                   ? "schedule"
                   : "scheduling..."}
               </Button>
+            </Box>
+          </Box>
+
+          <Box dir="col">
+            <div className="fw-bold">Recent Schedules</div>
+            <Box dir="col" gap={2}>
+              {orderBy(scheduleHistory, (x) => x.on).map((x, i) => {
+                const on = parseISO(x.on)
+                const week = toISODateString(startOfWeek(on))
+                const to = {
+                  pathname: scheduleUrl,
+                  search: addQueryParams(location.search, { week }),
+                }
+                return (
+                  <Box space="between" align="center" key={i}>
+                    <Link
+                      to={to}
+                      className="flex-grow-1"
+                      style={{ lineHeight: "1.3" }}
+                    >
+                      <div className="fw-500">
+                        {format(on, "E")} ∙ {formatHumanDate(on)}
+                      </div>
+                      <Box gap={1}>
+                        {isFuture(on) && <Clock size={14} />}
+                        <div>
+                          {isToday(on)
+                            ? // avoid showing "3 hours ago" for today
+                              ""
+                            : formatDistanceToNow(on, { allowFuture: true })}
+                        </div>
+                      </Box>
+                    </Link>
+                    <Button size="small" to={to}>
+                      view
+                    </Button>
+                  </Box>
+                )
+              })}
             </Box>
           </Box>
         </Box>

--- a/frontend/src/utils/querystring.ts
+++ b/frontend/src/utils/querystring.ts
@@ -4,17 +4,25 @@ export function setQueryParams(
   history: History<unknown>,
   paramUpdates: Record<string, string>,
 ) {
-  const params = new URLSearchParams(window.location.search)
-  Object.entries(paramUpdates).forEach(([key, value]) => {
-    params.set(key, value)
-  })
+  const search = addQueryParams(history.location.search, paramUpdates)
   void Promise.resolve().then(() => {
     // NOTE: we need to use react router history, otherwise the react version of
     // location won't update
     history.replace({
-      search: "?" + params.toString(),
+      search,
     })
   })
+}
+
+export function addQueryParams(
+  search: string,
+  paramUpdates: Record<string, string>,
+): string {
+  const params = new URLSearchParams(search)
+  Object.entries(paramUpdates).forEach(([key, value]) => {
+    params.set(key, value)
+  })
+  return "?" + params.toString()
 }
 
 export function removeQueryParams(


### PR DESCRIPTION
Now when you use the schedule modal on a recipe we show links to recent schedules (basically to avoid you scheduling the same recipe twice)

<img width="417" alt="Screen Shot 2023-04-15 at 3 35 42 PM" src="https://user-images.githubusercontent.com/7340772/232250182-cb2d32fc-ace6-44cb-8a39-3466ac573057.png">
<img width="1624" alt="Screen Shot 2023-04-15 at 3 35 46 PM" src="https://user-images.githubusercontent.com/7340772/232250184-da3ac46b-64f0-4c5a-9933-f7ecb7cdee49.png">
