### PR TITLE
api: refactor api library format

### DIFF
--- a/backend/recipeyak/api/ably_retrieve_view.py
+++ b/backend/recipeyak/api/ably_retrieve_view.py
@@ -28,7 +28,7 @@ async def get_token(user_id: str, team_ids: list[int]) -> dict[str, object]:
 
 @endpoint()
 def ably_retrieve_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[dict[str, object]]:
     # NOTE: this isn't really scalable if the user has a lot of teams.
     team_ids = list(get_teams(user=request.user).values_list("id", flat=True))

--- a/backend/recipeyak/api/algolia_retrieve_view.py
+++ b/backend/recipeyak/api/algolia_retrieve_view.py
@@ -24,7 +24,7 @@ def get_token(team_id: int) -> str:
 
 @endpoint()
 def algolia_retrieve_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[dict[str, str]]:
     team = get_team(request.user)
     return JsonResponse(

--- a/backend/recipeyak/api/base/decorators.py
+++ b/backend/recipeyak/api/base/decorators.py
@@ -1,18 +1,21 @@
+import typing
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, Literal, Protocol, overload
+from typing import Any, Generic, Literal, Protocol, TypeVar, cast, overload
 
 from django.contrib.auth.views import redirect_to_login as redirect_to_login_url
 from django.http import HttpResponse
 
-from recipeyak.api.base.exceptions import APIError
+from recipeyak.api.base.exceptions import APIError, RequestValidationError
+from recipeyak.api.base.json import json_loads
 from recipeyak.api.base.request import AnonymousHttpRequest, AuthedHttpRequest
+from recipeyak.api.base.serialization import RequestParams
+
+_P = TypeVar("_P", bound="RequestParams | None", contravariant=True)
 
 
-class AuthedView(Protocol):
-    def __call__(
-        self, request: AuthedHttpRequest[Any], *args: Any, **kwargs: Any
-    ) -> HttpResponse:
+class AuthedView(Protocol, Generic[_P]):
+    def __call__(self, request: AuthedHttpRequest, params: _P) -> HttpResponse:
         ...
 
     @property
@@ -20,10 +23,8 @@ class AuthedView(Protocol):
         ...
 
 
-class AnonView(Protocol):
-    def __call__(
-        self, request: AnonymousHttpRequest[Any], *args: Any, **kwargs: Any
-    ) -> HttpResponse:
+class AnonView(Protocol, Generic[_P]):
+    def __call__(self, request: AnonymousHttpRequest, params: _P) -> HttpResponse:
         ...
 
     @property
@@ -72,8 +73,46 @@ def endpoint(
                     message="Authentication credentials were not provided.",
                     status=403,
                 )
-            return func(request, *args, **kwargs)
+
+            params = _parse_param_data(request, func, kwargs)
+            return func(request, params)
 
         return wrapper
 
     return decorator_func
+
+
+def _parse_param_data(
+    request: Any, func: AnyView, kwargs: dict[str, Any]
+) -> RequestParams | None:
+    param_type = typing.get_type_hints(func)["params"]
+    if param_type is type(None):
+        return None
+    request_params = {}
+    if request.method == "GET":
+        request_params = request.GET.dict()
+    elif (
+        request.method == "POST" or request.method == "PATCH" or request.method == "PUT"
+    ):
+        if request.body:
+            request_params = json_loads(request.body)
+    elif request.method == "HEAD" or request.method == "DELETE":
+        # don't need to do anything with these
+        pass
+    else:
+        raise Exception(f"unexpected request method: {request.method}")
+
+    for key in kwargs:
+        if key in request_params:
+            raise RequestValidationError(
+                [
+                    {
+                        "type": "unexpected_param",
+                        "msg": f"Unexpected parameter. param: {key}",
+                        "input": None,
+                        "loc": (),
+                    }
+                ]
+            )
+    request_params |= kwargs
+    return cast(RequestParams, param_type).parse_obj(request_params)

--- a/backend/recipeyak/api/base/decorators.py
+++ b/backend/recipeyak/api/base/decorators.py
@@ -44,14 +44,14 @@ class AnyView(Protocol):
 @overload
 def endpoint(
     *, auth_required: Literal[False], redirect_to_login: bool = ...
-) -> Callable[[AnonView], AnonView]:
+) -> Callable[[AnonView[_P]], AnonView[_P]]:
     ...
 
 
 @overload
 def endpoint(
     *, auth_required: Literal[True] = ..., redirect_to_login: bool = ...
-) -> Callable[[AuthedView], AuthedView]:
+) -> Callable[[AuthedView[_P]], AuthedView[_P]]:
     ...
 
 
