### PR TITLE
api: fix parsing ingredients with slashes

### DIFF
--- a/backend/recipeyak/parsing_test.py
+++ b/backend/recipeyak/parsing_test.py
@@ -442,6 +442,15 @@ def test_parse_name_description(ingredient: str, expected: tuple[str, str]) -> N
             ),
             id="lemon-juice",
         ),
+        pytest.param(
+            "1 cup plus 2 Tablespoons/148 grams all-purpose flour, plus more for dusting",
+            _IngredientResult(
+                quantity="1 cup plus 2 Tablespoons/148 grams",
+                name="all-purpose flour",
+                description="plus more for dusting",
+            ),
+            id="flour",
+        ),
     ],
 )
 def test_parse_ingredient(ingredient: str, expected: _IngredientResult) -> None:


### PR DESCRIPTION
before the quantity of:

```
1 cup plus 2 Tablespoons/148 grams all-purpose flour
```

would be:

```
1 cup plus 2
```

instead of:

```
1 cup plus 2 Tablespoons/148 grams
```