### PR TITLE
ui: fix focus ring on nav links

### DIFF
--- a/frontend/src/components/NavLink.tsx
+++ b/frontend/src/components/NavLink.tsx
@@ -24,6 +24,10 @@ export const NavLink = ({
           p.isHovered &&
             "bg-[--color-background-calendar-day] text-[--color-link-hover]",
           p.isPressed && "bg-[--color-border]",
+          // Only show the focus ring on keyboard devices
+          p.isFocusVisible
+            ? "focus-visible:outline-[3px] focus-visible:-outline-offset-2 focus-visible:outline-[rgb(47,129,247)]"
+            : "outline-none",
           !noActiveState &&
             location.pathname === to &&
             "bg-[--color-background-calendar-day]",


### PR DESCRIPTION
clicking on the nav link shouldn't trigger an outline