### PR TITLE
ui: recipe-detail recent schedules date issues & empty state

### DIFF
--- a/frontend/src/date.test.ts
+++ b/frontend/src/date.test.ts
@@ -1,6 +1,13 @@
-import { addDays, subDays, subHours, subMinutes } from "date-fns"
+import {
+  addDays,
+  addHours,
+  startOfDay,
+  subDays,
+  subHours,
+  subMinutes,
+} from "date-fns"
 
-import { formatHumanDateTimeRaw } from "@/date"
+import { formatDistanceToNow, formatHumanDateTimeRaw } from "@/date"
 
 test("timezone set to UTC", () => {
   expect(new Date().getTimezoneOffset()).toBe(0)
@@ -54,4 +61,17 @@ describe("formatHumanDateTimeRaw", () => {
       "Oct 5, 2021 at 10:10 pm",
     )
   })
+})
+
+test("formatDistanceToNow", () => {
+  const now = startOfDay(new Date())
+  // check that we ignore hours
+  const inFuture = addHours(addDays(startOfDay(now), 4), 12)
+  expect(
+    formatDistanceToNow(inFuture, {
+      allowFuture: true,
+      now,
+      ignoreHours: true,
+    }),
+  ).toMatchInlineSnapshot('"in 4 days"')
 })

--- a/frontend/src/date.ts
+++ b/frontend/src/date.ts
@@ -1,4 +1,4 @@
-import { differenceInMonths, isSameDay, isSameYear } from "date-fns"
+import { differenceInMonths, isSameDay, isSameYear, startOfDay } from "date-fns"
 import format from "date-fns/format"
 import formatDistance from "date-fns/formatDistance"
 import isAfter from "date-fns/isAfter"
@@ -20,14 +20,20 @@ export function isInsideChangeWindow(date: Date): boolean {
 
 export function formatDistanceToNow(
   date: Date,
-  options: { allowFuture?: boolean } = {},
+  options: { allowFuture?: boolean; now?: Date; ignoreHours?: boolean } = {},
 ): string {
-  const now = new Date()
-  // Avoid clock skew, otherwise the distance can say "in a few seconds"
-  // sometimes, which doesn't make sense.
-  //
-  // TODO: I don't think this really handles clock skew
+  let now = options.now ?? new Date()
+  if (options.ignoreHours) {
+    // Date is really a DateTime and we want Date in this case so we use
+    // `startOfDay` to get there.
+    date = startOfDay(date)
+    now = startOfDay(now)
+  }
   if (!options.allowFuture) {
+    // Avoid clock skew, otherwise the distance can say "in a few seconds"
+    // sometimes, which doesn't make sense.
+    //
+    // TODO: I don't think this really handles clock skew
     date = min([date, now])
   }
   return formatDistance(date, now, { addSuffix: true })

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -49,7 +49,10 @@ function RecentSchedules({
                     {isToday(on)
                       ? // avoid showing "3 hours ago" for today
                         ""
-                      : formatDistanceToNow(on, { allowFuture: true })}
+                      : formatDistanceToNow(on, {
+                          allowFuture: true,
+                          ignoreHours: true,
+                        })}
                   </div>
                 </Box>
               </Link>

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -15,6 +15,55 @@ import { useScheduleRecipeCreate } from "@/queries/scheduledRecipeCreate"
 import { scheduleURLFromTeamID } from "@/urls"
 import { addQueryParams } from "@/utils/querystring"
 
+function RecentSchedules({
+  scheduleHistory,
+  scheduleUrl,
+}: {
+  readonly scheduleHistory: readonly RecentSchedule[]
+  readonly scheduleUrl: string
+}) {
+  return (
+    <Box dir="col">
+      <div className="fw-bold">Recent Schedules</div>
+      <Box dir="col" gap={2}>
+        {orderBy(scheduleHistory, (x) => x.on).map((x, i) => {
+          const on = parseISO(x.on)
+          const week = toISODateString(startOfWeek(on))
+          const to = {
+            pathname: scheduleUrl,
+            search: addQueryParams(location.search, { week }),
+          }
+          return (
+            <Box space="between" align="center" key={i}>
+              <Link
+                to={to}
+                className="flex-grow-1"
+                style={{ lineHeight: "1.3" }}
+              >
+                <div className="fw-500">
+                  {format(on, "E")} ∙ {formatHumanDate(on)}
+                </div>
+                <Box gap={1}>
+                  {isFuture(on) && <Clock size={14} />}
+                  <div>
+                    {isToday(on)
+                      ? // avoid showing "3 hours ago" for today
+                        ""
+                      : formatDistanceToNow(on, { allowFuture: true })}
+                  </div>
+                </Box>
+              </Link>
+              <Button size="small" to={to}>
+                view
+              </Button>
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}
+
 export function ScheduleModal({
   recipeName,
   recipeId,
@@ -101,44 +150,14 @@ export function ScheduleModal({
             </Box>
           </Box>
 
-          <Box dir="col">
-            <div className="fw-bold">Recent Schedules</div>
-            <Box dir="col" gap={2}>
-              {orderBy(scheduleHistory, (x) => x.on).map((x, i) => {
-                const on = parseISO(x.on)
-                const week = toISODateString(startOfWeek(on))
-                const to = {
-                  pathname: scheduleUrl,
-                  search: addQueryParams(location.search, { week }),
-                }
-                return (
-                  <Box space="between" align="center" key={i}>
-                    <Link
-                      to={to}
-                      className="flex-grow-1"
-                      style={{ lineHeight: "1.3" }}
-                    >
-                      <div className="fw-500">
-                        {format(on, "E")} ∙ {formatHumanDate(on)}
-                      </div>
-                      <Box gap={1}>
-                        {isFuture(on) && <Clock size={14} />}
-                        <div>
-                          {isToday(on)
-                            ? // avoid showing "3 hours ago" for today
-                              ""
-                            : formatDistanceToNow(on, { allowFuture: true })}
-                        </div>
-                      </Box>
-                    </Link>
-                    <Button size="small" to={to}>
-                      view
-                    </Button>
-                  </Box>
-                )
-              })}
-            </Box>
-          </Box>
+          {scheduleHistory.length > 0 && (
+            // we intentionally hide from view when there are no scheduled
+            // recipes in the history window -- avoids having an empty state
+            <RecentSchedules
+              scheduleHistory={scheduleHistory}
+              scheduleUrl={scheduleUrl}
+            />
+          )}
         </Box>
       }
     />


### PR DESCRIPTION
we were including hours in our date calculations which resulted in errors

also added an empty state (hide the UI) when there aren't any recently scheduled entries.