### PR TITLE
ui: workaround for react-aria bug

### DIFF
--- a/frontend/src/components/CloseButton.tsx
+++ b/frontend/src/components/CloseButton.tsx
@@ -1,12 +1,15 @@
 import { X } from "react-feather"
 
 import { Box } from "@/components/Box"
-import { Button } from "@/components/Buttons"
 
 export function CloseButton({ onClose }: { onClose?: () => void }) {
   return (
-    <Button
-      size="small"
+    // Workaround for https://github.com/adobe/react-spectrum/issues/1513 we use
+    // a normal button instead of the react-aria one, which was causing pressing
+    // close on the modal to also trigger a click on any elements behind it
+    //
+    // eslint-disable-next-line react/forbid-elements
+    <button
       onClick={onClose}
       data-testid="close modal"
       className="!border-none bg-[unset] p-0 !shadow-none"
@@ -26,6 +29,6 @@ export function CloseButton({ onClose }: { onClose?: () => void }) {
       >
         <X size={14} strokeWidth={3} />
       </Box>
-    </Button>
+    </button>
   )
 }


### PR DESCRIPTION
took me a while to find the existing issue, but clicking on the modal's close button would trigger the elements underneath it.

tried sprinkling some `preventDefault`s on the elements above the button but that didn't work. instead swapping out the usePress powered `<Button` for an ol' fashioned onClick `<button`

see: https://github.com/adobe/react-spectrum/issues/1513