### PR TITLE
fix clicking on search icon in bottom toolbar

### DIFF
--- a/frontend/src/components/NavRecipeSearch.tsx
+++ b/frontend/src/components/NavRecipeSearch.tsx
@@ -60,8 +60,7 @@ export function NavRecipeSearch({
           }
           setShowPopover(true)
         }}
-        // more closely mimic the behavior of the search input vs onPress/onClick
-        onPressStart={() => {
+        onClick={() => {
           setShowPopover((s) => !s)
         }}
         children={


### PR DESCRIPTION
Now the search text focuses and the keyboard appears on iOS.

I think this broke with 680d3fcc247972c4907cfcd9138d74f4d151d3d1