### PR TITLE
api: simplify return definitions

### DIFF
--- a/backend/recipeyak/api/ably_retrieve_view.py
+++ b/backend/recipeyak/api/ably_retrieve_view.py
@@ -6,7 +6,6 @@ from ably import AblyRest
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.team_update_view import get_teams
 from recipeyak.config import ABLY_API_KEY
 
@@ -27,12 +26,9 @@ async def get_token(user_id: str, team_ids: list[int]) -> dict[str, object]:
 
 
 @endpoint()
-def ably_retrieve_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[dict[str, object]]:
+def ably_retrieve_view(request: AuthedHttpRequest, params: None) -> dict[str, object]:
     # NOTE: this isn't really scalable if the user has a lot of teams.
     team_ids = list(get_teams(user=request.user).values_list("id", flat=True))
-    return JsonResponse(
-        asyncio.run(get_token(user_id=str(request.user.id), team_ids=team_ids)),
-        status=200,
+    return asyncio.run(
+        get_token(user_id=str(request.user.id), team_ids=team_ids),
     )

--- a/backend/recipeyak/api/algolia_retrieve_view.py
+++ b/backend/recipeyak/api/algolia_retrieve_view.py
@@ -7,7 +7,6 @@ from algoliasearch.search_client import SearchClient
 from recipeyak import config
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models import get_team
 
 
@@ -23,14 +22,9 @@ def get_token(team_id: int) -> str:
 
 
 @endpoint()
-def algolia_retrieve_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[dict[str, str]]:
+def algolia_retrieve_view(request: AuthedHttpRequest, params: None) -> dict[str, str]:
     team = get_team(request.user)
-    return JsonResponse(
-        {
-            "app_id": config.ALGOLIA_APPLICATION_ID,
-            "api_key": get_token(team_id=team.pk),
-        },
-        status=200,
-    )
+    return {
+        "app_id": config.ALGOLIA_APPLICATION_ID,
+        "api_key": get_token(team_id=team.pk),
+    }

--- a/backend/recipeyak/api/base/response.py
+++ b/backend/recipeyak/api/base/response.py
@@ -14,8 +14,7 @@ class JsonResponse(HttpResponse, Generic[_T]):
         data: _T,
         **kwargs: Any,
     ) -> None:
-        if data is None and (kwargs.get("status", 200) != 204):
-            raise ValueError("data must not be None unless status is 204")
+        assert data is not None
         kwargs.setdefault("content_type", "application/json")
         content = json_dumps(data)
         super().__init__(content=content, **kwargs)

--- a/backend/recipeyak/api/base/schema.py
+++ b/backend/recipeyak/api/base/schema.py
@@ -312,15 +312,8 @@ def _remove_titles(
 def _route_to_endpoint(route: Route) -> _Endpoint:
     assert isinstance(route.method, str)
     endpoint_types = typing.get_type_hints(route.view)
-    # grab the return type: JsonResponse[T]
-    return_class = endpoint_types.pop("return")
-    # get the type param: T
-    try:
-        return_type = typing.get_args(return_class)[0]
-    except IndexError as e:
-        raise ValueError(
-            f"invalid schema, you must specify a return type param: {route.view.__name__}"
-        ) from e
+    # grab the return type: -> T
+    return_type = endpoint_types.pop("return")
     if return_type is type(None):
         return_type_schema = None
     else:

--- a/backend/recipeyak/api/calendar_delete_view.py
+++ b/backend/recipeyak/api/calendar_delete_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.calendar_list_view import get_scheduled_recipes
 from recipeyak.models import get_team
@@ -16,10 +15,9 @@ class CalendarDeleteParams(Params):
 @endpoint()
 def calendar_delete_view(
     request: AuthedHttpRequest, params: CalendarDeleteParams
-) -> JsonResponse[None]:
+) -> None:
     team_id = get_team(request.user).id
     get_scheduled_recipes(team_id).filter(id=params.scheduled_recipe_id).delete()
     publish_calendar_event_deleted(
         recipe_id=params.scheduled_recipe_id, team_id=team_id
     )
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/calendar_generate_link_view.py
+++ b/backend/recipeyak/api/calendar_generate_link_view.py
@@ -2,7 +2,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.calendar_list_view import (
     CalendarSettingsSerializer,
     get_cal_settings,
@@ -13,10 +12,10 @@ from recipeyak.models import Membership, get_random_ical_id, get_team
 @endpoint()
 def calendar_generate_link_view(
     request: AuthedHttpRequest, params: None
-) -> JsonResponse[CalendarSettingsSerializer]:
+) -> CalendarSettingsSerializer:
     team_id = get_team(request.user).id
     membership = get_object_or_404(Membership, team=team_id, user=request.user)
     membership.calendar_secret_key = get_random_ical_id()
     membership.save()
 
-    return JsonResponse(get_cal_settings(request=request, team_id=team_id))
+    return get_cal_settings(request=request, team_id=team_id)

--- a/backend/recipeyak/api/calendar_list_view.py
+++ b/backend/recipeyak/api/calendar_list_view.py
@@ -7,7 +7,6 @@ from typing_extensions import TypedDict
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.calendar_serialization import (
     ScheduleRecipeSerializer,
@@ -45,7 +44,7 @@ class CalendarListResponse(TypedDict):
 @endpoint()
 def calendar_list_view(
     request: AuthedHttpRequest, params: CalendarListParams
-) -> JsonResponse[CalendarListResponse]:
+) -> CalendarListResponse:
     start = params.start
     end = params.end
     team_id = get_team(request.user).id
