### PR TITLE
ui: fix 301 with ably auth api

### DIFF
--- a/frontend/src/queries/scheduledRecipeList.ts
+++ b/frontend/src/queries/scheduledRecipeList.ts
@@ -10,7 +10,7 @@ import { onScheduledRecipeUpdateSuccess } from "@/queries/scheduledRecipeUpdate"
 import { unwrapEither } from "@/query"
 
 configureAbly({
-  authUrl: "/api/v1/auth/ably",
+  authUrl: "/api/v1/auth/ably/",
 })
 
 type ScheduledRecipeUpdated = {


### PR DESCRIPTION
```
[16/Sep/2023 17:44:06] "GET /api/v1/auth/ably?rnd=06675516961737249 HTTP/1.1" 301 0
[16/Sep/2023 17:44:06] "GET /api/v1/auth/ably/?rnd=06675516961737249 HTTP/1.1" 200 208
```

after:

```
[17/Sep/2023 03:57:57] "GET /api/v1/auth/ably/?rnd=2287839871387971 HTTP/1.1" 200 208
```