### PR TITLE
api: use pytest-xdist to parallelize tests

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1181,6 +1181,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.0.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "execnet-2.0.2-py3-none-any.whl", hash = "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41"},
+    {file = "execnet-2.0.2.tar.gz", hash = "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "extruct"
 version = "0.13.0"
 description = "Extract embedded metadata from HTML markup"
@@ -2722,6 +2736,26 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.5.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.5.0.tar.gz", hash = "sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a"},
+    {file = "pytest_xdist-3.5.0-py3-none-any.whl", hash = "sha256:d075629c7e00b611df89f490a5063944bee7a4362a5ff11c7cc7824a03dfce24"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -3515,4 +3549,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9fac2033b641e789682d78300d320299fdc0fe3aad57842ebf0a9aea9662d9ce"
+content-hash = "851f0cdd882b941a73581a8735d5100454c5b8e85675731101cc987360899773"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,6 +53,7 @@ mypy = "^1.7.0"
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.24"
 ruff = "^0.3.5"
+pytest-xdist = "^3.5.0"
 
 [tool.ruff]
 src = ["recipeyak"]

--- a/backend/s/test
+++ b/backend/s/test
@@ -11,7 +11,7 @@ main() {
   ARGS="${@}"
 
   # shellcheck disable=SC2086
-  ./.venv/bin/pytest $ARGS
+  ./.venv/bin/pytest -n auto $ARGS
 }
 
 main "$@"


### PR DESCRIPTION
still slow, but ~3.5s instead of ~6s

I think the spinning up test databases for each processes is not great and I don't think it runs the tests in parallel in each process