### PR TITLE
api: improve pytest startup

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -105,7 +105,9 @@ ban-relative-imports = "all"
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "recipeyak.django.settings"
 python_files = "*_test.py *_tests.py"
-addopts = "-s --pdbcls IPython.terminal.debugger:TerminalPdb --reuse-db -p no:warnings"
+addopts = "-s --pdbcls IPython.terminal.debugger:TerminalPdb --reuse-db -p no:warnings -p no:pastebin -p no:nose -p no:junitxml -p no:doctest -p no:freeze_support -p no:stepwise -p no:python_path -p no:setuponly -p no:setupplan -p no:legacypath-tmpdir -p no:unittest"
+testpaths = "recipeyak"
+
 
 [tool.mypy]
 mypy_path = "./typings"

--- a/backend/recipeyak/api/upload_start_view.py
+++ b/backend/recipeyak/api/upload_start_view.py
@@ -12,8 +12,9 @@ from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import filter_recipes, get_team
 from recipeyak.models.recipe import Recipe
-from recipeyak.models.upload import Upload, s3
+from recipeyak.models.upload import Upload
 from recipeyak.models.user import User
+from recipeyak.storage import s3
 
 
 class StartUploadParams(RequestParams):
@@ -70,7 +71,7 @@ def upload_start_view(request: AuthedHttpRequest) -> JsonResponse:
     )
     upload.save()
 