@@ -85,7 +85,7 @@ def endpoint(
 def _parse_param_data(
     request: Any, func: AnyView, kwargs: dict[str, Any]
 ) -> RequestParams | None:
-    param_type = typing.get_type_hints(func)["params"]
+    param_type: type[None] | RequestParams = typing.get_type_hints(func)["params"]
     if param_type is type(None):
         return None
     request_params = {}

--- a/backend/recipeyak/api/base/json.py
+++ b/backend/recipeyak/api/base/json.py
@@ -40,3 +40,7 @@ def json_dumps(data: Any, indent: bool = False) -> bytes:
     if indent:
         options |= orjson.OPT_INDENT_2
     return orjson.dumps(data, default=default, option=options)
+
+
+def json_loads(data: bytes | bytearray | memoryview | str) -> Any:
+    return orjson.loads(data)

--- a/backend/recipeyak/api/base/request.py
+++ b/backend/recipeyak/api/base/request.py
@@ -1,16 +1,12 @@
-from typing import Generic, TypeVar
-
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 
 from recipeyak.models import User
 
-_T = TypeVar("_T")
 
-
-class AuthedHttpRequest(HttpRequest, Generic[_T]):
+class AuthedHttpRequest(HttpRequest):
     user: User
 
 
-class AnonymousHttpRequest(HttpRequest, Generic[_T]):
+class AnonymousHttpRequest(HttpRequest):
     user: AnonymousUser | User

--- a/backend/recipeyak/api/calendar_delete_view.py
+++ b/backend/recipeyak/api/calendar_delete_view.py
@@ -3,16 +3,23 @@ from __future__ import annotations
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.api.calendar_list_view import get_scheduled_recipes
 from recipeyak.models import get_team
 from recipeyak.realtime import publish_calendar_event_deleted
 
 
+class CalendarDeleteParams(RequestParams):
+    scheduled_recipe_id: int
+
+
 @endpoint()
 def calendar_delete_view(
-    request: AuthedHttpRequest[None], scheduled_recipe_id: int
+    request: AuthedHttpRequest, params: CalendarDeleteParams
 ) -> JsonResponse[None]:
     team_id = get_team(request.user).id
-    get_scheduled_recipes(team_id).filter(id=scheduled_recipe_id).delete()
-    publish_calendar_event_deleted(recipe_id=scheduled_recipe_id, team_id=team_id)
+    get_scheduled_recipes(team_id).filter(id=params.scheduled_recipe_id).delete()
+    publish_calendar_event_deleted(
+        recipe_id=params.scheduled_recipe_id, team_id=team_id
+    )
     return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/calendar_generate_link_view.py
+++ b/backend/recipeyak/api/calendar_generate_link_view.py
@@ -9,7 +9,7 @@ from recipeyak.models import Membership, get_random_ical_id, get_team
 
 @endpoint()
 def calendar_generate_link_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[CalSettings]:
     team_id = get_team(request.user).id
     membership = get_object_or_404(Membership, team=team_id, user=request.user)

--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -41,9 +41,8 @@ class CalendarListResponse(TypedDict):
 
 @endpoint()
 def calendar_list_view(
-    request: AuthedHttpRequest[StartEndDateParams]
+    request: AuthedHttpRequest, params: StartEndDateParams
 ) -> JsonResponse[CalendarListResponse]:
-    params = StartEndDateParams.parse_obj(request.GET.dict())
     start = params.start
     end = params.end
     team_id = get_team(request.user).id

--- a/backend/recipeyak/api/calendar_settings_retrieve_view.py
+++ b/backend/recipeyak/api/calendar_settings_retrieve_view.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from django.shortcuts import get_object_or_404
 from typing_extensions import TypedDict
 

--- a/backend/recipeyak/api/calendar_settings_retrieve_view.py
+++ b/backend/recipeyak/api/calendar_settings_retrieve_view.py
@@ -19,7 +19,7 @@ class CalSettings(TypedDict):
 def get_cal_settings(
     *,
     team_id: int,
-    request: AuthedHttpRequest[Any],
+    request: AuthedHttpRequest,
 ) -> CalSettings:
     membership = get_object_or_404(Membership, team=team_id, user=request.user)
     calendar_link = f"webcal://{request.get_host()}/t/{team_id}/ical/{membership.calendar_secret_key}/schedule.ics"
@@ -31,7 +31,7 @@ def get_cal_settings(
 
 @endpoint()
 def calendar_settings_retrieve_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[CalSettings]:
     team_id = get_team(request.user).id
     settings = get_cal_settings(request=request, team_id=team_id)

--- a/backend/recipeyak/api/calendar_update_settings_view.py
+++ b/backend/recipeyak/api/calendar_update_settings_view.py
@@ -14,9 +14,8 @@ class CalSettingsParams(RequestParams):
 
 @endpoint()
 def calendar_update_settings_view(
-    request: AuthedHttpRequest[CalSettingsParams]
+    request: AuthedHttpRequest, params: CalSettingsParams
 ) -> JsonResponse[CalSettings]:
-    params = CalSettingsParams.parse_raw(request.body)
     sync_enabled = params.syncEnabled
     team_id = get_team(request.user).id
 

--- a/backend/recipeyak/api/calendar_update_view.py
+++ b/backend/recipeyak/api/calendar_update_view.py
@@ -17,20 +17,20 @@ from recipeyak.realtime import publish_calendar_event
 
 class ScheduledRecipeUpdateParams(RequestParams):
     on: date
+    scheduled_recipe_id: int
 
 
 @endpoint()
 def calendar_update_view(
-    request: AuthedHttpRequest[ScheduledRecipeUpdateParams], scheduled_recipe_id: int
+    request: AuthedHttpRequest, params: ScheduledRecipeUpdateParams
 ) -> JsonResponse[ScheduleRecipeSerializer]:
-    params = ScheduledRecipeUpdateParams.parse_raw(request.body)
     team_id = get_team(request.user).id
-    scheduled_recipe = get_scheduled_recipes(team_id).get(id=scheduled_recipe_id)
+    scheduled_recipe = get_scheduled_recipes(team_id).get(id=params.scheduled_recipe_id)
     with transaction.atomic():
         scheduled_recipe.on = params.on
         scheduled_recipe.save()
         ScheduleEvent.objects.create(
-            scheduled_recipe_id=scheduled_recipe_id,
+            scheduled_recipe_id=params.scheduled_recipe_id,
             before_on=scheduled_recipe.on,
             after_on=params.on,
             actor=request.user,

--- a/backend/recipeyak/api/cook_checklist_create_view.py
+++ b/backend/recipeyak/api/cook_checklist_create_view.py
@@ -22,16 +22,15 @@ class CookChecklistPostSerializer(pydantic.BaseModel):
 class CookChecklistPostParams(RequestParams):
     ingredient_id: int
     checked: bool
+    recipe_id: int
 
 
 @endpoint()
 def cook_checklist_create_view(
-    request: AuthedHttpRequest[CookChecklistPostParams], recipe_id: int
+    request: AuthedHttpRequest, params: CookChecklistPostParams
 ) -> JsonResponse[CookChecklistPostSerializer]:
     team = get_team(request.user)
-    recipe = filter_recipe_or_404(recipe_id=recipe_id, team=team)
-
-    params = CookChecklistPostParams.parse_raw(request.body)
+    recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
     with connection.cursor() as cursor:
         cursor.execute(
             """

--- a/backend/recipeyak/api/cook_checklist_retrieve_view.py
+++ b/backend/recipeyak/api/cook_checklist_retrieve_view.py
@@ -3,19 +3,24 @@ from __future__ import annotations
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import (
     filter_cook_checklist,
     get_team,
 )
 
 
+class CookChecklistRetrieveParams(RequestParams):
+    recipe_id: int
+
+
 @endpoint()
 def cook_checklist_retrieve_view(
-    request: AuthedHttpRequest[None], recipe_id: int
+    request: AuthedHttpRequest, params: CookChecklistRetrieveParams
 ) -> JsonResponse[dict[int, bool]]:
     team = get_team(request.user)
     recipe_checklist_items = filter_cook_checklist(team=team).filter(
-        recipe_id=recipe_id
+        recipe_id=params.recipe_id
     )
 
     return JsonResponse(

--- a/backend/recipeyak/api/ingredient_delete_view.py
+++ b/backend/recipeyak/api/ingredient_delete_view.py
@@ -6,18 +6,25 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.api.serializers.recipe import ingredient_to_text
 from recipeyak.models import ChangeType, RecipeChange, filter_ingredients, get_team
 from recipeyak.realtime import publish_recipe
 from recipeyak.versioning import save_recipe_version
 
 
+class IngredientDeleteParams(RequestParams):
+    ingredient_id: int
+
+
 @endpoint()
 def ingredient_delete_view(
-    request: AuthedHttpRequest[None], ingredient_id: int
+    request: AuthedHttpRequest, params: IngredientDeleteParams
 ) -> JsonResponse[None]:
     team = get_team(request.user)
-    ingredient = get_object_or_404(filter_ingredients(team=team), pk=ingredient_id)
+    ingredient = get_object_or_404(
+        filter_ingredients(team=team), pk=params.ingredient_id
+    )
     with transaction.atomic():
         recipe_id = ingredient.recipe.id
         RecipeChange.objects.create(
@@ -27,7 +34,7 @@ def ingredient_delete_view(
             after="",
             change_type=ChangeType.INGREDIENT_DELETE,
         )
-        filter_ingredients(team=team).filter(pk=ingredient_id).delete()
+        filter_ingredients(team=team).filter(pk=params.ingredient_id).delete()
         save_recipe_version(recipe_id=recipe_id, actor=request.user)
     publish_recipe(recipe_id=ingredient.recipe_id, team_id=team.id)
     return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/ingredient_update_view.py
+++ b/backend/recipeyak/api/ingredient_update_view.py
@@ -26,15 +26,17 @@ class IngredientsPatchParams(RequestParams):
     description: Annotated[str, StringConstraints(strip_whitespace=True)] | None = None
     position: str | None = None
     optional: bool | None = None
+    ingredient_id: int
 
 
 @endpoint()
 def ingredient_update_view(
-    request: AuthedHttpRequest[IngredientsPatchParams], ingredient_id: int
+    request: AuthedHttpRequest, params: IngredientsPatchParams
 ) -> JsonResponse[IngredientResponse]:
     team = get_team(request.user)
-    params = IngredientsPatchParams.parse_raw(request.body)
-    ingredient = get_object_or_404(filter_ingredients(team=team), pk=ingredient_id)
+    ingredient = get_object_or_404(
+        filter_ingredients(team=team), pk=params.ingredient_id
+    )
 
     with transaction.atomic():
         before = ingredient_to_text(ingredient)

--- a/backend/recipeyak/api/invite_accept_view.py
+++ b/backend/recipeyak/api/invite_accept_view.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models.invite import Invite
 
 
@@ -11,12 +12,16 @@ class InviteAcceptResponse(pydantic.BaseModel):
     detail: str
 
 
+class InviteAcceptParams(RequestParams):
+    invite_id: int
+
+
 @endpoint()
 def invite_accept_view(
-    request: AuthedHttpRequest[None], invite_id: int
+    request: AuthedHttpRequest, params: InviteAcceptParams
 ) -> JsonResponse[InviteAcceptResponse]:
     invite = get_object_or_404(
-        Invite.objects.filter(membership__user=request.user), id=invite_id
+        Invite.objects.filter(membership__user=request.user), id=params.invite_id
     )
     invite.accept()
     return JsonResponse(InviteAcceptResponse(detail="accepted invite"), status=200)

--- a/backend/recipeyak/api/invite_create_view.py
+++ b/backend/recipeyak/api/invite_create_view.py
@@ -14,6 +14,7 @@ from recipeyak.models.invite import Invite
 class CreateInviteParams(RequestParams):
     emails: list[str]
     level: Literal["admin", "contributor", "read"]
+    team_id: int
 
 
 class CreateInviteResponse(pydantic.BaseModel):
@@ -22,7 +23,7 @@ class CreateInviteResponse(pydantic.BaseModel):
 
 @endpoint()
 def invite_create_view(
-    request: AuthedHttpRequest[CreateInviteParams], team_id: int
+    request: AuthedHttpRequest, params: CreateInviteParams
 ) -> JsonResponse[CreateInviteResponse]:
     """
     for creating, we want: level, user_id
@@ -30,8 +31,7 @@ def invite_create_view(
     We want id, user object, and team data response
     need to use to_representation or form_represenation
     """
-    team = Team.objects.get(pk=team_id)
-    params = CreateInviteParams.parse_raw(request.body)
+    team = Team.objects.get(pk=params.team_id)
     with transaction.atomic():
         invite_ids = list[int]()
         for email in params.emails:

--- a/backend/recipeyak/api/invite_decline_view.py
+++ b/backend/recipeyak/api/invite_decline_view.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models.invite import Invite
 
 
@@ -11,12 +12,16 @@ class InviteAcceptResponse(pydantic.BaseModel):
     detail: str
 
 
+class InviteDeclineParams(RequestParams):
+    invite_id: int
+
+
 @endpoint()
 def invite_decline_view(
-    request: AuthedHttpRequest[None], invite_id: int
+    request: AuthedHttpRequest, params: InviteDeclineParams
 ) -> JsonResponse[InviteAcceptResponse]:
     invite = get_object_or_404(
-        Invite.objects.filter(membership__user=request.user), id=invite_id
+        Invite.objects.filter(membership__user=request.user), id=params.invite_id
     )
     invite.decline()
     return JsonResponse(InviteAcceptResponse(detail="declined invite"), status=200)

--- a/backend/recipeyak/api/invite_list_view.py
+++ b/backend/recipeyak/api/invite_list_view.py
@@ -31,7 +31,7 @@ class InviteResponse(pydantic.BaseModel):
 
 @endpoint()
 def invite_list_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[list[InviteResponse]]:
     with connection.cursor() as cursor:
         cursor.execute(

--- a/backend/recipeyak/api/member_list_view.py
+++ b/backend/recipeyak/api/member_list_view.py
@@ -9,6 +9,7 @@ from django.db import connection
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import get_team_by_id
 from recipeyak.models.user import get_avatar_url
 
@@ -27,11 +28,15 @@ class TeamMemberResponse(pydantic.BaseModel):
     user: UserResponse
 
 
+class MemberListParams(RequestParams):
+    team_id: int
+
+
 @endpoint()
 def member_list_view(
-    request: AuthedHttpRequest[None], team_id: int
+    request: AuthedHttpRequest, params: MemberListParams
 ) -> JsonResponse[list[TeamMemberResponse]]:
-    team = get_team_by_id(user_id=request.user.id, team_id=team_id)
+    team = get_team_by_id(user_id=request.user.id, team_id=params.team_id)
     with connection.cursor() as cursor:
         cursor.execute(
             """

--- a/backend/recipeyak/api/member_update_view.py
+++ b/backend/recipeyak/api/member_update_view.py
@@ -43,14 +43,14 @@ class TeamMemberResponse(pydantic.BaseModel):
 
 class UpdateMembershipParams(RequestParams):
     level: Literal["admin", "contributor", "read"]
+    member_id: int
 
 
 @endpoint()
 def member_update_view(
-    request: AuthedHttpRequest[UpdateMembershipParams], *, member_id: int
+    request: AuthedHttpRequest, params: UpdateMembershipParams
 ) -> JsonResponse[TeamMemberResponse]:
-    params = UpdateMembershipParams.parse_raw(request.body)
-    membership = get_object_or_404(Membership, pk=member_id)
+    membership = get_object_or_404(Membership, pk=params.member_id)
     if not is_team_admin(team_id=membership.team_id, user_id=request.user.id):
         raise APIError(
             code="insufficient_permissions",

--- a/backend/recipeyak/api/note_create_view.py
+++ b/backend/recipeyak/api/note_create_view.py
@@ -15,6 +15,7 @@ from recipeyak.realtime import publish_recipe
 class CreateNoteParams(RequestParams):
     text: str
     attachment_upload_ids: list[str]
+    recipe_id: int
 
     @model_validator(mode="after")
     def validate_non_empty(self) -> CreateNoteParams:
@@ -25,11 +26,10 @@ class CreateNoteParams(RequestParams):
 
 @endpoint()
 def note_create_view(
-    request: AuthedHttpRequest[CreateNoteParams], recipe_id: int
+    request: AuthedHttpRequest, params: CreateNoteParams
 ) -> JsonResponse[NoteResponse]:
     team = get_team(request.user)
-    recipe = get_object_or_404(filter_recipes(team=team), pk=recipe_id)
-    params = CreateNoteParams.parse_raw(request.body)
+    recipe = get_object_or_404(filter_recipes(team=team), pk=params.recipe_id)
 
     note = Note.objects.create(
         text=params.text,

--- a/backend/recipeyak/api/note_delete_view.py
+++ b/backend/recipeyak/api/note_delete_view.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import filter_notes, get_team
 from recipeyak.realtime import publish_recipe
 
 
+class NoteDeleteParams(RequestParams):
+    note_id: str
+
+
 @endpoint()
 def note_delete_view(
-    request: AuthedHttpRequest[None], note_id: str
+    request: AuthedHttpRequest, params: NoteDeleteParams
 ) -> JsonResponse[None]:
     team = get_team(request.user)
     if (
         note := filter_notes(team=team)
-        .filter(pk=note_id, created_by=request.user)
+        .filter(pk=params.note_id, created_by=request.user)
         .first()
     ):
         note.delete()

--- a/backend/recipeyak/api/note_update_view.py
+++ b/backend/recipeyak/api/note_update_view.py
@@ -17,15 +17,15 @@ from recipeyak.versioning import save_note_version
 class EditNoteParams(RequestParams):
     text: str | None = None
     attachment_upload_ids: list[str] | None = None
+    note_id: str
 
 
 @endpoint()
 def note_update_view(
-    request: AuthedHttpRequest[EditNoteParams], note_id: str
+    request: AuthedHttpRequest, params: EditNoteParams
 ) -> JsonResponse[NoteResponse]:
-    params = EditNoteParams.parse_raw(request.body)
     team = get_team(request.user)
-    note = get_object_or_404(filter_notes(team=team), pk=note_id)
+    note = get_object_or_404(filter_notes(team=team), pk=params.note_id)
     # only allow the note's author to update the note
     if note.created_by.id != request.user.id:
         raise APIError(

--- a/backend/recipeyak/api/reaction_create_view.py
+++ b/backend/recipeyak/api/reaction_create_view.py
@@ -20,17 +20,16 @@ EMOJIS = Literal["❤️", "😆", "🤮"]
 
 class ReactToNoteViewParams(RequestParams):
     type: EMOJIS
+    note_id: str
 
 
 @endpoint()
 def reaction_create_view(
-    request: AuthedHttpRequest[ReactToNoteViewParams], note_id: str
+    request: AuthedHttpRequest, params: ReactToNoteViewParams
 ) -> JsonResponse[ReactionResponse]:
-    params = ReactToNoteViewParams.parse_raw(request.body)
-
     team = get_team(request.user)
 
-    note = get_object_or_404(filter_notes(team=team), pk=note_id)
+    note = get_object_or_404(filter_notes(team=team), pk=params.note_id)
     reaction = Reaction(emoji=params.type, created_by=request.user, note=note)
     try:
         reaction.save()

--- a/backend/recipeyak/api/reaction_delete_view.py
+++ b/backend/recipeyak/api/reaction_delete_view.py
@@ -3,15 +3,24 @@ from __future__ import annotations
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import user_reactions
 from recipeyak.realtime import publish_recipe
 
 
+class ReactionDeleteParams(RequestParams):
+    reaction_id: str
+
+
 @endpoint()
 def reaction_delete_view(
-    request: AuthedHttpRequest[None], reaction_id: str
+    request: AuthedHttpRequest, params: ReactionDeleteParams
 ) -> JsonResponse[None]:
-    if reaction := user_reactions(user=request.user).filter(pk=reaction_id).first():
+    if (
+        reaction := user_reactions(user=request.user)
+        .filter(pk=params.reaction_id)
+        .first()
+    ):
         recipe = reaction.note.recipe
         reaction.delete()
         if recipe.team_id:

--- a/backend/recipeyak/api/recipe_bot_detail_view.py
+++ b/backend/recipeyak/api/recipe_bot_detail_view.py
@@ -7,6 +7,7 @@ from yarl import URL
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AnonymousHttpRequest
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.config import IMAGE_TRANSFORM_FORMAT
 from recipeyak.models.recipe import Recipe
 
@@ -47,9 +48,7 @@ def _format_img_open_graph(x: str) -> str:
     raise Exception(f"Unexpected IMAGE_TRANSFORM_FORMAT:{IMAGE_TRANSFORM_FORMAT}")
 
 
-def _recipe_get_view(
-    request: AnonymousHttpRequest[None], recipe_id: str
-) -> HttpResponse:
+def _recipe_get_view(request: AnonymousHttpRequest, recipe_id: str) -> HttpResponse:
     recipe = get_object_or_404(Recipe, pk=recipe_id)
 
     recipe_title = recipe.name
@@ -72,8 +71,12 @@ def _recipe_get_view(
     )
 
 
+class RecipeBotDetailParams(RequestParams):
+    recipe_id: str
+
+
 @endpoint(auth_required=False)
 def recipe_bot_detail_view(
-    request: AnonymousHttpRequest[None], recipe_id: str
+    request: AnonymousHttpRequest, params: RecipeBotDetailParams
 ) -> HttpResponse:
-    return _recipe_get_view(request, recipe_id)
+    return _recipe_get_view(request, params.recipe_id)

--- a/backend/recipeyak/api/recipe_create_view.py
+++ b/backend/recipeyak/api/recipe_create_view.py
@@ -98,10 +98,9 @@ def create_recipe_from_scrape(*, scrape: ScrapeResult, team: Team) -> Recipe:
 
 @endpoint()
 def recipe_create_view(
-    request: AuthedHttpRequest[RecipePostParams]
+    request: AuthedHttpRequest, params: RecipePostParams
 ) -> JsonResponse[RecipeResponse]:
     log = logger.bind(user_id=request.user.id)
-    params = RecipePostParams.parse_raw(request.body)
 
     # validate params
     team = Team.objects.filter(id=params.team, membership__user=request.user).first()

--- a/backend/recipeyak/api/recipe_delete_view.py
+++ b/backend/recipeyak/api/recipe_delete_view.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import (
     filter_recipe_or_404,
     get_team,
@@ -12,13 +13,17 @@ from recipeyak.models import (
 from recipeyak.realtime import publish_recipe
 
 
+class RecipeDeleteParams(RequestParams):
+    recipe_id: int
+
+
 @endpoint()
 def recipe_delete_view(
-    request: AuthedHttpRequest[None], recipe_id: int
+    request: AuthedHttpRequest, params: RecipeDeleteParams
 ) -> JsonResponse[None]:
     team = get_team(request.user)
     with transaction.atomic():
-        recipe = filter_recipe_or_404(team=team, recipe_id=recipe_id)
+        recipe = filter_recipe_or_404(team=team, recipe_id=params.recipe_id)
         recipe.delete()
         # no need to save version, since we aren't "updating" the recipe, we
         # have the previous post-update version saved already

--- a/backend/recipeyak/api/recipe_recently_created_view.py
+++ b/backend/recipeyak/api/recipe_recently_created_view.py
@@ -34,7 +34,7 @@ class RecipeRecentlyCreatedViewResponse(pydantic.BaseModel):
 
 @endpoint()
 def recipe_recently_created_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[list[RecipeRecentlyCreatedViewResponse]]:
     team = get_team(request.user)
     recipes = list[RecipeRecentlyCreatedViewResponse]()

--- a/backend/recipeyak/api/recipe_recently_viewed_view.py
+++ b/backend/recipeyak/api/recipe_recently_viewed_view.py
@@ -26,7 +26,7 @@ class RecentlyViewRecipeResponse(TypedDict):
 
 @endpoint()
 def recipe_recently_viewed_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[list[RecentlyViewRecipeResponse]]:
     team = get_team(request.user)
     recipes: list[RecentlyViewRecipeResponse] = []

--- a/backend/recipeyak/api/recipe_retrieve_view.py
+++ b/backend/recipeyak/api/recipe_retrieve_view.py
@@ -5,6 +5,7 @@ from django.db import connection
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.api.serializers.recipe import RecipeResponse, serialize_recipe
 from recipeyak.models import (
     filter_recipe_or_404,
@@ -12,12 +13,16 @@ from recipeyak.models import (
 )
 
 
+class RecipeRetrieveParams(RequestParams):
+    recipe_id: int
+
+
 @endpoint()
 def recipe_retrieve_view(
-    request: AuthedHttpRequest[None], recipe_id: int
+    request: AuthedHttpRequest, params: RecipeRetrieveParams
 ) -> JsonResponse[RecipeResponse]:
     team = get_team(request.user)
-    recipe = filter_recipe_or_404(recipe_id=recipe_id, team=team)
+    recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
     with connection.cursor() as cursor:
         cursor.execute(
             """

--- a/backend/recipeyak/api/recipe_timeline_view.py
+++ b/backend/recipeyak/api/recipe_timeline_view.py
@@ -10,6 +10,7 @@ from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import Recipe, ScheduledRecipe, User
 
 
@@ -18,22 +19,26 @@ class RecipeTimelineResponse(pydantic.BaseModel):
     on: date
 
 
+class RecipeTimelineParams(RequestParams):
+    recipe_id: int
+
+
 @endpoint()
 def recipe_timline_view(
-    request: AuthedHttpRequest[None], recipe_id: int
+    request: AuthedHttpRequest, params: RecipeTimelineParams
 ) -> JsonResponse[list[RecipeTimelineResponse]]:
     user: User = request.user
     # TODO: we probably don't want to rely on this so we can support multiple
     # sessions with different teams for a given user.
     team = user.schedule_team
 
-    recipe = get_object_or_404(Recipe, pk=recipe_id)
+    recipe = get_object_or_404(Recipe, pk=params.recipe_id)
 
     if not has_recipe_access(recipe=recipe, user=user):
         raise APIError(code="no_access", message="No access to recipe", status=403)
 
     scheduled_recipes = ScheduledRecipe.objects.filter(team=team).filter(
-        recipe=recipe_id
+        recipe=params.recipe_id
     )
 
     return JsonResponse(

--- a/backend/recipeyak/api/recipe_update_view.py
+++ b/backend/recipeyak/api/recipe_update_view.py
@@ -36,15 +36,15 @@ class RecipePatchParams(RequestParams):
     # attributes requiring custom handling.
     primaryImageId: str | None = None
 
+    recipe_id: int
+
 
 @endpoint()
 def recipe_update_view(
-    request: AuthedHttpRequest[RecipePatchParams], recipe_id: int
+    request: AuthedHttpRequest, params: RecipePatchParams
 ) -> JsonResponse[RecipeResponse]:
     team = get_team(request.user)
-    recipe = filter_recipe_or_404(recipe_id=recipe_id, team=team)
-
-    params = RecipePatchParams.parse_raw(request.body)
+    recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
 
     with transaction.atomic():
         provided_fields = set(params.dict(exclude_unset=True))
@@ -124,5 +124,5 @@ def recipe_update_view(
     publish_recipe(recipe_id=recipe.id, team_id=team.id)
 
     team = get_team(request.user)
-    recipe = filter_recipe_or_404(team=team, recipe_id=recipe_id)
+    recipe = filter_recipe_or_404(team=team, recipe_id=params.recipe_id)
     return JsonResponse(serialize_recipe(recipe))

--- a/backend/recipeyak/api/scheduled_recipe_create_view.py
+++ b/backend/recipeyak/api/scheduled_recipe_create_view.py
@@ -24,10 +24,8 @@ class ScheduledRecipeCreateParams(RequestParams):
 
 @endpoint()
 def scheduled_recipe_create_view(
-    request: AuthedHttpRequest[ScheduledRecipeCreateParams]
+    request: AuthedHttpRequest, params: ScheduledRecipeCreateParams
 ) -> JsonResponse[ScheduleRecipeSerializer]:
-    params = ScheduledRecipeCreateParams.parse_raw(request.body)
-
     team = get_team(request.user)
 
     recipe = get_object_or_404(filter_recipes(team=team), id=params.recipe)

--- a/backend/recipeyak/api/section_create_view.py
+++ b/backend/recipeyak/api/section_create_view.py
@@ -19,17 +19,16 @@ from recipeyak.versioning import save_recipe_version
 class SectionCreateParams(RequestParams):
     position: str | None = None
     title: str
+    recipe_id: int
 
 
 @endpoint()
 def section_create_view(
-    request: AuthedHttpRequest[SectionCreateParams], recipe_id: int
+    request: AuthedHttpRequest, params: SectionCreateParams
 ) -> JsonResponse[SectionResponse]:
-    recipe = get_object_or_404(Recipe, pk=recipe_id)
+    recipe = get_object_or_404(Recipe, pk=params.recipe_id)
     if not has_recipe_access(recipe=recipe, user=request.user):
         raise APIError(code="no_access", message="No access to recipe", status=403)
-
-    params = SectionCreateParams.parse_raw(request.body)
 
     with transaction.atomic():
         RecipeChange.objects.create(

--- a/backend/recipeyak/api/section_delete_view.py
+++ b/backend/recipeyak/api/section_delete_view.py
@@ -8,16 +8,21 @@ from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import ChangeType, RecipeChange, Section
 from recipeyak.realtime import publish_recipe
 from recipeyak.versioning import save_recipe_version
 
 
+class SectionDeleteParams(RequestParams):
+    section_id: int
+
+
 @endpoint()
 def section_delete_view(
-    request: AuthedHttpRequest[None], section_id: int
+    request: AuthedHttpRequest, params: SectionDeleteParams
 ) -> JsonResponse[None]:
-    section = get_object_or_404(Section, pk=section_id)
+    section = get_object_or_404(Section, pk=params.section_id)
     recipe = section.recipe
     if not has_recipe_access(recipe=recipe, user=request.user):
         raise APIError(

--- a/backend/recipeyak/api/section_update_view.py
+++ b/backend/recipeyak/api/section_update_view.py
@@ -18,17 +18,17 @@ from recipeyak.versioning import save_recipe_version
 class SectionUpdateParams(RequestParams):
     position: str | None = None
     title: str | None = None
+    section_id: int
 
 
 @endpoint()
 def section_update_view(
-    request: AuthedHttpRequest[SectionUpdateParams], section_id: int
+    request: AuthedHttpRequest, params: SectionUpdateParams
 ) -> JsonResponse[SectionResponse]:
-    section = get_object_or_404(Section, pk=section_id)
+    section = get_object_or_404(Section, pk=params.section_id)
     if not has_recipe_access(recipe=section.recipe, user=request.user):
         raise APIError(code="no_access", message="No access to recipe", status=403)
 
-    params = SectionUpdateParams.parse_raw(request.body)
     with transaction.atomic():
         if params.title is not None:
             section.title = params.title

--- a/backend/recipeyak/api/session_delete_all_view.py
+++ b/backend/recipeyak/api/session_delete_all_view.py
@@ -6,6 +6,8 @@ from recipeyak.api.base.response import JsonResponse
 
 
 @endpoint()
-def session_delete_all_view(request: AuthedHttpRequest[None]) -> JsonResponse[None]:
+def session_delete_all_view(
+    request: AuthedHttpRequest, params: None
+) -> JsonResponse[None]:
     request.user.session_set.exclude(pk=request.session.session_key).delete()
     return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/session_delete_view.py
+++ b/backend/recipeyak/api/session_delete_view.py
@@ -5,11 +5,16 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
+
+
+class SessionDeleteParams(RequestParams):
+    session_id: str
 
 
 @endpoint()
 def session_delete_view(
-    request: AuthedHttpRequest[None], session_id: str
+    request: AuthedHttpRequest, params: SessionDeleteParams
 ) -> JsonResponse[None]:
-    get_object_or_404(request.user.session_set, pk=session_id).delete()
+    get_object_or_404(request.user.session_set, pk=params.session_id).delete()
     return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/session_list_view.py
+++ b/backend/recipeyak/api/session_list_view.py
@@ -28,7 +28,7 @@ class SessionResponse(pydantic.BaseModel):
 
 @endpoint()
 def session_list_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[list[SessionResponse]]:
     query_set = request.user.session_set
 

--- a/backend/recipeyak/api/shoppinglist_retrieve_view.py
+++ b/backend/recipeyak/api/shoppinglist_retrieve_view.py
@@ -74,10 +74,9 @@ def _fmt_small_decimal(d: Decimal) -> str:
 
 @endpoint()
 def shoppinglist_retrieve_view(
-    request: AuthedHttpRequest[ShoppingListParams]
+    request: AuthedHttpRequest, params: ShoppingListParams
 ) -> JsonResponse[ShoppingListResponse]:
     team_id = get_team(request.user).id
-    params = ShoppingListParams.parse_obj(request.GET.dict())
     scheduled_recipes = get_scheduled_recipes(params=params, team_id=team_id)
     if scheduled_recipes is None:
         raise APIError(code="invalid_params", message="Couldn't find scheduled recipes")

--- a/backend/recipeyak/api/step_delete_view.py
+++ b/backend/recipeyak/api/step_delete_view.py
@@ -6,17 +6,22 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import ChangeType, RecipeChange, filter_steps, get_team
 from recipeyak.realtime import publish_recipe
 from recipeyak.versioning import save_recipe_version
 
 
+class StepDeleteParams(RequestParams):
+    step_id: int
+
+
 @endpoint()
 def step_delete_view(
-    request: AuthedHttpRequest[None], step_id: int
+    request: AuthedHttpRequest, params: StepDeleteParams
 ) -> JsonResponse[None]:
     team = get_team(request.user)
-    step = get_object_or_404(filter_steps(team=team), pk=step_id)
+    step = get_object_or_404(filter_steps(team=team), pk=params.step_id)
     recipe = step.recipe
     with transaction.atomic():
         RecipeChange.objects.create(

--- a/backend/recipeyak/api/step_update_view.py
+++ b/backend/recipeyak/api/step_update_view.py
@@ -19,15 +19,16 @@ from recipeyak.versioning import save_recipe_version
 class StepPatchParams(RequestParams):
     text: Annotated[str, StringConstraints(strip_whitespace=True)] | None = None
     position: str | None = None
+    step_id: int
 
 
 @endpoint()
 def step_update_view(
-    request: AuthedHttpRequest[StepPatchParams], step_id: int
+    request: AuthedHttpRequest,
+    params: StepPatchParams,
 ) -> JsonResponse[StepResponse]:
     team = get_team(request.user)
-    params = StepPatchParams.parse_raw(request.body)
-    step = get_object_or_404(filter_steps(team=team), pk=step_id)
+    step = get_object_or_404(filter_steps(team=team), pk=params.step_id)
     with transaction.atomic():
         before_text = step.text
         if params.text is not None:

--- a/backend/recipeyak/api/team_create_view.py
+++ b/backend/recipeyak/api/team_create_view.py
@@ -26,9 +26,8 @@ class TeamCreateParams(RequestParams):
 
 @endpoint()
 def team_create_view(
-    request: AuthedHttpRequest[TeamCreateParams]
+    request: AuthedHttpRequest, params: TeamCreateParams
 ) -> JsonResponse[RetrieveTeamResponse]:
-    params = TeamCreateParams.parse_raw(request.body)
     with transaction.atomic():
         team = Team.objects.create(name=params.name)
         team.force_join_admin(request.user)

--- a/backend/recipeyak/api/team_delete_view.py
+++ b/backend/recipeyak/api/team_delete_view.py
@@ -8,6 +8,7 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import Team
 from recipeyak.models.membership import Membership
 from recipeyak.models.user import User
@@ -23,12 +24,16 @@ def is_team_admin(*, team_id: int, user_id: int) -> bool:
     ).exists()
 
 
+class TeamDeleteParams(RequestParams):
+    team_id: int
+
+
 @endpoint()
 def team_delete_view(
-    request: AuthedHttpRequest[None], team_id: int
+    request: AuthedHttpRequest, params: TeamDeleteParams
 ) -> JsonResponse[None]:
     with transaction.atomic():
-        team = get_object_or_404(get_teams(request.user), pk=team_id)
+        team = get_object_or_404(get_teams(request.user), pk=params.team_id)
         if (
             not is_team_admin(team_id=team.id, user_id=request.user.id)
             # don't allow deleting last team

--- a/backend/recipeyak/api/team_list_view.py
+++ b/backend/recipeyak/api/team_list_view.py
@@ -17,12 +17,9 @@ class ListTeamResponse(BaseModel):
     members: int
 
 
-# TODO: rename func and module to team_list_view
-
-
 @endpoint()
 def team_list_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[list[ListTeamResponse]]:
     with connection.cursor() as cursor:
         cursor.execute(

--- a/backend/recipeyak/api/team_retrieve_view.py
+++ b/backend/recipeyak/api/team_retrieve_view.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models import Team
 from recipeyak.models.user import User
 
@@ -20,9 +21,13 @@ class RetrieveTeamResponse(pydantic.BaseModel):
     name: str
 
 
+class TeamRetrieveParams(RequestParams):
+    team_id: int
+
+
 @endpoint()
 def team_retrieve_view(
-    request: AuthedHttpRequest[None], team_id: int
+    request: AuthedHttpRequest, params: TeamRetrieveParams
 ) -> JsonResponse[RetrieveTeamResponse]:
-    team = get_object_or_404(get_teams(request.user), pk=team_id)
+    team = get_object_or_404(get_teams(request.user), pk=params.team_id)
     return JsonResponse(RetrieveTeamResponse(id=team.id, name=team.name))

--- a/backend/recipeyak/api/team_update_view.py
+++ b/backend/recipeyak/api/team_update_view.py
@@ -18,22 +18,21 @@ class UpdateTeamResponse(pydantic.BaseModel):
 
 
 class UpdateTeamParams(RequestParams):
+    team_id: int
     name: str
 
 
 @endpoint()
 def team_update_view(
-    request: AuthedHttpRequest[UpdateTeamParams], team_id: int
+    request: AuthedHttpRequest, params: UpdateTeamParams
 ) -> JsonResponse[UpdateTeamResponse]:
-    team = get_object_or_404(get_teams(request.user), pk=team_id)
+    team = get_object_or_404(get_teams(request.user), pk=params.team_id)
     if not is_team_admin(team_id=team.id, user_id=request.user.id):
         raise APIError(
             code="insufficent_permissions",
             message="Must be a team admin for updates.",
             status=403,
         )
-
-    params = UpdateTeamParams.parse_raw(request.body)
 
     with transaction.atomic():
         team.name = params.name

--- a/backend/recipeyak/api/upload_complete_view.py
+++ b/backend/recipeyak/api/upload_complete_view.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.models.upload import Upload
 
 
@@ -16,13 +17,17 @@ class CompleteUploadResponse(pydantic.BaseModel):
     contentType: str
 
 
+class UploadCompleteParams(RequestParams):
+    upload_id: int
+
+
 @endpoint()
 def upload_complete_view(
-    request: AuthedHttpRequest[None], upload_id: int
+    request: AuthedHttpRequest, params: UploadCompleteParams
 ) -> JsonResponse[CompleteUploadResponse]:
     with transaction.atomic():
         upload = get_object_or_404(
-            Upload.objects.filter(created_by=request.user), pk=upload_id
+            Upload.objects.filter(created_by=request.user), pk=params.upload_id
         )
         upload.completed = True
         # A little bodgy but set the upload on the user when we're done, maybe

--- a/backend/recipeyak/api/upload_start_view.py
+++ b/backend/recipeyak/api/upload_start_view.py
@@ -44,9 +44,8 @@ class StartUploadResponse(pydantic.BaseModel):
 
 @endpoint()
 def upload_start_view(
-    request: AuthedHttpRequest[StartUploadParams]
+    request: AuthedHttpRequest, params: StartUploadParams
 ) -> JsonResponse[StartUploadResponse]:
-    params = StartUploadParams.parse_raw(request.body)
     key = f"{request.user.id}/{uuid4().hex}/{params.file_name}"
     team = get_team(request.user)
 

--- a/backend/recipeyak/api/user_comments_list_view.py
+++ b/backend/recipeyak/api/user_comments_list_view.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.api.serializers.recipe import NoteResponse, serialize_note
 from recipeyak.api.user_retrieve_by_id_view import has_team_connection
 from recipeyak.models import filter_notes, get_team
@@ -23,10 +24,15 @@ class UserCommentsListResponse(pydantic.BaseModel):
     comments: list[Comment]
 
 
+class UserCommentsListParams(RequestParams):
+    user_id: str
+
+
 @endpoint()
 def user_comments_list_view(
-    request: AuthedHttpRequest[None], user_id: str
+    request: AuthedHttpRequest, params: UserCommentsListParams
 ) -> JsonResponse[UserCommentsListResponse]:
+    user_id = params.user_id
     if not has_team_connection(user_id, request.user.id):
         raise Http404
     team = get_team(request.user)

--- a/backend/recipeyak/api/user_create_view.py
+++ b/backend/recipeyak/api/user_create_view.py
@@ -47,9 +47,8 @@ class UserCreateResponse(pydantic.BaseModel):
 
 @endpoint(auth_required=False)
 def user_create_view(
-    request: AnonymousHttpRequest[RegisterUserDetailViewParams]
+    request: AnonymousHttpRequest, params: RegisterUserDetailViewParams
 ) -> JsonResponse[UserCreateResponse]:
-    params = RegisterUserDetailViewParams.parse_raw(request.body)
     with transaction.atomic():
         team = Team.objects.create(name="Personal")
         user = User()

--- a/backend/recipeyak/api/user_delete_view.py
+++ b/backend/recipeyak/api/user_delete_view.py
@@ -6,7 +6,7 @@ from recipeyak.api.base.response import JsonResponse
 
 
 @endpoint()
-def user_delete_view(request: AuthedHttpRequest[None]) -> JsonResponse[None]:
+def user_delete_view(request: AuthedHttpRequest, params: None) -> JsonResponse[None]:
     user = request.user
     logout(request)
     user.delete()

--- a/backend/recipeyak/api/user_login_view.py
+++ b/backend/recipeyak/api/user_login_view.py
@@ -28,7 +28,7 @@ class LoginResponse(pydantic.BaseModel):
 
 @endpoint(auth_required=False)
 def user_login_view(
-    request: AnonymousHttpRequest[LoginUserParams]
+    request: AnonymousHttpRequest, params: LoginUserParams
 ) -> JsonResponse[LoginResponse]:
     """
     Check the credentials and login if credentials are valid and authenticated.
@@ -36,7 +36,6 @@ def user_login_view(
 
     Accept the following POST parameters: username, password
     """
-    params = LoginUserParams.parse_raw(request.body)
     user = authenticate(email=params.email, password=params.password)
     if not user:
         raise APIError(code="invalid_credentials", message="invalid email or password")

--- a/backend/recipeyak/api/user_logout_view.py
+++ b/backend/recipeyak/api/user_logout_view.py
@@ -14,7 +14,7 @@ class UserLogoutResponse(pydantic.BaseModel):
 
 @endpoint()
 def user_logout_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[UserLogoutResponse]:
     """
     Calls Django logout method and logs out current User object.

--- a/backend/recipeyak/api/user_password_reset_confirm_view.py
+++ b/backend/recipeyak/api/user_password_reset_confirm_view.py
@@ -39,10 +39,8 @@ class ResetPasswordViewParams(RequestParams):
 
 @endpoint(auth_required=False)
 def user_password_reset_confirm_view(
-    request: AnonymousHttpRequest[ResetPasswordViewParams]
+    request: AnonymousHttpRequest, params: ResetPasswordViewParams
 ) -> JsonResponse[UserSerializer]:
-    params = ResetPasswordViewParams.parse_raw(request.body)
-
     user_id = urlsafe_base64_decode(params.uid)
     user = User.objects.filter(pk=user_id).first()
     if user is None:

--- a/backend/recipeyak/api/user_password_reset_view.py
+++ b/backend/recipeyak/api/user_password_reset_view.py
@@ -40,10 +40,8 @@ class ResetPasswordViewResponse(pydantic.BaseModel):
 
 @endpoint(auth_required=False)
 def user_password_reset_view(
-    request: AnonymousHttpRequest[ResetPasswordViewParams]
+    request: AnonymousHttpRequest, params: ResetPasswordViewParams
 ) -> JsonResponse[ResetPasswordViewResponse]:
-    params = ResetPasswordViewParams.parse_raw(request.body)
-
     user = User.objects.filter(email=params.email).first()
     if user is None:
         raise APIError(code="email_not_found", message="email not found")

--- a/backend/recipeyak/api/user_password_update_view.py
+++ b/backend/recipeyak/api/user_password_update_view.py
@@ -25,7 +25,7 @@ class UserPasswordUpdateResponse(pydantic.BaseModel):
 
 @endpoint()
 def user_password_update_view(
-    request: AuthedHttpRequest[PasswordChangeParams]
+    request: AuthedHttpRequest, params: PasswordChangeParams
 ) -> JsonResponse[UserPasswordUpdateResponse]:
     """
     Calls Django Auth SetPasswordForm save method.
@@ -33,7 +33,6 @@ def user_password_update_view(
     Accepts the following POST parameters: new_password1, new_password2
     Returns the success/fail message.
     """
-    params = PasswordChangeParams.parse_raw(request.body)
     user = request.user
     if not user.check_password(params.old_password):
         raise APIError(

--- a/backend/recipeyak/api/user_retrieve_by_id_view.py
+++ b/backend/recipeyak/api/user_retrieve_by_id_view.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
 from recipeyak.api.base.response import JsonResponse
+from recipeyak.api.base.serialization import RequestParams
 from recipeyak.api.unwrap import unwrap
 from recipeyak.models.note import Note
 from recipeyak.models.scheduled_recipe import ScheduledRecipe
@@ -274,10 +275,15 @@ where a.user_id = %(user_a_id)s
         return cursor.fetchone() is not None
 
 
+class UserRetrieveByIdParams(RequestParams):
+    user_id: str
+
+
 @endpoint()
 def user_retrieve_by_id_view(
-    request: AuthedHttpRequest[None], user_id: str
+    request: AuthedHttpRequest, params: UserRetrieveByIdParams
 ) -> JsonResponse[UserDetailByIdResponse]:
+    user_id = params.user_id
     user = get_object_or_404(User, id=user_id)
     if not has_team_connection(user_id, request.user.id):
         raise Http404

--- a/backend/recipeyak/api/user_retrieve_view.py
+++ b/backend/recipeyak/api/user_retrieve_view.py
@@ -46,6 +46,6 @@ def serialize_user(user: User) -> UserSerializer:
 
 @endpoint()
 def user_retrieve_view(
-    request: AuthedHttpRequest[None]
+    request: AuthedHttpRequest, params: None
 ) -> JsonResponse[UserSerializer]:
     return JsonResponse(serialize_user(request.user))

--- a/backend/recipeyak/api/user_update_view.py
+++ b/backend/recipeyak/api/user_update_view.py
@@ -23,10 +23,8 @@ class UserUpdateParams(RequestParams):
 
 @endpoint()
 def user_update_view(
-    request: AuthedHttpRequest[UserUpdateParams]
+    request: AuthedHttpRequest, params: UserUpdateParams
 ) -> JsonResponse[UserSerializer]:
-    params = UserUpdateParams.parse_raw(request.body)
-
     with transaction.atomic():
         if params.schedule_team is not None:
             request.user.schedule_team_id = params.schedule_team


### PR DESCRIPTION
instead of:

```python
@endpoint()
def ingredient_update_view(
    request: AuthedHttpRequest[IngredientsPatchParams], ingredient_id: int
) -> JsonResponse[IngredientResponse]:
    params = IngredientsPatchParams.parse_raw(request.body)
    ...
```

we instead have:

```python
@endpoint()
def ingredient_update_view(
    request: AuthedHttpRequest, params: IngredientsPatchParams
) -> JsonResponse[IngredientResponse]:
    ...
```

when there are no params, you use None:

```python
@endpoint()
def ably_retrieve_view(
    request: AuthedHttpRequest, params: None
) -> JsonResponse[dict[str, object]]:
    ...
```

future:
Make the return type just the type, no JsonResponse wrapper. Not sure it's possible with different status codes, but would be nice!