### PR TITLE
fix font size for rescheduling recipe

### DIFF
--- a/frontend/src/pages/schedule/ScheduledRecipeEditModal.tsx
+++ b/frontend/src/pages/schedule/ScheduledRecipeEditModal.tsx
@@ -305,7 +305,7 @@ function RescheduleSection({
                 value={toISODateString(localDate)}
                 onChange={handleDateChange}
                 type="date"
-                className="w-full rounded-md border border-solid border-[--color-border] p-1"
+                className="w-full rounded-md border border-solid border-[--color-border] p-1 text-base"
               />
               <details>
                 <summary>shortcuts</summary>


### PR DESCRIPTION
This change prevents zooming on iOS when a user taps the date picker