-    upload_url = s3.generate_presigned_url(
+    upload_url = s3().generate_presigned_url(
         "put_object",
         Params={
             "Bucket": config.STORAGE_BUCKET_NAME,

--- a/backend/recipeyak/cumin/cat.py
+++ b/backend/recipeyak/cumin/cat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping
+from functools import cache
 from typing import Any
 
 from recipeyak.cumin.inflect import singularize
@@ -452,9 +452,10 @@ DEPARTMENT_MAPPING = {
 }
 
 
-def create_trie(mapping: Mapping[str, set[str]]) -> dict[str, Any]:
+@cache
+def create_trie() -> dict[str, Any]:
     trie: dict[str, Any] = {}
-    for category, ingredients in mapping.items():
+    for category, ingredients in DEPARTMENT_MAPPING.items():
         for ingredient in ingredients:
             tree = trie
             words = [singularize(x) for x in ingredient.replace("-", " ").split()]
@@ -467,13 +468,12 @@ def create_trie(mapping: Mapping[str, set[str]]) -> dict[str, Any]:
                 is_last = idx == len(words) - 1
                 if is_last and "$" not in tree:
                     tree["$"] = (category, len(ingredient))
+
     return trie
 
 
-trie = create_trie(DEPARTMENT_MAPPING)
-
-
-def search(item: str, trie: dict[str, Any] = trie) -> dict[str, set[int]]:
+def search(item: str) -> dict[str, set[int]]:
+    trie = create_trie()
     items = [singularize(x) for x in item.split()]
     counts = defaultdict(set)
     for start in range(len(items)):

--- a/backend/recipeyak/cumin/cat_test.py
+++ b/backend/recipeyak/cumin/cat_test.py
@@ -110,16 +110,3 @@ def test_categorize_ingredient_test_cases(snapshot: Any) -> None:
     ).splitlines()
 
     assert sorted((w, category(w)) for w in cases) == snapshot()
-
-
-def test_trie() -> None:
-    mapping = {
-        "spices": {
-            "red chile flakes",
-            "chile powder",
-        }
-    }
-
-    trie = create_trie(mapping)
-    assert search("red chile flakes", trie=trie)
-    assert search("red chile powder", trie=trie)

--- a/backend/recipeyak/cumin/cat_test.py
+++ b/backend/recipeyak/cumin/cat_test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-from recipeyak.cumin.cat import category, create_trie, search
+from recipeyak.cumin.cat import category
 
 
 def test_categorize_ingredients() -> None:

--- a/backend/recipeyak/models/upload.py
+++ b/backend/recipeyak/models/upload.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import boto3
-from botocore.client import Config
 from django.db import models
 from yarl import URL
 
@@ -12,13 +10,6 @@ from recipeyak.models.base import CommonInfo
 
 if TYPE_CHECKING:
     from recipeyak.models import Note, Recipe, User  # noqa: F401
-
-s3 = boto3.client(
-    "s3",
-    config=Config(signature_version="s3v4"),
-    aws_access_key_id=config.AWS_ACCESS_KEY_ID,
-    aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
-)
 
 
 def public_url(key: str) -> str:

--- a/backend/recipeyak/scraper/scrape_recipe.py
+++ b/backend/recipeyak/scraper/scrape_recipe.py
@@ -19,10 +19,11 @@ from recipe_scrapers import scrape_html as parse_html
 
 from recipeyak import config
 from recipeyak.models import Scrape
-from recipeyak.models.upload import Upload, s3
+from recipeyak.models.upload import Upload
 from recipeyak.models.user import User
 from recipeyak.scraper.extract import extract_recipe
 from recipeyak.scraper.fetch import fetch_bytes, fetch_content_length
+from recipeyak.storage import s3
 
 
 @dataclass
@@ -105,7 +106,7 @@ def _find_and_save_largest_image(
         )
         upload.save()
         # put_object seems simplier than upload_fileobj so going with it
-        s3.put_object(
+        s3().put_object(
             Bucket=config.STORAGE_BUCKET_NAME,
             Key=key,
             Body=image_res,

--- a/backend/recipeyak/storage.py
+++ b/backend/recipeyak/storage.py
@@ -1,0 +1,17 @@
+from functools import cache
+
+import boto3
+from botocore.client import Config
+from mypy_boto3_s3 import S3Client
+
+from recipeyak import config
+
+
+@cache
+def s3() -> S3Client:
+    return boto3.client(
+        "s3",
+        config=Config(signature_version="s3v4"),
+        aws_access_key_id=config.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=config.AWS_SECRET_ACCESS_KEY,
+    )

--- a/frontend/src/pages/recipe-list/RecipeListSearch.tsx
+++ b/frontend/src/pages/recipe-list/RecipeListSearch.tsx
@@ -415,7 +415,7 @@ export function RecipeSearchList() {
           />
 
           <Button size="small" onClick={searchTools.toggle}>
-            {searchTools.enabled ? "hide search tools" : "search tools"}
+            {searchTools.enabled ? "Hide Search Tools" : "Search Tools"}
           </Button>
         </div>
 

--- a/frontend/src/pages/team-detail/Members.tsx
+++ b/frontend/src/pages/team-detail/Members.tsx
@@ -124,7 +124,7 @@ function MembersList({
                           }}
                           loading={deleteTeamMember.isPending}
                         >
-                          {member.user.id === userId ? "leave" : "remove"}
+                          {member.user.id === userId ? "Leave" : "Remove"}
                         </Button>
                       ) : (
                         <div>–</div>


### PR DESCRIPTION
pytest is still super slow -- largely because it runs everything in serial

Was benchmarking the collect with --collect-only and also just running the tests


```sh
export TESTING=1
export DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres
export DEBUG=1
export DJANGO_SETTINGS_MODULE="recipeyak.django.settings"

# shellcheck disable=SC2124
ARGS="${@}"

# shellcheck disable=SC2086
time py-spy record -r 200 --format speedscope -o test -- ./.venv/bin/pytest $ARGS
```


Then viewing the json in: https://www.speedscope.app

[py_spy_profile.speedscope.json](https://github.com/recipeyak/recipeyak/files/13910257/py_spy_profile.speedscope.json)

<img width="1624" alt="Screenshot 2024-01-11 at 7 57 36 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/d6bc0d4b-d50a-4e58-96d0-00688a8a709a">
