### PR TITLE
ui: cleanup spacing in notes aka comments

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -1,3 +1,4 @@
+import { omit } from "lodash-es"
 import { findAndReplace } from "mdast-util-find-and-replace"
 import React from "react"
 import ReactMarkdown, { Components } from "react-markdown"
@@ -41,10 +42,15 @@ function renderLink({
   if (href?.startsWith(settings.DOMAIN)) {
     const to = new URL(href).pathname
     return (
-      <Link {...props} to={to} children={to.substring(1)} className={linkCss} />
+      <Link
+        {...omit(props, "node")}
+        to={to}
+        children={to.substring(1)}
+        className={linkCss}
+      />
     )
   }
-  return <a {...props} href={href} className={linkCss} />
+  return <a {...omit(props, "node")} href={href} className={linkCss} />
 }
 
 function renderUl({
@@ -55,7 +61,9 @@ function renderUl({
   HTMLUListElement
 >) {
   return (
-    <ul {...props} className="mb-2 list-inside list-disc">
+    // avoid serializing react markdown node prop that gets passed down
+    // aka avoid [object Object] in the DOM
+    <ul {...omit(props, "node")} className="mb-2 list-inside list-disc">
       {children}
     </ul>
   )
@@ -69,7 +77,7 @@ function renderOl({
   HTMLOListElement
 >) {
   return (
-    <ol {...props} className="mb-2 list-inside list-decimal">
+    <ol {...omit(props, "node")} className="mb-2 list-inside list-decimal">
       {children}
     </ol>
   )
@@ -84,7 +92,7 @@ function renderP({
 >) {
   return (
     // eslint-disable-next-line react/forbid-elements
-    <p {...props} className="last-child:mb-0 mb-2">
+    <p {...omit(props, "node")} className="mb-2 last:mb-0">
       {children}
     </p>
   )
@@ -99,7 +107,7 @@ function renderBlockQuote({
 >) {
   return (
     <blockquote
-      {...props}
+      {...omit(props, "node")}
       className="mb-2 border-y-0 border-l-[3px] border-r-0 border-solid border-l-[var(--color-border)] pl-2"
     >
       {children}

--- a/frontend/src/components/NavRecipeSearch.tsx
+++ b/frontend/src/components/NavRecipeSearch.tsx
@@ -125,8 +125,8 @@ export function NavRecipeSearch() {
   const [isClosed, setIsClosed] = React.useState(false)
   const searchInputRef = React.useRef<HTMLInputElement>(null)
 
-  const ref = React.useRef(null)
-  useOnClickOutside(ref, () => {
+  const searchContainerRef = React.useRef(null)
+  useOnClickOutside(searchContainerRef, () => {
     setIsClosed(true)
   })
 
@@ -163,7 +163,7 @@ export function NavRecipeSearch() {
   }
 
   return (
-    <div ref={ref} className="flex w-full">
+    <div ref={searchContainerRef} className="flex w-full">
       <SearchInput
         ref={searchInputRef}
         value={query}

--- a/frontend/src/pages/recipe-detail/Notes.tsx
+++ b/frontend/src/pages/recipe-detail/Notes.tsx
@@ -170,6 +170,33 @@ function SharedEntry({
   )
 }
 
+function Attachments({
+  attachments,
+  openImage,
+}: {
+  attachments: Note["attachments"]
+  openImage: (_: string) => void
+}) {
+  if (attachments.length === 0) {
+    return null
+  }
+  return (
+    <Box wrap gap={1}>
+      {attachments.map((attachment) => (
+        <FilePreview
+          key={attachment.id}
+          onClick={() => {
+            openImage(attachment.id)
+          }}
+          contentType={attachment.contentType}
+          src={attachment.url}
+          backgroundUrl={attachment.backgroundUrl}
+        />
+      ))}
+    </Box>
+  )
+}
+
 interface INoteProps {
   readonly note: Note
   readonly recipeId: number
@@ -267,25 +294,16 @@ export function Note({
           )}
         </Box>
         {!isEditing ? (
-          <Box dir="col" className="gap-2">
+          <Box dir="col" className="gap-1">
             <Markdown>{note.text}</Markdown>
             {(note.attachments.length > 0 ||
               note.reactions.length > 0 ||
               !readonly) && (
               <Box gap={1} dir="col">
-                <Box wrap gap={1}>
-                  {note.attachments.map((attachment) => (
-                    <FilePreview
-                      key={attachment.id}
-                      onClick={() => {
-                        openImage(attachment.id)
-                      }}
-                      contentType={attachment.contentType}
-                      src={attachment.url}
-                      backgroundUrl={attachment.backgroundUrl}
-                    />
-                  ))}
-                </Box>
+                <Attachments
+                  attachments={note.attachments}
+                  openImage={openImage}
+                />
                 <ReactionsFooter
                   readonly={readonly}
                   reactions={note.reactions}

--- a/frontend/src/pages/schedule/ScheduleRecipeModal.tsx
+++ b/frontend/src/pages/schedule/ScheduleRecipeModal.tsx
@@ -1,6 +1,4 @@
 import { Hit } from "@algolia/client-search"
-// import CheckIcon from "@spectrum-icons/workflow/Checkmark"
-// import ChevronUpDownIcon from "@spectrum-icons/workflow/ChevronUpDown"
 import { parseISO } from "date-fns"
 import { useState } from "react"
 import {


### PR DESCRIPTION
for some reason the eslint tailwind plugin wasn't warning about: last-child:mb-0 being an invalid class so we were getting extra padding in comments. Also adjusted the gap a bit and dom structure to avoid some spacing.