### PR TITLE
ui: adjust focus rings so they don't show up mobile

### DIFF
--- a/frontend/s/dev
+++ b/frontend/s/dev
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-yarn vite "$@"
+yarn vite "$@" --open

--- a/frontend/src/components/Buttons.tsx
+++ b/frontend/src/components/Buttons.tsx
@@ -1,6 +1,7 @@
 import { LocationDescriptor } from "history"
 import * as React from "react"
 import { ForwardedRef, forwardRef } from "react"
+import { useFocusVisible } from "react-aria"
 // eslint-disable-next-line no-restricted-imports
 import { Button as AriaButton, PressEvent } from "react-aria-components"
 
@@ -58,12 +59,17 @@ export const Button = forwardRef(
         "pointer-events-auto !border-none text-white !shadow-none backdrop-blur-[10px] ![background-color:rgba(0,0,0,0.46)]",
     )
 
-    const focusCss = clx(
-      variant !== "nostyle" &&
-        "focus-visible:outline focus-visible:outline-[3px] focus-visible:-outline-offset-2 focus-visible:outline-[rgb(47,129,247)]",
-      focus &&
-        "!outline !outline-[3px] !-outline-offset-2 !outline-[rgb(47,129,247)]",
-    )
+    // We don't want focus rings to appear on non-keyboard devices like iOS, so
+    // we have to do some JS land stuff
+    const { isFocusVisible } = useFocusVisible()
+    const focusCss = isFocusVisible
+      ? clx(
+          variant !== "nostyle" &&
+            "focus-visible:outline focus-visible:outline-[3px] focus-visible:-outline-offset-2 focus-visible:outline-[rgb(47,129,247)]",
+          focus &&
+            "!outline !outline-[3px] !-outline-offset-2 !outline-[rgb(47,129,247)]",
+        )
+      : "outline-none"
 
     const textSize = clx(
       size === "normal" && "text-base",

--- a/frontend/src/pages/recipe-detail/ScheduleModal.tsx
+++ b/frontend/src/pages/recipe-detail/ScheduleModal.tsx
@@ -121,6 +121,16 @@ export function ScheduleModal({
             value={toISODateString(isoDate)}
             onChange={handleDateChange}
           />
+          <div className="mt-auto flex flex-col gap-2">
+            <Button
+              size="normal"
+              variant="primary"
+              onClick={handleSave}
+              disabled={scheduledRecipeCreate.isPending}
+            >
+              {!scheduledRecipeCreate.isPending ? "Schedule" : "Scheduling..."}
+            </Button>
+          </div>
 
           {/* we intentionally hide from view when there are no scheduled
           recipes in the history window -- avoids having an empty state
@@ -171,17 +181,6 @@ export function ScheduleModal({
               </div>
             </>
           )}
-
-          <div className="mt-auto flex flex-col gap-2">
-            <Button
-              size="normal"
-              variant="primary"
-              onClick={handleSave}
-              disabled={scheduledRecipeCreate.isPending}
-            >
-              {!scheduledRecipeCreate.isPending ? "Schedule" : "Scheduling..."}
-            </Button>
-          </div>
         </div>
       }
     />

--- a/frontend/src/pages/schedule/CalendarDayItem.tsx
+++ b/frontend/src/pages/schedule/CalendarDayItem.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { useFocusVisible, usePress } from "react-aria"
 import { useDrag } from "react-dnd"
 import { Link } from "react-router-dom"
 
@@ -85,21 +86,47 @@ export function CalendarItem({
 
   drag(ref)
 
+  // We're doing some sketchy stuff here so that we can support clicking on the
+  // schedule recipe to open the modal but also allow shift clicking to open in
+  // a new tab
+  const { pressProps } = usePress({
+    onPress: (e) => {
+      if (e.shiftKey || e.metaKey) {
+        return
+      }
+      setShow(true)
+    },
+  })
+
+  const { isFocusVisible } = useFocusVisible()
+
   return (
     <>
       <li
         ref={ref}
+        onDoubleClick={(e) => {
+          // double clicking on the list items shouldn't result in the schedule
+          // modal popping open, only clicking on the empty space of a day
+          // should do that
+          e.preventDefault()
+        }}
         className={clx(visibility === "visible" ? "visible" : "invisible")}
       >
         <Link
-          className="flex w-full items-center gap-2 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[rgb(47,129,247)]"
+          className={clx(
+            "flex w-full items-center gap-2 rounded-md",
+            // only want to show focus outline on devices with a keyboard aka not most phones
+            isFocusVisible
+              ? "focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[rgb(47,129,247)]"
+              : "outline-none",
+          )}
           to={recipeURL(recipeID, recipeName)}
+          {...pressProps}
           onClick={(e) => {
             if (e.shiftKey || e.metaKey) {
               return
             }
             e.preventDefault()
-            setShow(true)
           }}
         >
           <Image

--- a/frontend/src/pages/schedule/ScheduleRecipeModal.tsx
+++ b/frontend/src/pages/schedule/ScheduleRecipeModal.tsx
@@ -1,6 +1,7 @@
 import { Hit } from "@algolia/client-search"
 import { parseISO } from "date-fns"
 import { useState } from "react"
+import { useFocusVisible } from "react-aria"
 import {
   ComboBox,
   Group,
@@ -48,6 +49,7 @@ function RecipeSelect({
   const [query, setQuery] = useState("")
   const { data } = useSearchRecipes({ query })
   const hits = data?.hits ?? []
+  const { isFocusVisible } = useFocusVisible()
 
   if (value != null) {
     return (
@@ -90,7 +92,13 @@ function RecipeSelect({
 
       <Group className="flex rounded-md border border-solid border-[--color-border]">
         <Input
-          className="w-full flex-1 rounded-md border-none bg-transparent px-3 py-2 text-base leading-5 text-[--color-text] outline-none placeholder:text-[--color-input-placeholder]"
+          className={() =>
+            clx(
+              "w-full flex-1 rounded-md border-none bg-transparent px-3 py-2 text-base leading-5 text-[--color-text] outline-none -outline-offset-1 placeholder:text-[--color-input-placeholder]",
+              isFocusVisible &&
+                "focus-within:outline focus-within:outline-[2px] focus-within:outline-[rgb(47,129,247)]",
+            )
+          }
           placeholder={"search recipes"}
         />
         <Button className="flex items-center rounded-l-none rounded-r-md border-0 border-l border-solid px-3 transition">


### PR DESCRIPTION
messing around with inputs as well as buttons, but not sure the ideal behavior for text inputs yet -- do we want to show the outline only on desktop or all the time?

buttons no longer show a focus right on pressing which is better and more native like