### PR TITLE
api: perf, don't sort ical keys

### DIFF
--- a/backend/recipeyak/api/ical_retrieve_view.py
+++ b/backend/recipeyak/api/ical_retrieve_view.py
@@ -120,5 +120,5 @@ def ical_retrieve_view(
             last_modified_scheduled.modified.timestamp()
         )
     with sentry_sdk.start_span(op="recipeyak.ical.render", description="render ical"):
-        response.content = cal.to_ical()
+        response.content = cal.to_ical(sorted=False)
     return response


### PR DESCRIPTION
hopefully make this endpoint less slow, to_ical is expensive