### PR TITLE
ui: selectable section titles, normalized notes

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -6,6 +6,7 @@ import smartypants from "remark-smartypants"
 
 import { Link } from "@/components/Routing"
 import * as settings from "@/settings"
+import { normalizeUnitsFracs } from "@/text"
 import { styled } from "@/theme"
 
 const MarkdownWrapper = styled.div`
@@ -78,18 +79,12 @@ const renderers = {
 interface IMarkdownProps {
   readonly children: string
   readonly onClick?: (_: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
-  readonly className?: string
   readonly title?: string
 }
 
-export function Markdown({
-  children: text,
-  className,
-  title,
-  onClick,
-}: IMarkdownProps) {
+export function Markdown({ children: text, title, onClick }: IMarkdownProps) {
   return (
-    <MarkdownWrapper className={className} title={title} onClick={onClick}>
+    <MarkdownWrapper className="selectable" title={title} onClick={onClick}>
       <ReactMarkdown
         allowedElements={ALLOWED_MARKDOWN_TYPES}
         remarkPlugins={[
@@ -114,7 +109,7 @@ export function Markdown({
           // auto convert -- to em dash and similar
           smartypants,
         ]}
-        children={text}
+        children={normalizeUnitsFracs(text)}
         components={renderers}
         unwrapDisallowed
       />

--- a/frontend/src/pages/profile/Profile.page.tsx
+++ b/frontend/src/pages/profile/Profile.page.tsx
@@ -1,5 +1,5 @@
 import { parseISO } from "date-fns"
-import { groupBy } from "lodash-es"
+import { groupBy, orderBy } from "lodash-es"
 import React from "react"
 import { RouteComponentProps } from "react-router"
 
@@ -334,9 +334,12 @@ function ActivityLog({
   const activityByDay = Object.values(groupBy(activity, "created_date"))
   // Map<Date, Array<Activity>>
   for (const dayOfActivity of activityByDay) {
-    // Map<RecipeId, Array<Activity>>
+    // Array<Array<Activity>>
     const activityByRecipe = Object.values(
-      groupBy(dayOfActivity, (x) => [x.created_date, x.recipe_id]),
+      groupBy(orderBy(dayOfActivity, "created", "desc"), (x) => [
+        x.created_date,
+        x.recipe_id,
+      ]),
     )
     let isFirst = true
     for (const activitiesForRecipe of activityByRecipe) {

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -263,7 +263,7 @@ export function Note({ note, recipeId, className, openImage }: INoteProps) {
         </Box>
         {!isEditing ? (
           <Box dir="col">
-            <Markdown className="selectable">{note.text}</Markdown>
+            <Markdown>{note.text}</Markdown>
             <Box gap={1} dir="col">
               <Box wrap gap={1}>
                 {note.attachments.map((attachment) => (

--- a/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
+++ b/frontend/src/pages/recipe-detail/RecipeDetail.page.tsx
@@ -338,18 +338,24 @@ const MyRecipeTitle = styled.div`
   font-family: Georgia, serif;
 `
 
-const RecipeMetaItem = styled.div<{ inline?: boolean }>`
-  ${(props) =>
-    props.inline
-      ? `
-  display: flex;
-  gap: 0.25rem;
-  `
-      : `
-  display: grid;
-  grid-template-columns: 90px 1fr;
-`}
-`
+function RecipeMetaItem({
+  inline,
+  children,
+  label,
+}: {
+  inline?: boolean
+  children: React.ReactNode
+  label: string
+}) {
+  return (
+    <div style={{ display: "flex", gap: inline ? "0.25rem" : undefined }}>
+      <div className="bold" style={!inline ? { width: 90 } : undefined}>
+        {label}
+      </div>
+      <div className="selectable">{children}</div>
+    </div>
+  )
+}
 
 const RecipeDetailsContainer = styled.div<{ spanColumns?: boolean }>`
   display: flex;
@@ -708,28 +714,22 @@ function RecipeInfo(props: {
             </RecipeTitleCenter>
             <RecipeMetaContainer inline={inlineLayout}>
               {notEmpty(props.recipe.time) && (
-                <RecipeMetaItem inline={inlineLayout}>
-                  <div className="bold">Time</div>
-                  <div className="selectable">{props.recipe.time}</div>
+                <RecipeMetaItem inline={inlineLayout} label={"Time"}>
+                  {props.recipe.time}
                 </RecipeMetaItem>
               )}
               {notEmpty(props.recipe.servings) && (
-                <RecipeMetaItem inline={inlineLayout}>
-                  <div className="bold">Servings</div>
-                  <div className="selectable">{props.recipe.servings}</div>
+                <RecipeMetaItem inline={inlineLayout} label={"Servings"}>
+                  <RecipeSource source={props.recipe.servings} />
                 </RecipeMetaItem>
               )}
               {notEmpty(props.recipe.source) && (
-                <RecipeMetaItem inline={inlineLayout}>
-                  <div className="bold">From</div>
-                  <div className="selectable">
-                    <RecipeSource source={props.recipe.source} />
-                  </div>
+                <RecipeMetaItem inline={inlineLayout} label={"From"}>
+                  <RecipeSource source={props.recipe.source} />
                 </RecipeMetaItem>
               )}
               {(props.recipe.tags?.length ?? 0) > 0 && (
-                <RecipeMetaItem inline={inlineLayout}>
-                  <div className="bold">Tags</div>
+                <RecipeMetaItem inline={inlineLayout} label={"Tags"}>
                   <Box gap={2}>
                     {props.recipe.tags?.map((x) => (
                       <Link

--- a/frontend/src/pages/recipe-detail/Section.tsx
+++ b/frontend/src/pages/recipe-detail/Section.tsx
@@ -157,7 +157,7 @@ export function Section({
     <li
       ref={editingEnabled ? ref : undefined}
       style={style}
-      className="mt-1 bold text-small"
+      className="mt-1 bold text-small selectable"
       title={editingEnabled ? "click to edit" : undefined}
       onClick={() => {
         if (editingEnabled) {

--- a/frontend/src/pages/recipe-detail/Step.tsx
+++ b/frontend/src/pages/recipe-detail/Step.tsx
@@ -112,7 +112,7 @@ function Step({
 }
 
 export function StepView({ text }: { text: string }) {
-  return <Markdown className="selectable">{normalizeUnitsFracs(text)}</Markdown>
+  return <Markdown>{text}</Markdown>
 }
 
 function StepBody({

--- a/frontend/src/pages/recipe-detail/Step.tsx
+++ b/frontend/src/pages/recipe-detail/Step.tsx
@@ -44,7 +44,6 @@ import { DragDrop, handleDndHover } from "@/dragDrop"
 import { IRecipe } from "@/queries/recipeFetch"
 import { useStepDelete } from "@/queries/stepDelete"
 import { useStepUpdate } from "@/queries/stepUpdate"
-import { normalizeUnitsFracs } from "@/text"
 
 interface IStepProps {
   readonly index: number


### PR DESCRIPTION
- make section titles selectable
- normalize notes (aka tablespoon and Teaspoon)
  - also refactor <Markdown a bit to include selectable class
- fix sub-day ordering in profile activity, the items during the day weren't ordered properly
- fix selecting on the recipe page by avoiding some css grid