### PR TITLE
ui: fix search palette being cut off on iOS

### DIFF
--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -151,7 +151,15 @@ function NavButtons({ size }: { size: number }) {
   return items
 }
 
-export function Navbar({ includeSearch = true }: { includeSearch?: boolean }) {
+export function Navbar({
+  includeSearch = true,
+  setShowRecipeSearch,
+  searchInputRef,
+}: {
+  includeSearch?: boolean
+  setShowRecipeSearch: (_: boolean) => void
+  searchInputRef: React.RefObject<HTMLButtonElement>
+}) {
   const isSmallerOrGreater = useMedia("(min-width: 640px)")
   const size = isSmallerOrGreater ? 20 : 24
   return (
@@ -163,7 +171,11 @@ export function Navbar({ includeSearch = true }: { includeSearch?: boolean }) {
         <HomeIcon size={size} />
       </NavLink>
       {(includeSearch || !isSmallerOrGreater) && (
-        <NavRecipeSearch size={size} />
+        <NavRecipeSearch
+          size={size}
+          setShowPopover={setShowRecipeSearch}
+          searchInputRef={searchInputRef}
+        />
       )}
       <NavButtons size={size} />
     </nav>

--- a/frontend/src/components/NavRecipeSearch.tsx
+++ b/frontend/src/components/NavRecipeSearch.tsx
@@ -1,24 +1,22 @@
-import { useRef, useState } from "react"
+import { useRef } from "react"
 import useOnClickOutside from "use-onclickoutside"
 
 import { clx } from "@/classnames"
 import { Button } from "@/components/Buttons"
-import { SearchIcon, SearchPalette } from "@/components/SearchPalette"
+import { SearchIcon } from "@/components/SearchPalette"
 import { isInputFocused } from "@/input"
 import { useGlobalEvent } from "@/useGlobalEvent"
 import { useMedia } from "@/useMedia"
 
-export function NavRecipeSearch({ size }: { size: number }) {
-  const [query, setQuery] = useState("")
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  // If a user clicks outside of the dropdown, we want to hide the dropdown, but
-  // keep their search query.
-  //
-  // The alternative would be to clear the search query when clicking outside,
-  // but I'm not sure that's desirable.
-  const [showPopover, setShowPopover] = useState(false)
-  const searchInputRef = useRef<HTMLButtonElement>(null)
-
+export function NavRecipeSearch({
+  size,
+  setShowPopover,
+  searchInputRef,
+}: {
+  size: number
+  setShowPopover: (_: boolean) => void
+  searchInputRef: React.RefObject<HTMLButtonElement>
+}) {
   const searchContainerRef = useRef(null)
   useOnClickOutside(searchContainerRef, () => {
     setShowPopover(false)
@@ -33,11 +31,6 @@ export function NavRecipeSearch({ size }: { size: number }) {
     },
   })
 
-  const resetForm = () => {
-    setQuery("")
-    setSelectedIndex(0)
-    setShowPopover(false)
-  }
   const isSmallerOrGreater = useMedia("(min-width: 640px)")
 
   return (
@@ -97,25 +90,6 @@ export function NavRecipeSearch({ size }: { size: number }) {
           "hover:bg-[--color-background-calendar-day] hover:text-[--color-link-hover]",
         )}
       />
-      {showPopover && (
-        <SearchPalette
-          selectedIndex={selectedIndex}
-          query={query}
-          setSelectedIndex={setSelectedIndex}
-          setQuery={(query) => {
-            setQuery(query)
-            // If we start searching after we already selected a
-            // suggestion, we should reset back to the initial state aka 0
-            if (selectedIndex !== 0) {
-              setSelectedIndex(0)
-            }
-          }}
-          onClose={() => {
-            resetForm()
-          }}
-          searchInputRef={searchInputRef}
-        />
-      )}
     </div>
   )
 }

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 
 import { CommandPalette } from "@/components/CommandPalette"
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { Footer } from "@/components/Footer"
 import { Helmet } from "@/components/Helmet"
 import { Navbar } from "@/components/Nav"
+import { SearchPalette } from "@/components/SearchPalette"
 import { pathHome } from "@/paths"
 
 const ContainerBase = ({
@@ -15,10 +16,41 @@ const ContainerBase = ({
   children: React.ReactNode
   includeSearch?: boolean
 }) => {
+  const [showRecipeSearch, setShowRecipeSearch] = useState(false)
+  const [query, setQuery] = useState("")
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const searchInputRef = useRef<HTMLButtonElement>(null)
+  // TODO(sbdchd): we should figure out a better way to handle the Palettes since
+  // they're kind of global
   return (
     <>
       <CommandPalette />
-      <Navbar includeSearch={includeSearch} />
+      <Navbar
+        includeSearch={includeSearch}
+        setShowRecipeSearch={setShowRecipeSearch}
+        searchInputRef={searchInputRef}
+      />
+      {showRecipeSearch && (
+        <SearchPalette
+          selectedIndex={selectedIndex}
+          query={query}
+          setSelectedIndex={setSelectedIndex}
+          setQuery={(query) => {
+            setQuery(query)
+            // If we start searching after we already selected a
+            // suggestion, we should reset back to the initial state aka 0
+            if (selectedIndex !== 0) {
+              setSelectedIndex(0)
+            }
+          }}
+          onClose={() => {
+            setQuery("")
+            setSelectedIndex(0)
+            setShowRecipeSearch(false)
+          }}
+          searchInputRef={searchInputRef}
+        />
+      )}
       <ErrorBoundary>{children}</ErrorBoundary>
     </>
   )

--- a/frontend/src/pages/recipe-list/RecipeListSearch.tsx
+++ b/frontend/src/pages/recipe-list/RecipeListSearch.tsx
@@ -417,8 +417,8 @@ export function RecipeSearchList() {
         }}
         placeholder={
           searchBy === "name_author"
-            ? "search by title & author..."
-            : "search by ingredient..."
+            ? "Search by title & author..."
+            : "Search by ingredient..."
         }
       />
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
for some reason position: fixed doesn't work the same as it does on MacOS

so instead we move the search palette around a bit in the DOM which should help