### PR TITLE
ui: hacky fix for intersection observer lazy loading images

### DIFF
--- a/frontend/src/components/Image.tsx
+++ b/frontend/src/components/Image.tsx
@@ -114,7 +114,7 @@ export function Image({
   readonly lazyLoad?: boolean
 }) {
   const ref = useRef<HTMLDivElement | null>(null)
-  const entry = useIntersectionObserver(ref, {
+  const entry = useIntersectionObserver(ref, sources?.url, {
     // How much to expand element's margin before calculating intersections
     // Means we load images before they're in view so there isn't a pop in.
     //

--- a/frontend/src/useIntersectionObserver.ts
+++ b/frontend/src/useIntersectionObserver.ts
@@ -1,20 +1,33 @@
 import { RefObject, useEffect, useState } from "react"
 
+// HACK: this leaks memory
+let seenBefore = new Set<string>()
+
+type Entry = Pick<IntersectionObserverEntry, "isIntersecting">
+
 // from: https://usehooks-ts.com/react-hook/use-intersection-observer
 export function useIntersectionObserver(
   elementRef: RefObject<Element>,
+  elementId: string | undefined,
   {
     threshold = 0,
     root = null,
     rootMargin = "0%",
     freezeOnceVisible = true,
   }: IntersectionObserverInit & { freezeOnceVisible?: boolean },
-): IntersectionObserverEntry | undefined {
-  const [entry, setEntry] = useState<IntersectionObserverEntry>()
+): Entry | undefined {
+  const [entry, setEntry] = useState<Entry>({
+    isIntersecting: elementId != null && seenBefore.has(elementId),
+  })
 
   const frozen = entry?.isIntersecting && freezeOnceVisible
 
-  const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
+  const updateEntry = ([entry]: Entry[]): void => {
+    // Keep track of seen Images so we don't have a flash of "not intersecting"
+    // when navigating from the browser page to the detail page and back
+    if (entry.isIntersecting && freezeOnceVisible && elementId != null) {
+      seenBefore.add(elementId)
+    }
     setEntry(entry)
   }
 


### PR DESCRIPTION
when naving back from the detail page to the list view the images will hide and then pop in when we've already loaded them.

this pr updates the useIntersectionObserver to keep a cache of urls we've already seen / intend to keep loaded so we don't have this flash