### PR TITLE
api: use watchman instead of polling for file reload with django

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2795,6 +2795,21 @@ files = [
 ]
 
 [[package]]
+name = "pywatchman"
+version = "2.0.0"
+description = "Watchman client for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pywatchman-2.0.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:a8b531a9276c1dc8897510824cbb3290e4a5775793889758020593aedb97015b"},
+    {file = "pywatchman-2.0.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:44217f0a38f40e64f975bd13eed91c73a076c0fb7e9e9908b96917389f53371e"},
+    {file = "pywatchman-2.0.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:51c2b4c72bea6b9fd90caf20759f5bc47febf0fd27bf2f247b87c66e2f6bab02"},
+    {file = "pywatchman-2.0.0-cp38-cp38-macosx_14_0_arm64.whl", hash = "sha256:ed905338952db01f6506104295a3176adf0d8c2575e4f00505cb123ae09a2755"},
+    {file = "pywatchman-2.0.0-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:4183ea206be46cb45d48f59ef7540b849582798ccd51ce54e1e400237b7dbf43"},
+    {file = "pywatchman-2.0.0.tar.gz", hash = "sha256:25354d9e3647f94411a4c13e510c83a1ceecc17977b0525ba41b16e7019c7b0c"},
+]
+
+[[package]]
 name = "pyxdg"
 version = "0.28"
 description = "PyXDG contains implementations of freedesktop.org standards in python."
@@ -3549,4 +3564,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "851f0cdd882b941a73581a8735d5100454c5b8e85675731101cc987360899773"
+content-hash = "65c60b7c06210b217fe1ba9b0636905d692c521bc1af6464eecb8a9258a63e87"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,7 @@ ruamel-yaml = "^0.18.5"
 pydantic = {extras = ["email"], version = "^2.5.3"}
 pydantic-settings = "^2.1.0"
 jsonref = "^1.1.0"
+pywatchman = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "7.2.0"


### PR DESCRIPTION
https://adamj.eu/tech/2021/01/20/efficient-reloading-in-djangos-runserver-with-watchman/

https://twitter.com/AdamChainz/status/1770755957133287643

reduces ambient CPU usage from 3.5% of a core to 0% on my laptop

Before:

<img width="852" alt="Screenshot 2024-04-20 at 6 44 52 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/3d96f95f-e02e-4327-8c0d-cc20dfcd10c8">

After:
<img width="808" alt="Screenshot 2024-04-20 at 6 45 32 PM" src="https://github.com/recipeyak/recipeyak/assets/7340772/b2415997-882e-4a94-980f-9ed76de03cf9">

