### PR TITLE
api: fix parsing ingredients with commas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             python -m pip install pip==22.2.2
-            command -v poetry || python -m pip install --user poetry==1.1.9
+            command -v poetry || python -m pip install --user poetry==1.3.2
             poetry config virtualenvs.in-project true
             poetry run pip install setuptools==61.1.1
             poetry install
@@ -72,7 +72,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             python -m pip install pip==22.2.2
-            command -v poetry || python -m pip install --user poetry==1.1.9
+            command -v poetry || python -m pip install --user poetry==1.3.2
             poetry config virtualenvs.in-project true
             poetry run pip install setuptools==61.1.1
             poetry install
@@ -116,7 +116,7 @@ jobs:
             echo 'export PATH="$PATH":"$HOME"/.local/bin' >> $BASH_ENV
             source $BASH_ENV
             python -m pip install pip==22.2.2
-            command -v poetry || python -m pip install --user poetry==1.1.9
+            command -v poetry || python -m pip install --user poetry==1.3.2
             poetry config virtualenvs.in-project true
             poetry run pip install setuptools==61.1.1
             poetry install

--- a/backend/recipeyak/cumin/quantity.py
+++ b/backend/recipeyak/cumin/quantity.py
@@ -442,8 +442,34 @@ def parse_quantity_name(text: str) -> tuple[str, str]:
     return (quantity.strip(), name.strip())
 
 
+NON_INGREDIENT_NAMES = frozenset({"bone-in", "skin-on", "fresh"})
+
+
+def parse_name_description(text: str) -> tuple[str, str]:
+    """
+    Some basic heuristics to partition a string into a name and description pair
+    """
+    prefix = ""
+    temp = []
+    for word in text.split():
+        if word.endswith(","):
+            word_stripped = word.removesuffix(",")
+            if word_stripped in NON_INGREDIENT_NAMES:
+                temp.append(word)
+                continue
+            temp.append(word_stripped)
+            prefix = " ".join(temp)
+            temp = []
+        else:
+            temp.append(word)
+    suffix = " ".join(temp)
+    if not prefix:
+        return (suffix, "")
+    return (prefix, suffix)
+
+
 def parse_ingredient(text: str) -> IngredientResult:
-    quantity_name, _, description = text.partition(",")
+    quantity_name, description = parse_name_description(text)
     quantity, name = parse_quantity_name(quantity_name)
     is_optional = "optional" in text.lower()
 

--- a/backend/recipeyak/cumin/quantity_test.py
+++ b/backend/recipeyak/cumin/quantity_test.py
@@ -312,6 +312,12 @@ def test_parse_quantity_name(ingredient: str, expected: tuple[str, str]) -> None
                 optional=True,
             ),
         ),
+        (
+            "2 pounds (900g) bone-in, skin-on chicken thighs",
+            IngredientResult(
+                quantity="2 pounds (900g)", name="bone-in, skin-on chicken thighs"
+            ),
+        ),
     ],
 )
 def test_parse_ingredient(ingredient: str, expected: IngredientResult) -> None:


### PR DESCRIPTION
seems like they're called coordinate commas so we're using a slightly less naive heuristic compared to before