### PR TITLE
kill systemd jobs after 10 minutes

### DIFF
--- a/infra/systemd-services/recipeyak-backfill_image_placeholders.service
+++ b/infra/systemd-services/recipeyak-backfill_image_placeholders.service
@@ -8,5 +8,7 @@ ExecStart=/usr/bin/docker run \
         --env-file=/root/.env-production \
         recipeyak/django:{{GIT_SHA}} \
         ./.venv/bin/python -m recipeyak.jobs.backfill_image_placeholders --no-dry-run
+# kill after 10 minutes
+TimeoutSec=600
 [Install]
 WantedBy=multi-user.target

--- a/infra/systemd-services/recipeyak-backup-postgres.service
+++ b/infra/systemd-services/recipeyak-backup-postgres.service
@@ -3,5 +3,7 @@ Description=Runs backup of postgres database
 [Service]
 EnvironmentFile=/root/.env-production
 ExecStart=/usr/local/bin/sentry-cli monitors run backup-postgres -- /etc/recipeyak/backup-postgres
+# kill after 10 minutes
+TimeoutSec=600
 [Install]
 WantedBy=multi-user.target

--- a/infra/systemd-services/recipeyak-remove_old_checklists.service
+++ b/infra/systemd-services/recipeyak-remove_old_checklists.service
@@ -8,5 +8,7 @@ ExecStart=/usr/bin/docker run \
         --env-file=/root/.env-production \
         recipeyak/django:{{GIT_SHA}} \
         ./.venv/bin/python -m recipeyak.jobs.remove_old_checklists
+# kill after 10 minutes
+TimeoutSec=600
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The backfill image job got stuck. This should prevent that in the future.

The 10 minutes is pretty arbitrary. Most jobs finish in under a second