@@ -62,4 +61,4 @@ def calendar_list_view(
     settings = get_cal_settings(request=request, team_id=team_id)
 
     # TODO(2024-04-10): remove the settings properties
-    return JsonResponse({"scheduledRecipes": scheduled_recipes, "settings": settings})
+    return {"scheduledRecipes": scheduled_recipes, "settings": settings}

--- a/backend/recipeyak/api/calendar_settings_retrieve_view.py
+++ b/backend/recipeyak/api/calendar_settings_retrieve_view.py
@@ -5,7 +5,6 @@ from typing_extensions import TypedDict
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models import Membership, get_team
 
 
@@ -30,7 +29,6 @@ def get_cal_settings(
 @endpoint()
 def calendar_settings_retrieve_view(
     request: AuthedHttpRequest, params: None
-) -> JsonResponse[CalendarSettingsSerializer]:
+) -> CalendarSettingsSerializer:
     team_id = get_team(request.user).id
-    settings = get_cal_settings(request=request, team_id=team_id)
-    return JsonResponse(settings)
+    return get_cal_settings(request=request, team_id=team_id)

--- a/backend/recipeyak/api/calendar_update_settings_view.py
+++ b/backend/recipeyak/api/calendar_update_settings_view.py
@@ -2,7 +2,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.calendar_list_view import (
     CalendarSettingsSerializer,
@@ -18,7 +17,7 @@ class CalendarUpdateSettingsParams(Params):
 @endpoint()
 def calendar_update_settings_view(
     request: AuthedHttpRequest, params: CalendarUpdateSettingsParams
-) -> JsonResponse[CalendarSettingsSerializer]:
+) -> CalendarSettingsSerializer:
     sync_enabled = params.syncEnabled
     team_id = get_team(request.user).id
 
@@ -26,4 +25,4 @@ def calendar_update_settings_view(
     membership.calendar_sync_enabled = sync_enabled
     membership.save()
 
-    return JsonResponse(get_cal_settings(request=request, team_id=team_id))
+    return get_cal_settings(request=request, team_id=team_id)

--- a/backend/recipeyak/api/calendar_update_view.py
+++ b/backend/recipeyak/api/calendar_update_view.py
@@ -4,7 +4,6 @@ from django.db import transaction
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.calendar_list_view import get_scheduled_recipes
 from recipeyak.api.calendar_serialization import (
@@ -23,7 +22,7 @@ class CalendarUpdateParams(Params):
 @endpoint()
 def calendar_update_view(
     request: AuthedHttpRequest, params: CalendarUpdateParams
-) -> JsonResponse[ScheduleRecipeSerializer]:
+) -> ScheduleRecipeSerializer:
     team_id = get_team(request.user).id
     scheduled_recipe = get_scheduled_recipes(team_id).get(id=params.scheduled_recipe_id)
     with transaction.atomic():
@@ -42,4 +41,4 @@ def calendar_update_view(
 
     publish_calendar_event(res, team_id)
 
-    return JsonResponse(res)
+    return res

--- a/backend/recipeyak/api/cook_checklist_create_view.py
+++ b/backend/recipeyak/api/cook_checklist_create_view.py
@@ -5,7 +5,6 @@ from django.db import connection
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import (
     filter_recipe_or_404,
@@ -28,7 +27,7 @@ class CookChecklistCreateParams(Params):
 @endpoint()
 def cook_checklist_create_view(
     request: AuthedHttpRequest, params: CookChecklistCreateParams
-) -> JsonResponse[CookChecklistCreateResponse]:
+) -> CookChecklistCreateResponse:
     team = get_team(request.user)
     recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
     with connection.cursor() as cursor:
@@ -54,8 +53,6 @@ def cook_checklist_create_view(
         checked=params.checked,
     )
 
-    return JsonResponse(
-        CookChecklistCreateResponse(
-            ingredient_id=params.ingredient_id, checked=params.checked
-        )
+    return CookChecklistCreateResponse(
+        ingredient_id=params.ingredient_id, checked=params.checked
     )

--- a/backend/recipeyak/api/cook_checklist_retrieve_view.py
+++ b/backend/recipeyak/api/cook_checklist_retrieve_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import (
     filter_cook_checklist,
@@ -17,12 +16,10 @@ class CookChecklistRetrieveParams(Params):
 @endpoint()
 def cook_checklist_retrieve_view(
     request: AuthedHttpRequest, params: CookChecklistRetrieveParams
-) -> JsonResponse[dict[int, bool]]:
+) -> dict[int, bool]:
     team = get_team(request.user)
     recipe_checklist_items = filter_cook_checklist(team=team).filter(
         recipe_id=params.recipe_id
     )
 
-    return JsonResponse(
-        {x["ingredient_id"]: x["checked"] for x in recipe_checklist_items.values()}
-    )
+    return {x["ingredient_id"]: x["checked"] for x in recipe_checklist_items.values()}

--- a/backend/recipeyak/api/ingredient_create_view.py
+++ b/backend/recipeyak/api/ingredient_create_view.py
@@ -8,7 +8,6 @@ from pydantic import StringConstraints
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import (
     IngredientSerializer,
@@ -38,7 +37,7 @@ class IngredientCreateParams(Params):
 @endpoint()
 def ingredient_create_view(
     request: AuthedHttpRequest, params: IngredientCreateParams
-) -> JsonResponse[IngredientSerializer]:
+) -> IngredientSerializer:
     team = get_team(request.user)
     recipe = get_object_or_404(filter_recipes(team=team), pk=params.recipe_id)
 
@@ -61,4 +60,4 @@ def ingredient_create_view(
         save_recipe_version(recipe_id=params.recipe_id, actor=request.user)
 
     publish_recipe(recipe_id=recipe.id, team_id=team.id)
-    return JsonResponse(serialize_ingredient(ingredient), status=201)
+    return serialize_ingredient(ingredient)

--- a/backend/recipeyak/api/ingredient_delete_view.py
+++ b/backend/recipeyak/api/ingredient_delete_view.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import ingredient_to_text
 from recipeyak.models import ChangeType, RecipeChange, filter_ingredients, get_team
@@ -20,7 +19,7 @@ class IngredientDeleteParams(Params):
 @endpoint()
 def ingredient_delete_view(
     request: AuthedHttpRequest, params: IngredientDeleteParams
-) -> JsonResponse[None]:
+) -> None:
     team = get_team(request.user)
     ingredient = get_object_or_404(
         filter_ingredients(team=team), pk=params.ingredient_id
@@ -37,4 +36,3 @@ def ingredient_delete_view(
         filter_ingredients(team=team).filter(pk=params.ingredient_id).delete()
         save_recipe_version(recipe_id=recipe_id, actor=request.user)
     publish_recipe(recipe_id=ingredient.recipe_id, team_id=team.id)
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/ingredient_update_view.py
+++ b/backend/recipeyak/api/ingredient_update_view.py
@@ -8,7 +8,6 @@ from pydantic import StringConstraints
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import (
     IngredientSerializer,
@@ -32,7 +31,7 @@ class IngredientUpdateParams(Params):
 @endpoint()
 def ingredient_update_view(
     request: AuthedHttpRequest, params: IngredientUpdateParams
-) -> JsonResponse[IngredientSerializer]:
+) -> IngredientSerializer:
     team = get_team(request.user)
     ingredient = get_object_or_404(
         filter_ingredients(team=team), pk=params.ingredient_id
@@ -62,4 +61,4 @@ def ingredient_update_view(
 
     publish_recipe(recipe_id=ingredient.recipe_id, team_id=team.id)
 
-    return JsonResponse(serialize_ingredient(ingredient))
+    return serialize_ingredient(ingredient)

--- a/backend/recipeyak/api/invite_accept_view.py
+++ b/backend/recipeyak/api/invite_accept_view.py
@@ -3,7 +3,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models.invite import Invite
 
@@ -19,9 +18,9 @@ class InviteAcceptParams(Params):
 @endpoint()
 def invite_accept_view(
     request: AuthedHttpRequest, params: InviteAcceptParams
-) -> JsonResponse[InviteAcceptResponse]:
+) -> InviteAcceptResponse:
     invite = get_object_or_404(
         Invite.objects.filter(membership__user=request.user), id=params.invite_id
     )
     invite.accept()
-    return JsonResponse(InviteAcceptResponse(detail="accepted invite"), status=200)
+    return InviteAcceptResponse(detail="accepted invite")

--- a/backend/recipeyak/api/invite_create_view.py
+++ b/backend/recipeyak/api/invite_create_view.py
@@ -5,7 +5,6 @@ from django.db import transaction
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import Team
 from recipeyak.models.invite import Invite
@@ -24,7 +23,7 @@ class InviteCreateResponse(pydantic.BaseModel):
 @endpoint()
 def invite_create_view(
     request: AuthedHttpRequest, params: InviteCreateParams
-) -> JsonResponse[InviteCreateResponse]:
+) -> InviteCreateResponse:
     """
     for creating, we want: level, user_id
     for response, we want: id, user data, team
@@ -40,4 +39,4 @@ def invite_create_view(
                     email=email, team=team, level=params.level, creator=request.user
                 )
                 invite_ids.append(invite.id)
-    return JsonResponse(InviteCreateResponse(invite_ids=invite_ids), status=201)
+    return InviteCreateResponse(invite_ids=invite_ids)

--- a/backend/recipeyak/api/invite_decline_view.py
+++ b/backend/recipeyak/api/invite_decline_view.py
@@ -3,7 +3,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models.invite import Invite
 
@@ -19,9 +18,9 @@ class InviteDeclineParams(Params):
 @endpoint()
 def invite_decline_view(
     request: AuthedHttpRequest, params: InviteDeclineParams
-) -> JsonResponse[InviteDeclineResponse]:
+) -> InviteDeclineResponse:
     invite = get_object_or_404(
         Invite.objects.filter(membership__user=request.user), id=params.invite_id
     )
     invite.decline()
-    return JsonResponse(InviteDeclineResponse(detail="declined invite"), status=200)
+    return InviteDeclineResponse(detail="declined invite")

--- a/backend/recipeyak/api/invite_list_view.py
+++ b/backend/recipeyak/api/invite_list_view.py
@@ -6,7 +6,6 @@ from django.db import connection
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models.user import get_avatar_url
 
 
@@ -30,9 +29,7 @@ class InviteListItem(pydantic.BaseModel):
 
 
 @endpoint()
-def invite_list_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[list[InviteListItem]]:
+def invite_list_view(request: AuthedHttpRequest, params: None) -> list[InviteListItem]:
     with connection.cursor() as cursor:
         cursor.execute(
             """
@@ -57,7 +54,7 @@ where
             {"user_id": request.user.id},
         )
         invite_rows = cursor.fetchall()
-        invites = [
+        return [
             InviteListItem(
                 id=invite_id,
                 created=created,
@@ -82,4 +79,3 @@ where
                 user_profile_upload_key,
             ) in invite_rows
         ]
-        return JsonResponse(invites)

--- a/backend/recipeyak/api/member_delete_view.py
+++ b/backend/recipeyak/api/member_delete_view.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.team_update_view import is_team_admin
 from recipeyak.models import Membership, Team
@@ -34,9 +33,7 @@ class MemberDeleteParams(Params):
 
 
 @endpoint()
-def member_delete_view(
-    request: AuthedHttpRequest, params: MemberDeleteParams
-) -> JsonResponse[None]:
+def member_delete_view(request: AuthedHttpRequest, params: MemberDeleteParams) -> None:
     """
     1. Admins of the team can edit any other member of the team
     2. Non-admins can edit themselves
@@ -62,4 +59,3 @@ def member_delete_view(
         membership.delete()
     except DemoteLastAdminError as e:
         raise APIError(code="demote_last_admin", message=str(e)) from e
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/member_list_view.py
+++ b/backend/recipeyak/api/member_list_view.py
@@ -8,7 +8,6 @@ from django.db import connection
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import get_team_by_id
 from recipeyak.models.user import get_avatar_url
@@ -35,7 +34,7 @@ class MemberListParams(Params):
 @endpoint()
 def member_list_view(
     request: AuthedHttpRequest, params: MemberListParams
-) -> JsonResponse[list[MemberListItem]]:
+) -> list[MemberListItem]:
     team = get_team_by_id(user_id=request.user.id, team_id=params.team_id)
     with connection.cursor() as cursor:
         cursor.execute(
@@ -86,4 +85,4 @@ where
                 user=user,
             )
         )
-    return JsonResponse(members)
+    return members

--- a/backend/recipeyak/api/member_update_view.py
+++ b/backend/recipeyak/api/member_update_view.py
@@ -10,7 +10,6 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.team_delete_view import is_team_admin
 from recipeyak.models import Membership, Team
@@ -49,7 +48,7 @@ class MemberUpdateParams(Params):
 @endpoint()
 def member_update_view(
     request: AuthedHttpRequest, params: MemberUpdateParams
-) -> JsonResponse[MemberUpdateResponse]:
+) -> MemberUpdateResponse:
     membership = get_object_or_404(Membership, pk=params.member_id)
     if not is_team_admin(team_id=membership.team_id, user_id=request.user.id):
         raise APIError(
@@ -67,21 +66,19 @@ def member_update_view(
             status=403,
         ) from e
 
-    return JsonResponse(
-        MemberUpdateResponse(
-            id=membership.id,
-            level=membership.level,
-            created=membership.created,
-            user=UserResponse(
-                id=membership.user.id,
-                name=membership.user.name,
-                avatar_url=get_avatar_url(
-                    email=membership.user.email,
-                    profile_upload_key=membership.user.profile_upload.key
-                    if membership.user.profile_upload is not None
-                    else None,
-                ),
+    return MemberUpdateResponse(
+        id=membership.id,
+        level=membership.level,
+        created=membership.created,
+        user=UserResponse(
+            id=membership.user.id,
+            name=membership.user.name,
+            avatar_url=get_avatar_url(
                 email=membership.user.email,
+                profile_upload_key=membership.user.profile_upload.key
+                if membership.user.profile_upload is not None
+                else None,
             ),
-        )
+            email=membership.user.email,
+        ),
     )

--- a/backend/recipeyak/api/note_create_view.py
+++ b/backend/recipeyak/api/note_create_view.py
@@ -5,7 +5,6 @@ from pydantic import model_validator
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import NoteSerializer, serialize_note
 from recipeyak.models import Note, Upload, filter_recipes, get_team
@@ -27,7 +26,7 @@ class NoteCreateParams(Params):
 @endpoint()
 def note_create_view(
     request: AuthedHttpRequest, params: NoteCreateParams
-) -> JsonResponse[NoteSerializer]:
+) -> NoteSerializer:
     team = get_team(request.user)
     recipe = get_object_or_404(filter_recipes(team=team), pk=params.recipe_id)
 
@@ -43,7 +42,7 @@ def note_create_view(
 
     publish_recipe(recipe_id=recipe.id, team_id=team.id)
 
-    return JsonResponse(
-        serialize_note(note, primary_image_id=recipe.primary_image_id),
-        status=201,
+    return serialize_note(
+        note,
+        primary_image_id=recipe.primary_image_id,
     )

--- a/backend/recipeyak/api/note_delete_view.py
+++ b/backend/recipeyak/api/note_delete_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import filter_notes, get_team
 from recipeyak.realtime import publish_recipe
@@ -13,9 +12,7 @@ class NoteDeleteParams(Params):
 
 
 @endpoint()
-def note_delete_view(
-    request: AuthedHttpRequest, params: NoteDeleteParams
-) -> JsonResponse[None]:
+def note_delete_view(request: AuthedHttpRequest, params: NoteDeleteParams) -> None:
     team = get_team(request.user)
     if (
         note := filter_notes(team=team)
@@ -24,4 +21,3 @@ def note_delete_view(
     ):
         note.delete()
         publish_recipe(recipe_id=note.recipe_id, team_id=team.id)
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/note_update_view.py
+++ b/backend/recipeyak/api/note_update_view.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import NoteSerializer, serialize_note
 from recipeyak.models import Upload, filter_notes, get_team
@@ -23,7 +22,7 @@ class NoteUpdateParams(Params):
 @endpoint()
 def note_update_view(
     request: AuthedHttpRequest, params: NoteUpdateParams
-) -> JsonResponse[NoteSerializer]:
+) -> NoteSerializer:
     team = get_team(request.user)
     note = get_object_or_404(filter_notes(team=team), pk=params.note_id)
     # only allow the note's author to update the note
@@ -50,6 +49,4 @@ def note_update_view(
         note.save()
     publish_recipe(recipe_id=note.recipe_id, team_id=team.id)
 
-    return JsonResponse(
-        serialize_note(note, primary_image_id=note.recipe.primary_image_id)
-    )
+    return serialize_note(note, primary_image_id=note.recipe.primary_image_id)

--- a/backend/recipeyak/api/reaction_create_view.py
+++ b/backend/recipeyak/api/reaction_create_view.py
@@ -8,7 +8,6 @@ from psycopg2.errors import UniqueViolation
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import ReactionSerializer, serialize_reactions
 from recipeyak.models import filter_notes, get_team, user_reactions
@@ -26,7 +25,7 @@ class ReactionCreateParams(Params):
 @endpoint()
 def reaction_create_view(
     request: AuthedHttpRequest, params: ReactionCreateParams
-) -> JsonResponse[ReactionSerializer]:
+) -> ReactionSerializer:
     team = get_team(request.user)
 
     note = get_object_or_404(filter_notes(team=team), pk=params.note_id)
@@ -42,4 +41,4 @@ def reaction_create_view(
         else:
             raise
     publish_recipe(recipe_id=note.recipe_id, team_id=team.id)
-    return JsonResponse(next(iter(serialize_reactions([reaction]))))
+    return next(iter(serialize_reactions([reaction])))

--- a/backend/recipeyak/api/reaction_delete_view.py
+++ b/backend/recipeyak/api/reaction_delete_view.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import user_reactions
 from recipeyak.realtime import publish_recipe
@@ -15,7 +14,7 @@ class ReactionDeleteParams(Params):
 @endpoint()
 def reaction_delete_view(
     request: AuthedHttpRequest, params: ReactionDeleteParams
-) -> JsonResponse[None]:
+) -> None:
     if (
         reaction := user_reactions(user=request.user)
         .filter(pk=params.reaction_id)
@@ -25,4 +24,3 @@ def reaction_delete_view(
         reaction.delete()
         if recipe.team_id:
             publish_recipe(recipe_id=recipe.id, team_id=recipe.team_id)
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/recipe_create_view.py
+++ b/backend/recipeyak/api/recipe_create_view.py
@@ -13,7 +13,6 @@ from recipeyak import ordering
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import (
     RecipeSerializer,
@@ -99,7 +98,7 @@ def _create_recipe_from_scrape(*, scrape: ScrapeResult, team: Team) -> Recipe:
 @endpoint()
 def recipe_create_view(
     request: AuthedHttpRequest, params: RecipeCreateParams
-) -> JsonResponse[RecipeSerializer]:
+) -> RecipeSerializer:
     log = logger.bind(user_id=request.user.id)
 
     # validate params
@@ -137,7 +136,4 @@ def recipe_create_view(
         # transaction
         save_recipe_version(recipe_id=recipe.id, actor=request.user)
 
-    return JsonResponse(
-        serialize_recipe(recipe=recipe),
-        status=201,
-    )
+    return serialize_recipe(recipe)

--- a/backend/recipeyak/api/recipe_create_view_test.py
+++ b/backend/recipeyak/api/recipe_create_view_test.py
@@ -25,7 +25,7 @@ def test_recipe_creation(client: Client, user: User, team: Team) -> None:
     }
 
     res = client.post("/api/v1/recipes/", data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     recipe_id = res.json().get("id")
     res = client.get(f"/api/v1/recipes/{recipe_id}/")
@@ -48,7 +48,7 @@ def test_creating_recipe_with_empty_ingredients_and_steps(
     data = {"name": "some recipe", "team": team.id}
 
     res = client.post("/api/v1/recipes/", data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
 
 
 def test_cache_headers(client: Client, user: User, recipe: Recipe, team: Team) -> None:
@@ -92,7 +92,7 @@ def test_recipe_creation_for_a_team(client: Client, team: Team, user: User) -> N
     url = "/api/v1/recipes/"
 
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     assert (
         TimelineEvent.objects.count()
@@ -287,10 +287,10 @@ def test_position_step_ingredient(
     url = url_template.format(recipe_id=recipe.id)
 
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
     model.objects.get(id=res.json()["id"]).delete()
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
 
 
 def test_adding_note_to_recipe(
@@ -304,7 +304,7 @@ def test_adding_note_to_recipe(
     res = client.post(
         f"/api/v1/recipes/{recipe.id}/notes/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert res.json()["created_by"]["id"] == user.id
     assert res.json()["text"] == data["text"]
 
@@ -363,7 +363,7 @@ def test_adding_ingredient_to_recipe(
         ingredient,
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     res = client.get(f"/api/v1/recipes/{recipe.id}/")
     assert res.status_code == 200

--- a/backend/recipeyak/api/recipe_delete_view.py
+++ b/backend/recipeyak/api/recipe_delete_view.py
@@ -4,7 +4,6 @@ from django.db import transaction
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import (
     filter_recipe_or_404,
@@ -18,9 +17,7 @@ class RecipeDeleteParams(Params):
 
 
 @endpoint()
-def recipe_delete_view(
-    request: AuthedHttpRequest, params: RecipeDeleteParams
-) -> JsonResponse[None]:
+def recipe_delete_view(request: AuthedHttpRequest, params: RecipeDeleteParams) -> None:
     team = get_team(request.user)
     with transaction.atomic():
         recipe = filter_recipe_or_404(team=team, recipe_id=params.recipe_id)
@@ -28,4 +25,3 @@ def recipe_delete_view(
         # no need to save version, since we aren't "updating" the recipe, we
         # have the previous post-update version saved already
     publish_recipe(recipe_id=recipe.id, team_id=team.id)
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/recipe_recently_created_view.py
+++ b/backend/recipeyak/api/recipe_recently_created_view.py
@@ -7,7 +7,6 @@ from django.db import connection
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models import get_team
 
 
@@ -35,7 +34,7 @@ class RecipeRecentlyCreatedItem(pydantic.BaseModel):
 @endpoint()
 def recipe_recently_created_view(
     request: AuthedHttpRequest, params: None
-) -> JsonResponse[list[RecipeRecentlyCreatedItem]]:
+) -> list[RecipeRecentlyCreatedItem]:
     team = get_team(request.user)
     recipes = list[RecipeRecentlyCreatedItem]()
     with connection.cursor() as cursor:
@@ -83,4 +82,4 @@ limit 6;
         rows = cursor.fetchall()
         for row in rows:
             recipes.append(RecipeRecentlyCreatedItem.model_validate(row[0]))
-    return JsonResponse(recipes)
+    return recipes

--- a/backend/recipeyak/api/recipe_recently_viewed_view.py
+++ b/backend/recipeyak/api/recipe_recently_viewed_view.py
@@ -6,7 +6,6 @@ from typing_extensions import TypedDict
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models import RecipeView, get_team
 
 
@@ -27,7 +26,7 @@ class RecipeRecentlyViewedItem(TypedDict):
 @endpoint()
 def recipe_recently_viewed_view(
     request: AuthedHttpRequest, params: None
-) -> JsonResponse[list[RecipeRecentlyViewedItem]]:
+) -> list[RecipeRecentlyViewedItem]:
     team = get_team(request.user)
     recipes: list[RecipeRecentlyViewedItem] = []
     for rv in (
@@ -52,4 +51,4 @@ def recipe_recently_viewed_view(
             }
         )
 
-    return JsonResponse(recipes)
+    return recipes

--- a/backend/recipeyak/api/recipe_retrieve_view.py
+++ b/backend/recipeyak/api/recipe_retrieve_view.py
@@ -4,7 +4,6 @@ from django.db import connection
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import RecipeSerializer, serialize_recipe
 from recipeyak.models import (
@@ -20,7 +19,7 @@ class RecipeRetrieveParams(Params):
 @endpoint()
 def recipe_retrieve_view(
     request: AuthedHttpRequest, params: RecipeRetrieveParams
-) -> JsonResponse[RecipeSerializer]:
+) -> RecipeSerializer:
     team = get_team(request.user)
     recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
     with connection.cursor() as cursor:
@@ -47,4 +46,4 @@ def recipe_retrieve_view(
             {"user_id": request.user.id, "recipe_id": recipe.id},
         )
 
-    return JsonResponse(serialize_recipe(recipe))
+    return serialize_recipe(recipe)

--- a/backend/recipeyak/api/recipe_timeline_view.py
+++ b/backend/recipeyak/api/recipe_timeline_view.py
@@ -9,7 +9,6 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import Recipe, ScheduledRecipe, User
 
@@ -26,7 +25,7 @@ class RecipeTimelineParams(Params):
 @endpoint()
 def recipe_timeline_view(
     request: AuthedHttpRequest, params: RecipeTimelineParams
-) -> JsonResponse[list[RecipeTimelineItem]]:
+) -> list[RecipeTimelineItem]:
     user: User = request.user
     # TODO: we probably don't want to rely on this so we can support multiple
     # sessions with different teams for a given user.
@@ -41,6 +40,4 @@ def recipe_timeline_view(
         recipe=params.recipe_id
     )
 
-    return JsonResponse(
-        [RecipeTimelineItem(id=s.id, on=s.on) for s in scheduled_recipes]
-    )
+    return [RecipeTimelineItem(id=s.id, on=s.on) for s in scheduled_recipes]

--- a/backend/recipeyak/api/recipe_update_view.py
+++ b/backend/recipeyak/api/recipe_update_view.py
@@ -9,7 +9,6 @@ from pydantic import StringConstraints
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import RecipeSerializer, serialize_recipe
 from recipeyak.models import (
@@ -42,7 +41,7 @@ class RecipeUpdateParams(Params):
 @endpoint()
 def recipe_update_view(
     request: AuthedHttpRequest, params: RecipeUpdateParams
-) -> JsonResponse[RecipeSerializer]:
+) -> RecipeSerializer:
     team = get_team(request.user)
     recipe = filter_recipe_or_404(recipe_id=params.recipe_id, team=team)
 
@@ -125,4 +124,4 @@ def recipe_update_view(
 
     team = get_team(request.user)
     recipe = filter_recipe_or_404(team=team, recipe_id=params.recipe_id)
-    return JsonResponse(serialize_recipe(recipe))
+    return serialize_recipe(recipe)

--- a/backend/recipeyak/api/recipe_update_view_test.py
+++ b/backend/recipeyak/api/recipe_update_view_test.py
@@ -32,7 +32,7 @@ def test_step_create(client: Client, recipe: Recipe, user: User, team: Team) -> 
     res = client.post(
         f"/api/v1/recipes/{recipe.id}/steps/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert res.json()["text"] == data["text"]
 
     assert RecipeChange.objects.count() == 1, "We should have our step creation change."
@@ -224,7 +224,7 @@ def test_ingredient_create(
         ingredient_data,
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     assert RecipeChange.objects.count() == 1
     change: RecipeChange = RecipeChange.objects.get()

--- a/backend/recipeyak/api/recipe_versioning_test.py
+++ b/backend/recipeyak/api/recipe_versioning_test.py
@@ -21,7 +21,7 @@ def test_create_recipe_saves_version() -> None:
         },
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert RecipeHistorical.objects.filter(recipe=res.json()["id"]).exists()
 
 
@@ -59,7 +59,7 @@ def test_section_create_saves_version() -> None:
         content_type="application/json",
     )
 
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert RecipeHistorical.objects.filter(recipe_id=recipe.id).count() == before + 1
 
 
@@ -114,7 +114,7 @@ def test_step_create_saves_version() -> None:
         content_type="application/json",
     )
 
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert RecipeHistorical.objects.filter(recipe_id=recipe.id).count() == before + 1
 
 
@@ -174,7 +174,7 @@ def test_ingredient_create_saves_version() -> None:
         content_type="application/json",
     )
 
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert RecipeHistorical.objects.filter(recipe_id=recipe.id).count() == before + 1
 
 

--- a/backend/recipeyak/api/scheduled_recipe_create_view.py
+++ b/backend/recipeyak/api/scheduled_recipe_create_view.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.calendar_serialization import (
     ScheduleRecipeSerializer,
@@ -25,7 +24,7 @@ class ScheduledRecipeCreateParams(Params):
 @endpoint()
 def scheduled_recipe_create_view(
     request: AuthedHttpRequest, params: ScheduledRecipeCreateParams
-) -> JsonResponse[ScheduleRecipeSerializer]:
+) -> ScheduleRecipeSerializer:
     team = get_team(request.user)
 
     recipe = get_object_or_404(filter_recipes(team=team), id=params.recipe)
@@ -40,7 +39,4 @@ def scheduled_recipe_create_view(
     )
 
     publish_calendar_event(res, team_id=team.id)
-    return JsonResponse(
-        res,
-        status=201,
-    )
+    return res

--- a/backend/recipeyak/api/scheduled_recipe_create_view_test.py
+++ b/backend/recipeyak/api/scheduled_recipe_create_view_test.py
@@ -17,7 +17,7 @@ def test_creating_scheduled_recipe(
     data = {"recipe": recipe.id, "on": date(1976, 7, 6)}
     client.force_login(user)
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert ScheduledRecipe.objects.filter(id=res.json()["id"]).exists()
     assert res.json()[
         "created"
@@ -34,6 +34,6 @@ def test_adding_to_team_calendar(
     assert team.is_member(user)
     client.force_login(user)
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
     scheduled = ScheduledRecipe.objects.get(id=res.json().get("id"))
     assert scheduled.team is not None and scheduled.team.pk == team.pk

--- a/backend/recipeyak/api/section_create_view.py
+++ b/backend/recipeyak/api/section_create_view.py
@@ -8,7 +8,6 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import SectionSerializer, serialize_section
 from recipeyak.models import ChangeType, Recipe, RecipeChange, Section
@@ -25,7 +24,7 @@ class SectionCreateParams(Params):
 @endpoint()
 def section_create_view(
     request: AuthedHttpRequest, params: SectionCreateParams
-) -> JsonResponse[SectionSerializer]:
+) -> SectionSerializer:
     recipe = get_object_or_404(Recipe, pk=params.recipe_id)
     if not has_recipe_access(recipe=recipe, user=request.user):
         raise APIError(code="no_access", message="No access to recipe", status=403)
@@ -56,4 +55,4 @@ def section_create_view(
 
     publish_recipe(recipe_id=recipe.id, team_id=recipe.team_id)
 
-    return JsonResponse(serialize_section(section), status=201)
+    return serialize_section(section)

--- a/backend/recipeyak/api/section_create_view_test.py
+++ b/backend/recipeyak/api/section_create_view_test.py
@@ -18,7 +18,7 @@ def test_creating_section(client: Client, user: User, recipe: Recipe) -> None:
         f"/api/v1/recipes/{recipe.id}/sections", data, content_type="application/json"
     )
 
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert isinstance(res.json()["id"], int)
     assert isinstance(res.json()["title"], str)
     assert isinstance(res.json()["position"], str)
@@ -48,7 +48,7 @@ def test_creating_section_without_position(
         f"/api/v1/recipes/{recipe.id}/sections", data, content_type="application/json"
     )
 
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert isinstance(res.json()["id"], int)
     assert isinstance(res.json()["title"], str)
     assert isinstance(res.json()["position"], str)

--- a/backend/recipeyak/api/section_delete_view.py
+++ b/backend/recipeyak/api/section_delete_view.py
@@ -7,7 +7,6 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import ChangeType, RecipeChange, Section
 from recipeyak.realtime import publish_recipe
@@ -21,7 +20,7 @@ class SectionDeleteParams(Params):
 @endpoint()
 def section_delete_view(
     request: AuthedHttpRequest, params: SectionDeleteParams
-) -> JsonResponse[None]:
+) -> None:
     section = get_object_or_404(Section, pk=params.section_id)
     recipe = section.recipe
     if not has_recipe_access(recipe=recipe, user=request.user):
@@ -41,5 +40,3 @@ def section_delete_view(
         save_recipe_version(recipe_id=recipe.id, actor=request.user)
 
     publish_recipe(recipe_id=recipe.id, team_id=recipe.team_id)
-
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/section_update_view.py
+++ b/backend/recipeyak/api/section_update_view.py
@@ -7,7 +7,6 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.permissions import has_recipe_access
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import SectionSerializer, serialize_section
 from recipeyak.models import ChangeType, RecipeChange, Section
@@ -24,7 +23,7 @@ class SectionUpdateParams(Params):
 @endpoint()
 def section_update_view(
     request: AuthedHttpRequest, params: SectionUpdateParams
-) -> JsonResponse[SectionSerializer]:
+) -> SectionSerializer:
     section = get_object_or_404(Section, pk=params.section_id)
     if not has_recipe_access(recipe=section.recipe, user=request.user):
         raise APIError(code="no_access", message="No access to recipe", status=403)
@@ -45,4 +44,4 @@ def section_update_view(
         save_recipe_version(recipe_id=section.recipe_id, actor=request.user)
     publish_recipe(recipe_id=section.recipe.id, team_id=section.recipe.team_id)
 
-    return JsonResponse(serialize_section(section))
+    return serialize_section(section)

--- a/backend/recipeyak/api/session_delete_all_view.py
+++ b/backend/recipeyak/api/session_delete_all_view.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 
 
 @endpoint()
-def session_delete_all_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[None]:
+def session_delete_all_view(request: AuthedHttpRequest, params: None) -> None:
     request.user.session_set.exclude(pk=request.session.session_key).delete()
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/session_delete_view.py
+++ b/backend/recipeyak/api/session_delete_view.py
@@ -4,7 +4,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 
 
@@ -15,6 +14,5 @@ class SessionDeleteParams(Params):
 @endpoint()
 def session_delete_view(
     request: AuthedHttpRequest, params: SessionDeleteParams
-) -> JsonResponse[None]:
+) -> None:
     get_object_or_404(request.user.session_set, pk=params.session_id).delete()
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/session_list_view.py
+++ b/backend/recipeyak/api/session_list_view.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from recipeyak import user_agent
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 
 
 class DeviceResponse(pydantic.BaseModel):
@@ -29,7 +28,7 @@ class SessionListItem(pydantic.BaseModel):
 @endpoint()
 def session_list_view(
     request: AuthedHttpRequest, params: None
-) -> JsonResponse[list[SessionListItem]]:
+) -> list[SessionListItem]:
     query_set = request.user.session_set
 
     qs = query_set.filter(expire_date__gt=timezone.now()).order_by("-last_activity")
@@ -48,4 +47,4 @@ def session_list_view(
             )
         )
 
-    return JsonResponse(sessions)
+    return sessions

--- a/backend/recipeyak/api/shoppinglist_retrieve_view.py
+++ b/backend/recipeyak/api/shoppinglist_retrieve_view.py
@@ -11,7 +11,6 @@ from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.json import json_dumps
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.category import category
 from recipeyak.combine import Ingredient, combine_ingredients
@@ -75,7 +74,7 @@ def _fmt_small_decimal(d: Decimal) -> str:
 @endpoint()
 def shoppinglist_retrieve_view(
     request: AuthedHttpRequest, params: ShoppinglistRetrieveParams
-) -> JsonResponse[ShoppinglistRetrieveResponse]:
+) -> ShoppinglistRetrieveResponse:
     team_id = get_team(request.user).id
     scheduled_recipes = get_scheduled_recipes(params=params, team_id=team_id)
     if scheduled_recipes is None:
@@ -111,7 +110,4 @@ def shoppinglist_retrieve_view(
 
     ShoppingList.objects.create(ingredients=json_dumps(ingredient_mapping).decode())
 
-    return JsonResponse(
-        {"ingredients": ingredient_mapping, "recipes": list(recipes.values())},
-        status=200,
-    )
+    return {"ingredients": ingredient_mapping, "recipes": list(recipes.values())}

--- a/backend/recipeyak/api/step_create_view.py
+++ b/backend/recipeyak/api/step_create_view.py
@@ -8,7 +8,6 @@ from pydantic import StringConstraints
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import StepSerializer, serialize_step
 from recipeyak.models import ChangeType, RecipeChange, Step, filter_recipes, get_team
@@ -25,7 +24,7 @@ class StepCreateParams(Params):
 @endpoint()
 def step_create_view(
     request: AuthedHttpRequest, params: StepCreateParams
-) -> JsonResponse[StepSerializer]:
+) -> StepSerializer:
     team = get_team(request.user)
     recipe = get_object_or_404(filter_recipes(team=team), pk=params.recipe_id)
 
@@ -43,4 +42,4 @@ def step_create_view(
         save_recipe_version(recipe_id=params.recipe_id, actor=request.user)
 
     publish_recipe(recipe_id=recipe.id, team_id=recipe.team_id)
-    return JsonResponse(serialize_step(step), status=201)
+    return serialize_step(step)

--- a/backend/recipeyak/api/step_create_view_test.py
+++ b/backend/recipeyak/api/step_create_view_test.py
@@ -56,7 +56,7 @@ def test_adding_step_to_recipe(
     res = client.post(
         f"/api/v1/recipes/{recipe.id}/steps/", step, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     res = client.get(f"/api/v1/recipes/{recipe.id}/")
     assert res.status_code == 200

--- a/backend/recipeyak/api/step_delete_view.py
+++ b/backend/recipeyak/api/step_delete_view.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import ChangeType, RecipeChange, filter_steps, get_team
 from recipeyak.realtime import publish_recipe
@@ -17,9 +16,7 @@ class StepDeleteParams(Params):
 
 
 @endpoint()
-def step_delete_view(
-    request: AuthedHttpRequest, params: StepDeleteParams
-) -> JsonResponse[None]:
+def step_delete_view(request: AuthedHttpRequest, params: StepDeleteParams) -> None:
     team = get_team(request.user)
     step = get_object_or_404(filter_steps(team=team), pk=params.step_id)
     recipe = step.recipe
@@ -34,4 +31,3 @@ def step_delete_view(
         step.delete()
         save_recipe_version(recipe_id=recipe.id, actor=request.user)
     publish_recipe(recipe_id=recipe.id, team_id=recipe.team_id)
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/step_update_view.py
+++ b/backend/recipeyak/api/step_update_view.py
@@ -8,7 +8,6 @@ from pydantic import StringConstraints
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import StepSerializer, serialize_step
 from recipeyak.models import ChangeType, RecipeChange, filter_steps, get_team
@@ -26,7 +25,7 @@ class StepUpdateParams(Params):
 def step_update_view(
     request: AuthedHttpRequest,
     params: StepUpdateParams,
-) -> JsonResponse[StepSerializer]:
+) -> StepSerializer:
     team = get_team(request.user)
     step = get_object_or_404(filter_steps(team=team), pk=params.step_id)
     with transaction.atomic():
@@ -48,4 +47,4 @@ def step_update_view(
 
     publish_recipe(recipe_id=step.recipe.id, team_id=step.recipe.team_id)
 
-    return JsonResponse(serialize_step(step))
+    return serialize_step(step)

--- a/backend/recipeyak/api/team_create_view.py
+++ b/backend/recipeyak/api/team_create_view.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models.invite import Invite
 from recipeyak.models.team import Team
@@ -27,7 +26,7 @@ class TeamCreateParams(Params):
 @endpoint()
 def team_create_view(
     request: AuthedHttpRequest, params: TeamCreateParams
-) -> JsonResponse[TeamCreateResponse]:
+) -> TeamCreateResponse:
     with transaction.atomic():
         team = Team.objects.create(name=params.name)
         team.force_join_admin(request.user)
@@ -35,7 +34,4 @@ def team_create_view(
             Invite.objects.create_invite(
                 email=email, team=team, level=params.level, creator=request.user
             )
-    return JsonResponse(
-        TeamCreateResponse(id=team.id, name=params.name),
-        status=201,
-    )
+    return TeamCreateResponse(id=team.id, name=params.name)

--- a/backend/recipeyak/api/team_create_view_test.py
+++ b/backend/recipeyak/api/team_create_view_test.py
@@ -23,7 +23,7 @@ def test_creating_team(client: Client, user: User, user2: User) -> None:
 
     client.force_login(user)
     res = client.post(url, data, content_type="application/json")
-    assert res.status_code == 201, "Authenticated users should be able to create teams"
+    assert res.status_code == 200, "Authenticated users should be able to create teams"
     assert res.json().get("name") == data.get("name")
     team_id = res.json().get("id")
     team = Team.objects.get(pk=team_id)
@@ -302,7 +302,7 @@ def test_create_team_invite(
         {"emails": [user2.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert user2.has_invite(team) and not team.is_member(user2)
 
     for data, description, s in [
@@ -314,7 +314,7 @@ def test_create_team_invite(
         (
             {"emails": [user2.email], "level": Membership.CONTRIBUTOR},
             "just filter out emails for invites that already exist",
-            201,
+            200,
         ),
     ]:
         res = client.post(url, data, content_type="application/json")
@@ -395,7 +395,7 @@ def test_retrieve_user_invite(
         {"emails": [user2.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
 
 def test_user_invites(
@@ -420,7 +420,7 @@ def test_user_invites(
         {"emails": [user2.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert user2.membership_set.filter(
         team=team
     ).exists(), "user should be a member of the team"
@@ -437,7 +437,7 @@ def test_user_invites(
         {"emails": [user3.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     # retrieve all invites for user2
     client.force_login(user2)
@@ -464,7 +464,7 @@ def test_accept_team_invite(
         {"emails": [user2.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     invite_id = res.json()["invite_ids"][0]
     assert Invite.objects.get(pk=invite_id).status == Invite.OPEN
 
@@ -500,7 +500,7 @@ def test_decline_team_invite(
         {"emails": [user2.email], "level": Membership.ADMIN},
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     invite_id = res.json()["invite_ids"][0]
     assert Invite.objects.get(pk=invite_id).status == Invite.OPEN
 
@@ -530,7 +530,7 @@ def test_creating_team_with_name_and_emails(
         },
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     team_id = res.json()["id"]
     team = Team.objects.get(id=team_id)
 

--- a/backend/recipeyak/api/team_delete_view.py
+++ b/backend/recipeyak/api/team_delete_view.py
@@ -7,7 +7,6 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import Team
 from recipeyak.models.membership import Membership
@@ -29,9 +28,7 @@ class TeamDeleteParams(Params):
 
 
 @endpoint()
-def team_delete_view(
-    request: AuthedHttpRequest, params: TeamDeleteParams
-) -> JsonResponse[None]:
+def team_delete_view(request: AuthedHttpRequest, params: TeamDeleteParams) -> None:
     with transaction.atomic():
         team = get_object_or_404(get_teams(request.user), pk=params.team_id)
         if (
@@ -43,4 +40,3 @@ def team_delete_view(
                 code="forbidden", message="You cannot delete this team.", status=403
             )
         team.delete()
-        return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/team_list_view.py
+++ b/backend/recipeyak/api/team_list_view.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 
 
 class TeamListItem(BaseModel):
@@ -18,9 +17,7 @@ class TeamListItem(BaseModel):
 
 
 @endpoint()
-def team_list_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[list[TeamListItem]]:
+def team_list_view(request: AuthedHttpRequest, params: None) -> list[TeamListItem]:
     with connection.cursor() as cursor:
         cursor.execute(
             """
@@ -47,8 +44,7 @@ GROUP BY
             {"user_id": request.user.id},
         )
         teams_raw = cursor.fetchall()
-    teams = [
+    return [
         TeamListItem(id=id, name=name, created=created, members=members)
         for id, name, created, members in teams_raw
     ]
-    return JsonResponse(teams)

--- a/backend/recipeyak/api/team_retrieve_view.py
+++ b/backend/recipeyak/api/team_retrieve_view.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import Team
 from recipeyak.models.user import User
@@ -28,6 +27,6 @@ class TeamRetrieveParams(Params):
 @endpoint()
 def team_retrieve_view(
     request: AuthedHttpRequest, params: TeamRetrieveParams
-) -> JsonResponse[TeamRetrieveResponse]:
+) -> TeamRetrieveResponse:
     team = get_object_or_404(get_teams(request.user), pk=params.team_id)
-    return JsonResponse(TeamRetrieveResponse(id=team.id, name=team.name))
+    return TeamRetrieveResponse(id=team.id, name=team.name)

--- a/backend/recipeyak/api/team_update_view.py
+++ b/backend/recipeyak/api/team_update_view.py
@@ -7,7 +7,6 @@ from django.shortcuts import get_object_or_404
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.team_delete_view import get_teams, is_team_admin
 
@@ -25,7 +24,7 @@ class TeamUpdateParams(Params):
 @endpoint()
 def team_update_view(
     request: AuthedHttpRequest, params: TeamUpdateParams
-) -> JsonResponse[TeamUpdateResponse]:
+) -> TeamUpdateResponse:
     team = get_object_or_404(get_teams(request.user), pk=params.team_id)
     if not is_team_admin(team_id=team.id, user_id=request.user.id):
         raise APIError(
@@ -39,4 +38,4 @@ def team_update_view(
         team.save()
         team.force_join_admin(request.user)
 
-    return JsonResponse(TeamUpdateResponse(id=team.id, name=team.name))
+    return TeamUpdateResponse(id=team.id, name=team.name)

--- a/backend/recipeyak/api/upload_complete_view.py
+++ b/backend/recipeyak/api/upload_complete_view.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models.upload import Upload
 
@@ -24,7 +23,7 @@ class UploadCompleteParams(Params):
 @endpoint()
 def upload_complete_view(
     request: AuthedHttpRequest, params: UploadCompleteParams
-) -> JsonResponse[UploadCompleteResponse]:
+) -> UploadCompleteResponse:
     with transaction.atomic():
         upload = get_object_or_404(
             Upload.objects.filter(created_by=request.user), pk=params.upload_id
@@ -38,8 +37,6 @@ def upload_complete_view(
             user.save()
         upload.save()
 
-    return JsonResponse(
-        UploadCompleteResponse(
-            id=str(upload.pk), url=upload.public_url(), contentType=upload.content_type
-        )
+    return UploadCompleteResponse(
+        id=str(upload.pk), url=upload.public_url(), contentType=upload.content_type
     )

--- a/backend/recipeyak/api/upload_start_view.py
+++ b/backend/recipeyak/api/upload_start_view.py
@@ -9,7 +9,6 @@ from recipeyak import config
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models import filter_recipes, get_team
 from recipeyak.models.recipe import Recipe
@@ -45,7 +44,7 @@ class UploadStartResponse(pydantic.BaseModel):
 @endpoint()
 def upload_start_view(
     request: AuthedHttpRequest, params: UploadStartParams
-) -> JsonResponse[UploadStartResponse]:
+) -> UploadStartResponse:
     key = f"{request.user.id}/{uuid4().hex}/{params.file_name}"
     team = get_team(request.user)
 
@@ -84,10 +83,8 @@ def upload_start_view(
         },
     )
 
-    return JsonResponse(
-        UploadStartResponse(
-            id=upload.pk,
-            upload_url=upload_url,
-            upload_headers={"x-amz-meta-db_id": str(upload.pk)},
-        )
+    return UploadStartResponse(
+        id=upload.pk,
+        upload_url=upload_url,
+        upload_headers={"x-amz-meta-db_id": str(upload.pk)},
     )

--- a/backend/recipeyak/api/user_comments_list_view.py
+++ b/backend/recipeyak/api/user_comments_list_view.py
@@ -3,7 +3,6 @@ from django.http import Http404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.serializers.recipe import NoteSerializer, serialize_note
 from recipeyak.api.user_retrieve_by_id_view import has_team_connection
@@ -31,7 +30,7 @@ class UserCommentsListParams(Params):
 @endpoint()
 def user_comments_list_view(
     request: AuthedHttpRequest, params: UserCommentsListParams
-) -> JsonResponse[UserCommentsListResponse]:
+) -> UserCommentsListResponse:
     user_id = params.user_id
     if not has_team_connection(user_id, request.user.id):
         raise Http404
@@ -55,4 +54,4 @@ def user_comments_list_view(
         .order_by("-created")
     ]
 
-    return JsonResponse(UserCommentsListResponse(comments=notes))
+    return UserCommentsListResponse(comments=notes)

--- a/backend/recipeyak/api/user_create_view.py
+++ b/backend/recipeyak/api/user_create_view.py
@@ -10,7 +10,6 @@ from pydantic import AfterValidator, model_validator
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AnonymousHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.user_retrieve_view import UserSerializer, serialize_user
 from recipeyak.models.team import Team
@@ -48,7 +47,7 @@ class UserCreateResponse(pydantic.BaseModel):
 @endpoint(auth_required=False)
 def user_create_view(
     request: AnonymousHttpRequest, params: UserCreateParams
-) -> JsonResponse[UserCreateResponse]:
+) -> UserCreateResponse:
     with transaction.atomic():
         team = Team.objects.create(name="Personal")
         user = User()
@@ -60,4 +59,4 @@ def user_create_view(
 
     login(request, user)
 
-    return JsonResponse(UserCreateResponse(user=serialize_user(user)), status=201)
+    return UserCreateResponse(user=serialize_user(user))

--- a/backend/recipeyak/api/user_create_view_test.py
+++ b/backend/recipeyak/api/user_create_view_test.py
@@ -25,7 +25,7 @@ def test_signup(client: Client) -> None:
     res = client.post(
         "/api/v1/auth/registration/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     res = client.get(url)
     assert res.status_code == 200
 
@@ -48,7 +48,7 @@ def test_signup_case_insensitive(client: Client) -> None:
     res = client.post(
         "/api/v1/auth/registration/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     res = client.get(url)
     assert res.status_code == 200

--- a/backend/recipeyak/api/user_delete_view.py
+++ b/backend/recipeyak/api/user_delete_view.py
@@ -2,12 +2,10 @@ from django.contrib.auth import logout
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 
 
 @endpoint()
-def user_delete_view(request: AuthedHttpRequest, params: None) -> JsonResponse[None]:
+def user_delete_view(request: AuthedHttpRequest, params: None) -> None:
     user = request.user
     logout(request)
     user.delete()
-    return JsonResponse(None, status=204)

--- a/backend/recipeyak/api/user_login_view.py
+++ b/backend/recipeyak/api/user_login_view.py
@@ -11,7 +11,6 @@ from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import (
     AnonymousHttpRequest,
 )
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.user_retrieve_view import UserSerializer, serialize_user
 from recipeyak.models.user import User
@@ -29,7 +28,7 @@ class UserLoginResponse(pydantic.BaseModel):
 @endpoint(auth_required=False)
 def user_login_view(
     request: AnonymousHttpRequest, params: UserLoginParams
-) -> JsonResponse[UserLoginResponse]:
+) -> UserLoginResponse:
     """
     Check the credentials and login if credentials are valid and authenticated.
     Calls Django Auth login method to register User ID in Django session framework.
@@ -42,6 +41,4 @@ def user_login_view(
 
     login(request, user)
 
-    return JsonResponse(
-        UserLoginResponse(user=serialize_user(cast(User, user))), status=200
-    )
+    return UserLoginResponse(user=serialize_user(cast(User, user)))

--- a/backend/recipeyak/api/user_login_view_test.py
+++ b/backend/recipeyak/api/user_login_view_test.py
@@ -29,7 +29,7 @@ def test_signup(client: Client) -> None:
     res = client.post(
         "/api/v1/auth/registration/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     res = client.get(url)
     assert res.status_code == 200
 
@@ -160,7 +160,7 @@ def test_signup_case_insensitive(client: Client) -> None:
     res = client.post(
         "/api/v1/auth/registration/", data, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
 
     res = client.get(url)
     assert res.status_code == 200

--- a/backend/recipeyak/api/user_logout_view.py
+++ b/backend/recipeyak/api/user_logout_view.py
@@ -5,7 +5,6 @@ from django.contrib.auth import logout
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 
 
 class UserLogoutResponse(pydantic.BaseModel):
@@ -13,9 +12,7 @@ class UserLogoutResponse(pydantic.BaseModel):
 
 
 @endpoint()
-def user_logout_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[UserLogoutResponse]:
+def user_logout_view(request: AuthedHttpRequest, params: None) -> UserLogoutResponse:
     """
     Calls Django logout method and logs out current User object.
 
@@ -23,6 +20,4 @@ def user_logout_view(
     """
     logout(request)
 
-    return JsonResponse(
-        UserLogoutResponse(detail="Successfully logged out."), status=200
-    )
+    return UserLogoutResponse(detail="Successfully logged out.")

--- a/backend/recipeyak/api/user_password_reset_confirm_view.py
+++ b/backend/recipeyak/api/user_password_reset_confirm_view.py
@@ -10,7 +10,6 @@ from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import (
     AnonymousHttpRequest,
 )
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.user_retrieve_view import UserSerializer, serialize_user
 from recipeyak.models.user import User
@@ -40,7 +39,7 @@ class UserPasswordResetConfirmParams(Params):
 @endpoint(auth_required=False)
 def user_password_reset_confirm_view(
     request: AnonymousHttpRequest, params: UserPasswordResetConfirmParams
-) -> JsonResponse[UserSerializer]:
+) -> UserSerializer:
     user_id = urlsafe_base64_decode(params.uid)
     user = User.objects.filter(pk=user_id).first()
     if user is None:
@@ -61,4 +60,4 @@ def user_password_reset_confirm_view(
     user.save()
     login(request, user)
 
-    return JsonResponse(serialize_user(user))
+    return serialize_user(user)

--- a/backend/recipeyak/api/user_password_reset_view.py
+++ b/backend/recipeyak/api/user_password_reset_view.py
@@ -11,7 +11,6 @@ from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import (
     AnonymousHttpRequest,
 )
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.models.user import User
 
@@ -41,7 +40,7 @@ class UserPasswordResetResponse(pydantic.BaseModel):
 @endpoint(auth_required=False)
 def user_password_reset_view(
     request: AnonymousHttpRequest, params: UserPasswordResetParams
-) -> JsonResponse[UserPasswordResetResponse]:
+) -> UserPasswordResetResponse:
     user = User.objects.filter(email=params.email).first()
     if user is None:
         raise APIError(code="email_not_found", message="email not found")
@@ -59,4 +58,4 @@ Please go to the following page and choose a new password:
         recipient_list=[user.email],
     )
 
-    return JsonResponse(UserPasswordResetResponse(detail="email sent"))
+    return UserPasswordResetResponse(detail="email sent")

--- a/backend/recipeyak/api/user_password_update_view.py
+++ b/backend/recipeyak/api/user_password_update_view.py
@@ -9,7 +9,6 @@ from pydantic import Field
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.exceptions import APIError
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 
 
@@ -26,7 +25,7 @@ class UserPasswordUpdateResponse(pydantic.BaseModel):
 @endpoint()
 def user_password_update_view(
     request: AuthedHttpRequest, params: UserPasswordUpdateParams
-) -> JsonResponse[UserPasswordUpdateResponse]:
+) -> UserPasswordUpdateResponse:
     """
     Calls Django Auth SetPasswordForm save method.
 
@@ -46,6 +45,4 @@ def user_password_update_view(
     user.save()
     update_session_auth_hash(request, user)
 
-    return JsonResponse(
-        UserPasswordUpdateResponse(detail="New password has been saved.")
-    )
+    return UserPasswordUpdateResponse(detail="New password has been saved.")

--- a/backend/recipeyak/api/user_retrieve_by_id_view.py
+++ b/backend/recipeyak/api/user_retrieve_by_id_view.py
@@ -8,7 +8,6 @@ from django.shortcuts import get_object_or_404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.unwrap import unwrap
 from recipeyak.models.note import Note
@@ -282,7 +281,7 @@ class UserRetrieveByIdParams(Params):
 @endpoint()
 def user_retrieve_by_id_view(
     request: AuthedHttpRequest, params: UserRetrieveByIdParams
-) -> JsonResponse[UserRetrieveByIdResponse]:
+) -> UserRetrieveByIdResponse:
     user_id = params.user_id
     user = get_object_or_404(User, id=user_id)
     if not has_team_connection(user_id, request.user.id):
@@ -294,26 +293,24 @@ def user_retrieve_by_id_view(
     photos_count = get_photos_count(user_id=user_id)
     primary_photos_count = get_primary_photos_count(user_id=user_id)
     activity = get_activity(user_id=user_id)
-    return JsonResponse(
-        UserRetrieveByIdResponse(
-            id=user.id,
-            name=user.name or user.email,
+    return UserRetrieveByIdResponse(
+        id=user.id,
+        name=user.name or user.email,
+        email=user.email,
+        avatar_url=get_avatar_url(
             email=user.email,
-            avatar_url=get_avatar_url(
-                email=user.email,
-                profile_upload_key=user.profile_upload.key
-                if user.profile_upload is not None
-                else None,
-            ),
-            created=user.created,
-            stats=UserDetailByIdStats(
-                recipesAdd=recipes_added_count,
-                recipesArchived=recipes_archived_count,
-                comments=comments_count,
-                scheduled=scheduled_count,
-                photos=photos_count,
-                primaryPhotos=primary_photos_count,
-            ),
-            activity=activity,
-        )
+            profile_upload_key=user.profile_upload.key
+            if user.profile_upload is not None
+            else None,
+        ),
+        created=user.created,
+        stats=UserDetailByIdStats(
+            recipesAdd=recipes_added_count,
+            recipesArchived=recipes_archived_count,
+            comments=comments_count,
+            scheduled=scheduled_count,
+            photos=photos_count,
+            primaryPhotos=primary_photos_count,
+        ),
+        activity=activity,
     )

--- a/backend/recipeyak/api/user_retrieve_view.py
+++ b/backend/recipeyak/api/user_retrieve_view.py
@@ -4,7 +4,6 @@ import pydantic
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.models.user import User, get_avatar_url
 
 
@@ -45,7 +44,5 @@ def serialize_user(user: User) -> UserSerializer:
 
 
 @endpoint()
-def user_retrieve_view(
-    request: AuthedHttpRequest, params: None
-) -> JsonResponse[UserSerializer]:
-    return JsonResponse(serialize_user(request.user))
+def user_retrieve_view(request: AuthedHttpRequest, params: None) -> UserSerializer:
+    return serialize_user(request.user)

--- a/backend/recipeyak/api/user_update_view.py
+++ b/backend/recipeyak/api/user_update_view.py
@@ -4,7 +4,6 @@ from django.db import transaction
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.user_retrieve_view import UserSerializer, serialize_user
 
@@ -24,7 +23,7 @@ class UserUpdateParams(Params):
 @endpoint()
 def user_update_view(
     request: AuthedHttpRequest, params: UserUpdateParams
-) -> JsonResponse[UserSerializer]:
+) -> UserSerializer:
     with transaction.atomic():
         if params.schedule_team is not None:
             request.user.schedule_team_id = params.schedule_team
@@ -40,4 +39,4 @@ def user_update_view(
             request.user.theme_mode = params.theme_mode
         request.user.save()
 
-    return JsonResponse(serialize_user(request.user))
+    return serialize_user(request.user)

--- a/backend/recipeyak/api/user_uploads_list_view.py
+++ b/backend/recipeyak/api/user_uploads_list_view.py
@@ -3,7 +3,6 @@ from django.http import Http404
 
 from recipeyak.api.base.decorators import endpoint
 from recipeyak.api.base.request import AuthedHttpRequest
-from recipeyak.api.base.response import JsonResponse
 from recipeyak.api.base.serialization import Params
 from recipeyak.api.user_retrieve_by_id_view import has_team_connection
 from recipeyak.models import filter_uploads, get_team
@@ -50,7 +49,7 @@ class UserUploadsListParams(Params):
 @endpoint()
 def user_uploads_list_view(
     request: AuthedHttpRequest, params: UserUploadsListParams
-) -> JsonResponse[UserUploadsListResponse]:
+) -> UserUploadsListResponse:
     if not has_team_connection(params.user_id, request.user.id):
         raise Http404
     team = get_team(request.user)
@@ -70,4 +69,4 @@ def user_uploads_list_view(
         .order_by("-created")
     ]
 
-    return JsonResponse(UserUploadsListResponse(uploads=uploads))
+    return UserUploadsListResponse(uploads=uploads)

--- a/backend/recipeyak/models/ingredient_test.py
+++ b/backend/recipeyak/models/ingredient_test.py
@@ -47,7 +47,7 @@ def test_recipe_field_trimming(client: Client, user: User, team: Team) -> None:
         "team": team.pk,
     }
     res = client.post("/api/v1/recipes/", payload, content_type="application/json")
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert res.json()["name"] == "Chocolate Cake"
 
     payload = {
@@ -96,7 +96,7 @@ def test_ingredient_field_trimming(
         payload,
         content_type="application/json",
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert res.json()["name"] == "tomato"
     assert res.json()["description"] == "chopped"
 
@@ -130,7 +130,7 @@ def test_step_field_trimming(
     res = client.post(
         f"/api/v1/recipes/{recipe.pk}/steps/", payload, content_type="application/json"
     )
-    assert res.status_code == 201
+    assert res.status_code == 200
     assert res.json()["text"] == "some test here"
 
     step_id = res.json()["id"]


### PR DESCRIPTION
now instead of:

```python
@endpoint()
def algolia_retrieve_view(
    request: AuthedHttpRequest, params: AlgoliaParams
) -> JsonResponse[dict[str, str]]: ...
```

it's

```python
@endpoint()
def algolia_retrieve_view(
    request: AuthedHttpRequest, params: AlgoliaParams
) -> dict[str, str]: ...
```