### PR TITLE
ui: fix client side filter parsing to allow capitalized versions

### DIFF
--- a/frontend/src/query-parser.test.ts
+++ b/frontend/src/query-parser.test.ts
@@ -7,6 +7,9 @@ describe("parseQuery", () => {
   test("simple", () => {
     expect(parseQuery("tag:chris")).toEqual([{ field: "tag", value: "chris" }])
   })
+  test("capital", () => {
+    expect(parseQuery("Tag:chris")).toEqual([{ field: "tag", value: "chris" }])
+  })
   test("single quotes", () => {
     expect(parseQuery("name:'mark bittman'")).toEqual([
       { field: "name", value: "mark bittman", quoted: true },

--- a/frontend/src/query-parser.ts
+++ b/frontend/src/query-parser.ts
@@ -68,8 +68,8 @@ export function parseQuery(query: string): QueryNode[] {
       // if we just have "tag:", we want to list all results. But if we have
       // "tag: ", we treat that as a normal string, not a field.
       return (
-        remainder.startsWith(renderField(field)) &&
-        !remainder.startsWith(renderField(field) + " ")
+        remainder.toLocaleLowerCase().startsWith(renderField(field)) &&
+        !remainder.toLocaleLowerCase().startsWith(renderField(field) + " ")
       )
     })
 


### PR DESCRIPTION
support Ingredient:foo in addition to ingredient:foo