### PR TITLE
ui: highlight baking soda and powder

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,16 +1,20 @@
+import { findAndReplace } from "mdast-util-find-and-replace"
 import React from "react"
 import ReactMarkdown, { Components } from "react-markdown"
 import remarkBreaks from "remark-breaks"
-import remarkGfm from "remark-gfm"
+import remarkGfm, { Root } from "remark-gfm"
 import smartypants from "remark-smartypants"
 
 import { Link } from "@/components/Routing"
 import * as settings from "@/settings"
 import { normalizeUnitsFracs } from "@/text"
 import { styled } from "@/theme"
+import {
+  THEME_CSS_BAKING_POWDER,
+  THEME_CSS_BAKING_SODA,
+} from "@/themeConstants"
 
 const MarkdownWrapper = styled.div`
-  word-break: break-word;
   a {
     text-decoration: underline;
   }
@@ -56,6 +60,8 @@ const ALLOWED_MARKDOWN_TYPES: (keyof Components)[] = [
   "link",
   "ol",
   "ul",
+  // allow our baking soda, baking powder replacer thing to work
+  "span",
 ]
 
 function renderLink({
@@ -76,19 +82,39 @@ const renderers = {
   a: renderLink,
 }
 
-interface IMarkdownProps {
-  readonly children: string
-  readonly onClick?: (_: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
-  readonly title?: string
+function remarkHighlightBakingSodaAndPowder() {
+  return (tree: Root): undefined => {
+    findAndReplace(tree, [
+      /(baking soda|baking powder)/gi,
+      (value: string) => {
+        // Took me a while to figure out how to inject a <span> into the markdown
+        // Spelunking through the various packages lead me to:
+        // https://github.com/rhysd/remark-emoji/blob/e4b9918ede15cddd6316f410cc53b83ed9afe549/index.js#L22-L37
+        //
+        // We need to dupe the value otherwise it doesn't typecheck, runtime seems fine
+        const cls =
+          value === "baking soda"
+            ? THEME_CSS_BAKING_SODA
+            : THEME_CSS_BAKING_POWDER
+        return {
+          type: "text",
+          value,
+          data: {
+            hName: "span",
+            hProperties: {
+              class: cls,
+            },
+            hChildren: [{ type: "text", value }],
+          },
+        }
+      },
+    ])
+  }
 }
 
-export function Markdown({ children: text, title, onClick }: IMarkdownProps) {
+export function Markdown({ children: text }: { children: string }) {
   return (
-    <MarkdownWrapper
-      className="cursor-auto select-text"
-      title={title}
-      onClick={onClick}
-    >
+    <MarkdownWrapper className="cursor-auto select-text [word-break:break-word]">
       <ReactMarkdown
         allowedElements={ALLOWED_MARKDOWN_TYPES}
         remarkPlugins={[
@@ -112,6 +138,7 @@ export function Markdown({ children: text, title, onClick }: IMarkdownProps) {
           remarkBreaks,
           // auto convert -- to em dash and similar
           smartypants,
+          remarkHighlightBakingSodaAndPowder,
         ]}
         children={normalizeUnitsFracs(text)}
         components={renderers}

--- a/frontend/src/pages/recipe-detail/IngredientView.tsx
+++ b/frontend/src/pages/recipe-detail/IngredientView.tsx
@@ -1,7 +1,12 @@
 import { DragElementWrapper, DragSourceOptions } from "react-dnd"
 
+import { clx } from "@/classnames"
 import { IIngredient } from "@/queries/recipeFetch"
 import { normalizeUnitsFracs } from "@/text"
+import {
+  THEME_CSS_BAKING_POWDER,
+  THEME_CSS_BAKING_SODA,
+} from "@/themeConstants"
 
 interface IIngredientVIewProps {
   readonly quantity: IIngredient["quantity"]
@@ -17,16 +22,25 @@ export function IngredientViewContent({
   description,
   optional,
 }: Omit<IIngredientVIewProps, "dragRef">) {
-  const fmtDescription = description
-    ? ", " + normalizeUnitsFracs(description)
+  description = description
+    ? ", " + normalizeUnitsFracs(description).trim()
     : ""
+  name = normalizeUnitsFracs(name.trim())
+  quantity = normalizeUnitsFracs(quantity).trim()
+  const isBakingSoda = name.toLocaleLowerCase() === "baking soda"
+  const isBakingPowder = name.toLocaleLowerCase() === "baking powder"
   return (
     <>
-      <span className="font-medium">
-        {normalizeUnitsFracs(quantity).trim()}
-      </span>{" "}
-      {normalizeUnitsFracs(name.trim())}
-      {fmtDescription.trim()}{" "}
+      <span className="font-medium">{quantity}</span>{" "}
+      <span
+        className={clx(
+          isBakingSoda && THEME_CSS_BAKING_SODA,
+          isBakingPowder && THEME_CSS_BAKING_POWDER,
+        )}
+      >
+        {name}
+      </span>
+      {description}{" "}
       {optional ? (
         <span className="text-[var(--color-text-muted)]">[optional]</span>
       ) : (

--- a/frontend/src/themeConstants.ts
+++ b/frontend/src/themeConstants.ts
@@ -1,6 +1,9 @@
 export type Theme = keyof typeof THEME_META
 export type ThemeMode = "single" | "sync_with_system"
 
+export const THEME_CSS_BAKING_SODA = "font-medium text-red-400 italic"
+export const THEME_CSS_BAKING_POWDER = "font-medium text-pink-400"
+
 export const THEME_META = {
   light: {
     displayName: "Light",


### PR DESCRIPTION

<img width="1624" alt="Screenshot 2023-12-19 at 9 57 11 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/1cbb3d8e-3239-48f6-846a-c74fe6eed1e6">
<img width="1624" alt="Screenshot 2023-12-19 at 9 57 29 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/03f049b5-313b-4849-b77b-98e535872dff">
<img width="1624" alt="Screenshot 2023-12-19 at 9 57 26 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/8f4c84cd-b571-47dc-be50-a9aefd68bd16">
<img width="1624" alt="Screenshot 2023-12-19 at 9 57 22 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/769256e7-dd55-41ea-a712-24ea6a1a0f90">
<img width="1624" alt="Screenshot 2023-12-19 at 9 57 32 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/f36e23e1-3973-40fc-b5b6-d4c853d01f5e">


Alternative considered, using underline instead of changing the text color:

```js
export const THEME_CSS_BAKING_SODA =
  "underline decoration-red-500 underline-offset-2 italic"
export const THEME_CSS_BAKING_POWDER =
  "underline decoration-pink-400 underline-offset-2"
```

<img width="1240" alt="Screenshot 2023-12-19 at 10 04 11 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/f6dcc8d3-4184-476a-bc0d-f1f7dca43862">
<img width="630" alt="Screenshot 2023-12-19 at 10 04 01 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/3d42aed1-cc27-4f15-ab6b-694af3e9fb9b">
