### PR TITLE
fix time parsing error

### DIFF
--- a/backend/recipeyak/scraper/extract.py
+++ b/backend/recipeyak/scraper/extract.py
@@ -60,7 +60,10 @@ def _extract_tips(parsed: AbstractScraper) -> list[str]:
 
 def _extract_total_time(parsed: AbstractScraper) -> str | None:
     try:
-        return human_time_duration(parsed.total_time() * 60)
+        total_time = parsed.total_time()
+        if total_time is None:
+            return None
+        return human_time_duration(total_time * 60)
     except SchemaOrgException:
         return None
 


### PR DESCRIPTION
fixes https://magnus-montis.sentry.io/issues/4985854938/events/21b3c25e185d4ca8a2366dead3cb75f3/

TypeError
unsupported operand type(s) for *: 'NoneType' and 'int'